### PR TITLE
ci: bump checkout/setup-python to Node-24 versions

### DIFF
--- a/.github/workflows/llmxive-pipeline.yml
+++ b/.github/workflows/llmxive-pipeline.yml
@@ -49,11 +49,11 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip

--- a/.github/workflows/llmxive-real-call-tests.yml
+++ b/.github/workflows/llmxive-real-call-tests.yml
@@ -23,13 +23,13 @@ jobs:
       DARTMOUTH_API_KEY: ${{ secrets.DARTMOUTH_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # On PR runs, github.head_ref is the source branch name (e.g.
           # 001-agentic-pipeline-refactor) rather than the PR-merge SHA;
           # the spec-kit bash scripts require a feature-branch name.
           ref: ${{ github.head_ref || github.ref }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,7 +19,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pipeline-brainstorm.yml
+++ b/.github/workflows/pipeline-brainstorm.yml
@@ -17,9 +17,9 @@ jobs:
       DARTMOUTH_CHAT_API_KEY: ${{ secrets.DARTMOUTH_CHAT_API_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with: { ref: main }
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with: { python-version: "3.11", cache: pip }
       - run: pip install -e ".[dev]"
       - name: Preflight

--- a/.github/workflows/pipeline-flesh-out.yml
+++ b/.github/workflows/pipeline-flesh-out.yml
@@ -17,9 +17,9 @@ jobs:
       DARTMOUTH_CHAT_API_KEY: ${{ secrets.DARTMOUTH_CHAT_API_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with: { ref: main }
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with: { python-version: "3.11", cache: pip }
       - run: pip install -e ".[dev]"
       - run: python -m llmxive preflight

--- a/.github/workflows/pipeline-implement.yml
+++ b/.github/workflows/pipeline-implement.yml
@@ -17,9 +17,9 @@ jobs:
       DARTMOUTH_CHAT_API_KEY: ${{ secrets.DARTMOUTH_CHAT_API_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with: { ref: main }
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with: { python-version: "3.11", cache: pip }
       - run: pip install -e ".[dev]"
       - run: python -m llmxive preflight

--- a/.github/workflows/pipeline-paper-speckit.yml
+++ b/.github/workflows/pipeline-paper-speckit.yml
@@ -17,9 +17,9 @@ jobs:
       DARTMOUTH_CHAT_API_KEY: ${{ secrets.DARTMOUTH_CHAT_API_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with: { ref: main }
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with: { python-version: "3.11", cache: pip }
       - run: pip install -e ".[dev]"
       - run: python -m llmxive preflight

--- a/.github/workflows/pipeline-paper-write.yml
+++ b/.github/workflows/pipeline-paper-write.yml
@@ -17,9 +17,9 @@ jobs:
       DARTMOUTH_CHAT_API_KEY: ${{ secrets.DARTMOUTH_CHAT_API_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with: { ref: main }
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with: { python-version: "3.11", cache: pip }
       - run: |
           sudo apt-get update && sudo apt-get install -y --no-install-recommends texlive texlive-latex-extra texlive-fonts-recommended texlive-bibtex-extra latexmk

--- a/.github/workflows/pipeline-research-speckit.yml
+++ b/.github/workflows/pipeline-research-speckit.yml
@@ -17,9 +17,9 @@ jobs:
       DARTMOUTH_CHAT_API_KEY: ${{ secrets.DARTMOUTH_CHAT_API_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with: { ref: main }
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with: { python-version: "3.11", cache: pip }
       - run: pip install -e ".[dev]"
       - run: python -m llmxive preflight

--- a/.github/workflows/pipeline-review.yml
+++ b/.github/workflows/pipeline-review.yml
@@ -17,9 +17,9 @@ jobs:
       DARTMOUTH_CHAT_API_KEY: ${{ secrets.DARTMOUTH_CHAT_API_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with: { ref: main }
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with: { python-version: "3.11", cache: pip }
       - run: pip install -e ".[dev]"
       - run: python -m llmxive preflight


### PR DESCRIPTION
GitHub Actions is deprecating Node 20 — `actions/checkout@v4` and `actions/setup-python@v5` run on it (force-migrated 2026-06-02, removed 2026-09-16; see https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Bumps to `actions/checkout@v5` + `actions/setup-python@v6` (Node 24) across all 10 workflow files. Pure version bump, no behavior change — the `real-call` workflow run on this PR exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)