### PR TITLE
hygiene: consolidate librarian default-field list into one canonical constant (#116)

### DIFF
--- a/src/llmxive/cli.py
+++ b/src/llmxive/cli.py
@@ -205,11 +205,9 @@ def _cmd_brainstorm(args: argparse.Namespace) -> int:
     for p in existing_projects:
         existing_titles_by_field.setdefault((p.field or "general").lower(), []).append(p.title)
 
-    default_fields = [
-        "biology", "chemistry", "computer science", "materials science",
-        "mathematics", "neuroscience", "physics", "psychology", "statistics",
-    ]
-    field_pool = [args.field] if args.field else default_fields
+    from llmxive.librarian import LIBRARIAN_DEFAULT_FIELDS
+
+    field_pool = [args.field] if args.field else list(LIBRARIAN_DEFAULT_FIELDS)
 
     n_target = max(1, args.count)
     now = datetime.now(timezone.utc)

--- a/src/llmxive/librarian/__init__.py
+++ b/src/llmxive/librarian/__init__.py
@@ -1,0 +1,34 @@
+"""Librarian sub-package — search + verify + pdf_sample + expand + cache +
+search_trail + theoremsearch + math_classifier.
+
+This module also holds the librarian's package-level shared constants. Per
+Constitution Principle I (Single Source of Truth), config values that more
+than one consumer needs live here in exactly one canonical place.
+"""
+
+from __future__ import annotations
+
+# The default scientific fields the librarian (and the brainstorm/cross-
+# domain machinery built around it) operates over. The CLI's per-field
+# pipeline pass (``llmxive run`` / ``llmxive brainstorm``) iterates this
+# list when no ``--field`` is given, and the cross-domain coverage test
+# parametrizes over it — so the two are guaranteed to stay in sync. The
+# ``agents/prompts/brainstorm.md`` prose mention of example fields is
+# *illustrative only* and intentionally not derived from this constant.
+#
+# Spec 006 (#113) added ``mathematics`` as the 9th field; #116 collapsed the
+# previously-duplicated copies (``cli.py`` + ``tests/phase2/
+# test_librarian_cross_domain.py``) into this one.
+LIBRARIAN_DEFAULT_FIELDS: tuple[str, ...] = (
+    "biology",
+    "chemistry",
+    "computer science",
+    "materials science",
+    "mathematics",
+    "neuroscience",
+    "physics",
+    "psychology",
+    "statistics",
+)
+
+__all__ = ["LIBRARIAN_DEFAULT_FIELDS"]

--- a/tests/phase2/test_librarian_cross_domain.py
+++ b/tests/phase2/test_librarian_cross_domain.py
@@ -28,6 +28,7 @@ import yaml
 from llmxive.agents import registry
 from llmxive.agents.librarian import LibrarianAgent
 from llmxive.credentials import load_dartmouth_key, load_semantic_scholar_key
+from llmxive.librarian import LIBRARIAN_DEFAULT_FIELDS
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 STATE_PROJECTS = REPO_ROOT / "state" / "projects"
@@ -40,17 +41,11 @@ both_keys_required = pytest.mark.skipif(
     reason="Cross-domain US4 needs DARTMOUTH_CHAT_API_KEY + SEMANTIC_SCHOLAR_API_KEY",
 )
 
-DEFAULT_FIELDS = [
-    "biology",
-    "chemistry",
-    "computer science",
-    "materials science",
-    "mathematics",
-    "neuroscience",
-    "physics",
-    "psychology",
-    "statistics",
-]
+# Sourced from the single canonical constant (#116) — the cross-domain
+# coverage test parametrizes over exactly the fields the CLI's per-field
+# pipeline pass uses. Kept as a module-level name for the parametrize
+# decorator below.
+DEFAULT_FIELDS = list(LIBRARIAN_DEFAULT_FIELDS)
 
 TARGET_N = 5  # spec.md SC-002
 

--- a/tests/phase2/test_librarian_default_fields.py
+++ b/tests/phase2/test_librarian_default_fields.py
@@ -1,0 +1,55 @@
+"""Guard test for the canonical librarian default-field list (#116).
+
+Per Constitution Principle I the field list lives in exactly one place —
+``llmxive.librarian.LIBRARIAN_DEFAULT_FIELDS`` — and both consumers
+(`cli.py`'s per-field pipeline pass and the cross-domain coverage test)
+import it. This test pins the expected contents (catching accidental
+edits) and asserts the consumers really do use the canonical constant
+rather than a stale copy.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from llmxive.librarian import LIBRARIAN_DEFAULT_FIELDS
+
+_EXPECTED = (
+    "biology",
+    "chemistry",
+    "computer science",
+    "materials science",
+    "mathematics",
+    "neuroscience",
+    "physics",
+    "psychology",
+    "statistics",
+)
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_canonical_field_list_contents() -> None:
+    assert LIBRARIAN_DEFAULT_FIELDS == _EXPECTED
+    assert isinstance(LIBRARIAN_DEFAULT_FIELDS, tuple)  # immutable canonical
+
+
+def test_cross_domain_test_uses_the_canonical_constant() -> None:
+    # The cross-domain coverage test parametrizes over exactly the
+    # canonical list (so it always covers what the CLI actually uses).
+    from tests.phase2 import test_librarian_cross_domain as cd
+
+    assert list(cd.DEFAULT_FIELDS) == list(LIBRARIAN_DEFAULT_FIELDS)
+
+
+def test_no_third_copy_of_the_field_list() -> None:
+    # Acceptance criterion from #116: the literal list ("biology" …
+    # "computer science" …) appears defined exactly once in the repo —
+    # in src/llmxive/librarian/__init__.py. (Test fixtures / this test
+    # itself may list the fields; we scan only src/ + the CLI/lib code.)
+    pat = re.compile(r'"biology"[\s,]+"chemistry"[\s,]+"computer science"', re.S)
+    hits = []
+    for path in (_REPO_ROOT / "src" / "llmxive").rglob("*.py"):
+        if pat.search(path.read_text(encoding="utf-8")):
+            hits.append(path.relative_to(_REPO_ROOT).as_posix())
+    assert hits == ["src/llmxive/librarian/__init__.py"], hits


### PR DESCRIPTION
Closes #116.

Per Constitution Principle I (Single Source of Truth). The librarian's 9-field default list (biology … statistics) was duplicated in `src/llmxive/cli.py` (`default_fields`) and `tests/phase2/test_librarian_cross_domain.py` (`DEFAULT_FIELDS`) — spec 006 (#113) had to update both copies in lockstep. Now it lives in exactly one place.

### Changes
- **NEW** `LIBRARIAN_DEFAULT_FIELDS: tuple[str, ...]` in `src/llmxive/librarian/__init__.py` (the librarian package's shared-constants home).
- `cli.py`'s `brainstorm` per-field pipeline pass imports it (keeps the `--field` override).
- the cross-domain coverage test's `@pytest.mark.parametrize` source imports it — so the test always parametrizes over exactly the fields the CLI uses.
- `agents/prompts/brainstorm.md` keeps its prose example list (illustrative only, not a hard enum) — unchanged.
- **NEW** `tests/phase2/test_librarian_default_fields.py` — pins the constant's contents (guards against accidental edits), asserts the cross-domain test uses it, asserts no third quoted-literal copy exists in `src/`.

### Acceptance (from #116)
- ✅ one canonical constant; `cli.py` + cross-domain test both import it; no third copy.
- ✅ cross-domain coverage test still runs all 9 fields (sourced from the constant).
- ✅ no behavior change.

`cli.py` has 9 pre-existing ruff nits unrelated to this change (typing.Sequence, `__all__` order, an unused local, …) — deliberately left untouched so this PR stays scoped to #116; they'd belong in a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)