### PR TITLE
website: fix search, dynamic contributor filters, add cross-project activity feed

### DIFF
--- a/docs/css/site.css
+++ b/docs/css/site.css
@@ -1141,3 +1141,67 @@ a:hover { color: var(--accent-2); }
 .artifact-dialog .ad-fb-msg.ok { color: oklch(0.4 0.15 150); }
 .artifact-dialog .ad-fb-msg.err { color: oklch(0.5 0.18 30); }
 .artifact-dialog .ad-fb-msg a { color: var(--accent); text-decoration: underline; }
+
+/* ── Activity tab (spec-008-followup recent-runs feed) ───────────────── */
+.activity-list {
+  display: flex; flex-direction: column;
+  background: var(--bg);
+  border: 1px solid var(--line-soft);
+  border-radius: var(--r-md);
+  overflow: hidden;
+  margin-top: 12px;
+}
+.activity-row {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line-soft);
+  font-size: 12.5px;
+}
+.activity-row:last-child { border-bottom: 0; }
+.activity-row:hover { background: var(--bg-2); }
+.activity-row .when {
+  font-family: var(--mono); font-size: 11px; color: var(--muted);
+  flex: 0 0 64px;
+}
+.activity-row .actor {
+  font-weight: 500; color: var(--text);
+  font-family: var(--mono); font-size: 12px;
+  flex: 0 0 auto;
+}
+.activity-row .atag {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: var(--bg-2);
+  border: 1px solid var(--line-soft);
+  border-radius: 4px;
+  padding: 1px 6px;
+  color: var(--text-2);
+  flex: 0 0 auto;
+}
+.activity-row .project {
+  font-family: var(--mono); font-size: 11px; color: var(--accent);
+  cursor: pointer;
+  flex: 1 1 200px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.activity-row .project:hover { text-decoration: underline; }
+.activity-row .project.muted { color: var(--muted); cursor: default; }
+.activity-row .outcome {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 1px 6px; border-radius: 4px;
+  flex: 0 0 auto;
+}
+.activity-row .outcome.ok { background: oklch(0.95 0.05 150); color: oklch(0.4 0.15 150); }
+.activity-row .outcome.bad { background: oklch(0.95 0.05 30);  color: oklch(0.5 0.18 30); }
+.activity-row .outcome.muted { background: var(--bg-2); color: var(--muted); }
+.activity-row .dur {
+  font-family: var(--mono); font-size: 10.5px; color: var(--muted);
+  flex: 0 0 auto;
+}
+.activity-empty {
+  text-align: center; padding: 40px; color: var(--muted);
+}
+[data-panel="activity"] .bar input[type="search"] {
+  margin-left: auto; min-width: 220px;
+}

--- a/docs/data/projects.json
+++ b/docs/data/projects.json
@@ -893,7 +893,7 @@
       "prompt_github_url": "https://github.com/ContextLab/llmXive/blob/main/agents/prompts/personality.md",
       "prompt_path": "agents/prompts/personality.md",
       "prompt_raw_url": "https://raw.githubusercontent.com/ContextLab/llmXive/main/agents/prompts/personality.md",
-      "purpose": "Simulated public-figure personas (David Krakauer, Geoffrey West, Dan Rockmore, Socrates, Aristotle, Daniel Kahneman, Ada Lovelace, Marie Curie, Rosalind Franklin, John von Neumann). One personality per 30-minute tick, rotating through a pool of prompt files at agents/prompts/personalities/. Each tick produces ONE contribution (comment / contribute / propose_arxiv / abstain) attributed as \"<Name> (simulated)\" with kind=llm. Per spec 008.",
+      "purpose": "Simulated public-figure personas (spec 008) \u2014 one per 30-min tick, rotating over agents/prompts/personalities/. Action \u2208 comment / contribute / propose_arxiv / abstain, tagged \"<Name> (simulated)\".",
       "registry_github_url": "https://github.com/ContextLab/llmXive/blob/main/agents/registry.yaml",
       "tools": []
     }
@@ -904,7 +904,7 @@
     "human_contributors": 5,
     "papers_posted": 0,
     "total_collaborations": 0,
-    "total_contributions": 1281,
+    "total_contributions": 1282,
     "total_contributors": 12
   },
   "contributors": [
@@ -925,7 +925,7 @@
         "robotics",
         "statistics"
       ],
-      "contribution_count": 604,
+      "contribution_count": 605,
       "kind": "llm",
       "name": "qwen.qwen3.5-122b"
     },
@@ -1047,7 +1047,7 @@
       "name": "Qwen2.5-1.5B-Instruct"
     }
   ],
-  "generated_at": "2026-05-14T01:38:10.148171+00:00",
+  "generated_at": "2026-05-14T03:54:12.183161+00:00",
   "personalities": [
     {
       "display_name": "Ada Lovelace",
@@ -44122,7 +44122,7 @@
       },
       "authors": [
         {
-          "contributions": 90,
+          "contributions": 92,
           "kind": "llm",
           "name": "qwen.qwen3.5-122b",
           "roles": [
@@ -44157,6 +44157,22 @@
       "id": "PROJ-545-the-influence-of-visual-salience-on-atte",
       "keywords": [],
       "last_run_log": [
+        {
+          "agent": "flesh_out",
+          "duration_s": 26.290644,
+          "ended_at": "2026-05-14T03:23:26.861233Z",
+          "model": "qwen.qwen3.5-122b",
+          "outcome": "success",
+          "started_at": "2026-05-14T03:23:00.570589Z"
+        },
+        {
+          "agent": "flesh_out",
+          "duration_s": 25.782505,
+          "ended_at": "2026-05-14T03:18:11.258276Z",
+          "model": "qwen.qwen3.5-122b",
+          "outcome": "success",
+          "started_at": "2026-05-14T03:17:45.475771Z"
+        },
         {
           "agent": "flesh_out",
           "duration_s": 31.76699,
@@ -44220,22 +44236,6 @@
           "model": "qwen.qwen3.5-122b",
           "outcome": "success",
           "started_at": "2026-05-13T20:41:55.631203Z"
-        },
-        {
-          "agent": "flesh_out",
-          "duration_s": 116.975668,
-          "ended_at": "2026-05-13T19:41:21.588018Z",
-          "model": "qwen.qwen3.5-122b",
-          "outcome": "success",
-          "started_at": "2026-05-13T19:39:24.612350Z"
-        },
-        {
-          "agent": "flesh_out",
-          "duration_s": 32.410827,
-          "ended_at": "2026-05-13T18:55:24.902467Z",
-          "model": "qwen.qwen3.5-122b",
-          "outcome": "success",
-          "started_at": "2026-05-13T18:54:52.491640Z"
         }
       ],
       "phase_group": "idea",
@@ -45017,7 +45017,7 @@
         "paper_tasks": null,
         "plan": null,
         "reviews_paper": null,
-        "reviews_research": null,
+        "reviews_research": "projects/PROJ-559-neuro-symbolic-learning-networks-bridgin/reviews/research",
         "spec": null,
         "tasks": null
       },
@@ -45028,6 +45028,14 @@
           "name": "Jeremy R. Manning",
           "roles": [
             "brainstorm_submitter"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "llm",
+          "name": "qwen.qwen3.5-122b",
+          "roles": [
+            "ada-lovelace-simulated"
           ]
         }
       ],
@@ -45049,7 +45057,16 @@
       "field": "computer science",
       "id": "PROJ-559-neuro-symbolic-learning-networks-bridgin",
       "keywords": [],
-      "last_run_log": [],
+      "last_run_log": [
+        {
+          "agent": "personality",
+          "duration_s": 15.270944,
+          "ended_at": "2026-05-14T03:04:24.523780+00:00",
+          "model": "qwen.qwen3.5-122b",
+          "outcome": "committed",
+          "started_at": "2026-05-14T03:04:09.252836+00:00"
+        }
+      ],
       "phase_group": "idea",
       "points_paper_total": 0.0,
       "points_research_total": 0.0,
@@ -45265,6 +45282,552 @@
       "submitter": "jeremymanning",
       "title": "A Stylometric Application of Large Language Models",
       "updated_at": "2026-05-13T13:15:00+00:00"
+    }
+  ],
+  "recent_activity": [
+    {
+      "agent": "flesh_out",
+      "duration_s": 26.290644,
+      "ended_at": "2026-05-14T03:23:26.861233Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-14T03:23:00.570589Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 25.782505,
+      "ended_at": "2026-05-14T03:18:11.258276Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-14T03:17:45.475771Z"
+    },
+    {
+      "action": "comment",
+      "agent": "personality",
+      "display_name": "Ada Lovelace (simulated)",
+      "duration_s": 15.270944,
+      "ended_at": "2026-05-14T03:04:24.523780+00:00",
+      "model": "qwen.qwen3.5-122b",
+      "model_kind": "personality_simulator",
+      "outcome": "committed",
+      "personality_slug": "ada-lovelace",
+      "project_id": "PROJ-559-neuro-symbolic-learning-networks-bridgin",
+      "started_at": "2026-05-14T03:04:09.252836+00:00"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 31.76699,
+      "ended_at": "2026-05-14T01:15:24.770822Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-14T01:14:53.003832Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 30.139904,
+      "ended_at": "2026-05-14T01:06:52.424507Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-14T01:06:22.284603Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 28.935503,
+      "ended_at": "2026-05-13T23:31:46.659496Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T23:31:17.723993Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 32.612011,
+      "ended_at": "2026-05-13T22:42:29.585722Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T22:41:56.973711Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 24.269646,
+      "ended_at": "2026-05-13T22:35:05.983680Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T22:34:41.714034Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 33.220469,
+      "ended_at": "2026-05-13T21:38:44.410783Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T21:38:11.190314Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 7.125095,
+      "ended_at": "2026-05-13T21:06:02.228913Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T21:05:55.103818Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 5.023659,
+      "ended_at": "2026-05-13T21:05:54.308393Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T21:05:49.284734Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 6.865143,
+      "ended_at": "2026-05-13T21:05:48.483659Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T21:05:41.618516Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 24.3017,
+      "ended_at": "2026-05-13T21:05:40.833805Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T21:05:16.532105Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 5.74452,
+      "ended_at": "2026-05-13T21:05:15.737968Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T21:05:09.993448Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 72.661392,
+      "ended_at": "2026-05-13T21:05:09.192835Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T21:03:56.531443Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 76.660187,
+      "ended_at": "2026-05-13T21:03:55.682188Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T21:02:39.022001Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 51.847655,
+      "ended_at": "2026-05-13T21:02:38.221077Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T21:01:46.373422Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 31.841421,
+      "ended_at": "2026-05-13T20:51:15.670807Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T20:50:43.829386Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 26.474917,
+      "ended_at": "2026-05-13T20:42:22.106120Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T20:41:55.631203Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 116.975668,
+      "ended_at": "2026-05-13T19:41:21.588018Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T19:39:24.612350Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 32.410827,
+      "ended_at": "2026-05-13T18:55:24.902467Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T18:54:52.491640Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 43.606178,
+      "ended_at": "2026-05-13T18:49:56.249057Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T18:49:12.642879Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 21.939299,
+      "ended_at": "2026-05-13T17:49:15.115182Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T17:48:53.175883Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 33.743101,
+      "ended_at": "2026-05-13T17:17:02.213350Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T17:16:28.470249Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 5.75165,
+      "ended_at": "2026-05-13T17:16:27.777406Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T17:16:22.025756Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 3.986421,
+      "ended_at": "2026-05-13T17:16:21.334158Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T17:16:17.347737Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 19.170526,
+      "ended_at": "2026-05-13T17:16:16.649694Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T17:15:57.479168Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 6.525911,
+      "ended_at": "2026-05-13T17:15:56.782504Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T17:15:50.256593Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 5.48043,
+      "ended_at": "2026-05-13T17:15:49.561884Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T17:15:44.081454Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 19.670569,
+      "ended_at": "2026-05-13T17:15:43.317984Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T17:15:23.647415Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 8.700796,
+      "ended_at": "2026-05-13T17:15:22.952556Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T17:15:14.251760Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 23.853205,
+      "ended_at": "2026-05-13T17:02:28.416631Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T17:02:04.563426Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 27.477671,
+      "ended_at": "2026-05-13T16:57:27.133192Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T16:56:59.655521Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 32.87436,
+      "ended_at": "2026-05-13T15:16:18.935309Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T15:15:46.060949Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 23.907778,
+      "ended_at": "2026-05-13T15:10:00.562437Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T15:09:36.654659Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 26.393981,
+      "ended_at": "2026-05-13T13:52:09.585384Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T13:51:43.191403Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 13.924339,
+      "ended_at": "2026-05-13T13:17:28.634785Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T13:17:14.710446Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 5.461546,
+      "ended_at": "2026-05-13T13:17:13.886826Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T13:17:08.425280Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 6.661125,
+      "ended_at": "2026-05-13T13:17:07.605794Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T13:17:00.944669Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 90.47539,
+      "ended_at": "2026-05-13T13:17:00.128613Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T13:15:29.653223Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 21.577145,
+      "ended_at": "2026-05-13T13:15:28.840515Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T13:15:07.263370Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 9.973086,
+      "ended_at": "2026-05-13T13:15:06.439208Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T13:14:56.466122Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 14.693137,
+      "ended_at": "2026-05-13T13:14:55.553003Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T13:14:40.859866Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 6.937311,
+      "ended_at": "2026-05-13T13:14:40.040250Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T13:14:33.102939Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 29.733006,
+      "ended_at": "2026-05-13T13:03:23.993055Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T13:02:54.260049Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 26.323885,
+      "ended_at": "2026-05-13T12:58:00.918985Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T12:57:34.595100Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 84.022919,
+      "ended_at": "2026-05-13T11:51:42.978704Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T11:50:18.955785Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 32.178456,
+      "ended_at": "2026-05-13T10:59:01.536144Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T10:58:29.357688Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 20.836627,
+      "ended_at": "2026-05-13T09:30:09.732374Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T09:29:48.895747Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 5.60524,
+      "ended_at": "2026-05-13T09:29:48.094176Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T09:29:42.488936Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 15.4483,
+      "ended_at": "2026-05-13T09:29:41.689538Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T09:29:26.241238Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 4.76232,
+      "ended_at": "2026-05-13T09:29:25.444484Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T09:29:20.682164Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 10.624897,
+      "ended_at": "2026-05-13T09:29:19.886538Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T09:29:09.261641Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 8.813247,
+      "ended_at": "2026-05-13T09:29:08.471645Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T09:28:59.658398Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 70.641441,
+      "ended_at": "2026-05-13T09:28:58.820445Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T09:27:48.179004Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 30.737701,
+      "ended_at": "2026-05-13T09:27:47.369849Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T09:27:16.632148Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 76.808226,
+      "ended_at": "2026-05-13T09:19:42.699092Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T09:18:25.890866Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 28.575738,
+      "ended_at": "2026-05-13T09:14:25.341124Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T09:13:56.765386Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 35.072876,
+      "ended_at": "2026-05-13T07:22:42.825276Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T07:22:07.752400Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 30.061652,
+      "ended_at": "2026-05-13T07:17:20.437046Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T07:16:50.375394Z"
     }
   ],
   "schema_version": "2.0.0"

--- a/docs/index.html
+++ b/docs/index.html
@@ -75,6 +75,7 @@
       <button class="tab"        data-tab="designs"     role="tab"><i class="fa-regular fa-compass"></i> Research specs <span class="count" data-count="designs"></span></button>
       <button class="tab"        data-tab="backlog"     role="tab"><i class="fa-solid fa-diagram-project"></i> Backlog <span class="count" data-count="backlog"></span></button>
       <button class="tab"        data-tab="contributors"role="tab"><i class="fa-regular fa-user"></i> Contributors</button>
+      <button class="tab"        data-tab="activity"    role="tab"><i class="fa-regular fa-clock"></i> Activity</button>
       <button class="tab"        data-tab="about"       role="tab"><i class="fa-regular fa-circle-question"></i> About</button>
       <span class="tab-underline" id="underline"></span>
     </div>
@@ -190,14 +191,10 @@
         <p>Human and AI collaborators ranked by successful pipeline contributions across spec, plan, code, data, paper, and review work.</p>
       </div>
     </div>
-    <div class="bar">
-      <span class="label">Filter</span>
-      <button class="chip active" data-filter="all">All areas</button>
-      <button class="chip" data-filter="spec">Specs</button>
-      <button class="chip" data-filter="plan">Plans</button>
-      <button class="chip" data-filter="code">Code</button>
-      <button class="chip" data-filter="paper">Papers</button>
-      <button class="chip" data-filter="review">Reviews</button>
+    <div class="bar" id="contrib-filter-bar">
+      <span class="label">Filter by area</span>
+      <!-- chips rendered dynamically by app.js renderContributors() from the
+           areas actually present in payload.contributors[].areas -->
     </div>
 
     <div class="podium" id="podium"></div>
@@ -213,6 +210,26 @@
       <div class="tr head">
         <div>Rank</div><div>Contributor</div><div>Type</div><div>Contributions</div><div>Areas</div>
       </div>
+    </div>
+  </section>
+
+  <section class="panel" data-panel="activity">
+    <div class="panel-head">
+      <div>
+        <h2>Recent activity</h2>
+        <p>The most recent agent runs across every project. Pipeline ticks, reviews, paper submissions, and simulated-personality contributions land here as they happen.</p>
+      </div>
+    </div>
+    <div class="bar">
+      <span class="label">Filter</span>
+      <button class="chip active" data-activity-filter="all">All</button>
+      <button class="chip" data-activity-filter="personality">Personalities</button>
+      <button class="chip" data-activity-filter="pipeline">Pipeline</button>
+      <button class="chip" data-activity-filter="reviews">Reviews</button>
+      <input type="search" data-activity-search="" placeholder="Search by project, agent, persona…" />
+    </div>
+    <div class="activity-list" id="activity-list">
+      <!-- rows rendered by app.js renderActivity() -->
     </div>
   </section>
 

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -105,17 +105,50 @@
       + '</article>';
   }
 
+  // Per-lane search state (one term per `data-search` input). Empty = no
+  // filter. setupSearch() wires the inputs; matchesSearch() decides which
+  // projects survive the filter for a given lane.
+  const searchState = {};
+
+  function matchesSearch(item, term) {
+    if (!term) return true;
+    const needle = term.trim().toLowerCase();
+    if (!needle) return true;
+    // Searchable haystack: title + description + field + keywords + author
+    // names (so "kahneman" matches a paper authored by Daniel Kahneman, and
+    // "biology" matches every biology project). Built once per card per
+    // keystroke; the catalog is small (≤ ~600 projects) so this is fine.
+    const parts = [
+      item.title,
+      item.description,
+      item.field,
+      ...(item.keywords || []),
+      ...((item.authors || []).map(a => a.name)),
+      item.submitter,
+      item.id,
+    ];
+    const hay = parts.filter(Boolean).join("  ").toLowerCase();
+    return hay.includes(needle);
+  }
+
   function renderCards(kind) {
     const el = document.getElementById(kind + "-cards");
     if (!el) return;
-    const items = (buckets && buckets[kind]) || [];
+    const allItems = (buckets && buckets[kind]) || [];
+    const term = searchState[kind] || "";
+    const items = allItems.filter(it => matchesSearch(it, term));
     if (!items.length) {
       el.replaceChildren();
       const empty = document.createElement("div");
       empty.style.cssText = "grid-column: 1/-1; text-align:center; padding:40px; color:var(--muted);";
+      // Distinguish "empty lane" from "search has no matches" — the user
+      // wants to know which one to act on.
+      const msg = term
+        ? `No matches for &ldquo;${escapeHtml(term)}&rdquo;.`
+        : "No projects in this stage yet.";
       empty.insertAdjacentHTML("beforeend",
         '<i class="fa-regular fa-folder-open" style="font-size:32px; opacity:0.5"></i>' +
-        '<p style="margin-top:12px;">No projects in this stage yet.</p>');
+        '<p style="margin-top:12px;">' + msg + '</p>');
       el.appendChild(empty);
       return;
     }
@@ -155,8 +188,13 @@
   }
 
   function renderBacklogLane(rootEl, lane, stages) {
+    // The Backlog tab has a single search input (`data-search="backlog"`)
+    // that filters BOTH the research and the paper kanban columns. Apply
+    // the same `matchesSearch` predicate per project before rendering.
+    const term = searchState["backlog"] || "";
     const html = stages.map(stage => {
-      const items = lane[stage] || [];
+      const stageItems = lane[stage] || [];
+      const items = stageItems.filter(p => matchesSearch(p, term));
       const label = D.STAGE_LABELS[stage] || stage;
       const issues = items.map(p => {
         const desc = (p.description || "").slice(0, 140) + ((p.description || "").length > 140 ? "…" : "");
@@ -202,28 +240,86 @@
     return "fa-regular fa-circle-question";
   }
 
+  // Current contributor-area filter: "all" → show everyone; otherwise the
+  // exact area string (e.g. "biology", "computer science"). Cleared by
+  // clicking the "All areas" chip; toggled by clicking any other chip.
+  let contributorAreaFilter = "all";
+
   function renderContributors() {
     // The data is already sorted (real contributors by count desc, the single
     // "unattributed" bucket last); keep that order. Rank only real contributors.
-    const list = (payload.contributors || []).slice();
-    list.forEach((c, i) => c.rank = i + 1);
+    const everyone = (payload.contributors || []).slice();
+    everyone.forEach((c, i) => c.rank = i + 1);
+
+    // 1. Render the filter chips ONCE per renderContributors() call. The
+    //    chip set is derived from the actual `areas` strings present in
+    //    payload.contributors — so it's always in sync with the data and
+    //    new fields show up automatically without an HTML edit (matches
+    //    the personality-pool extensibility property).
+    const bar = document.getElementById("contrib-filter-bar");
+    if (bar) {
+      // Collect every area, ranked by how many contributors touch it.
+      const areaCounts = new Map();
+      for (const c of everyone) {
+        if (c.kind === "unattributed") continue;
+        for (const a of (c.areas || [])) {
+          areaCounts.set(a, (areaCounts.get(a) || 0) + 1);
+        }
+      }
+      const orderedAreas = [...areaCounts.entries()]
+        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+        .map(([a]) => a);
+      // Remove any pre-existing chip buttons (label survives) and rebuild.
+      [...bar.querySelectorAll(".chip")].forEach(n => n.remove());
+      const chipsHtml = ['<button class="chip' + (contributorAreaFilter === "all" ? " active" : "") + '" data-area-filter="all">All areas</button>']
+        .concat(orderedAreas.map(a =>
+          '<button class="chip' + (contributorAreaFilter === a ? " active" : "") +
+          '" data-area-filter="' + escapeHtml(a) + '">' + escapeHtml(a) + '</button>'
+        )).join("");
+      bar.insertAdjacentHTML("beforeend", chipsHtml);
+      // Re-bind handlers every time so the closure captures the freshest
+      // renderContributors. Idempotent because we replaced the chip nodes.
+      bar.querySelectorAll(".chip[data-area-filter]").forEach(chip => {
+        chip.addEventListener("click", () => {
+          contributorAreaFilter = chip.dataset.areaFilter;
+          renderContributors();
+        });
+      });
+    }
+
+    // 2. Apply the filter. "all" → everyone; otherwise keep only
+    //    contributors whose `areas` include the selected area. Unattributed
+    //    bucket is always kept (it's the catch-all at the bottom).
+    const matches = c => contributorAreaFilter === "all"
+      || c.kind === "unattributed"
+      || (c.areas || []).includes(contributorAreaFilter);
+    const list = everyone.filter(matches);
     const ranked = list.filter(c => c.kind !== "unattributed");
+
+    // 3. Re-rank within the filter so the podium reflects "top-3 in this
+    //    area" rather than "top-3 overall, possibly absent here". The
+    //    original rank (across all areas) is preserved in `c.rank` for
+    //    the table column so users can see absolute standing too.
+    ranked.forEach((c, i) => c.filteredRank = i + 1);
 
     const podium = document.getElementById("podium");
     podium.replaceChildren();
     if (!ranked.length) {
+      const msg = contributorAreaFilter === "all"
+        ? "No contributors yet."
+        : `No contributors in &ldquo;${escapeHtml(contributorAreaFilter)}&rdquo;.`;
       podium.insertAdjacentHTML("beforeend",
-        '<div style="grid-column: 1/-1; text-align:center; padding:40px; color:var(--muted);">No contributors yet.</div>');
+        '<div style="grid-column: 1/-1; text-align:center; padding:40px; color:var(--muted);">' + msg + '</div>');
     } else {
       const top3 = ranked.slice(0, 3);
       const podiumOrder = [top3[1], top3[0], top3[2]];
       const html = podiumOrder.map((c) => {
         if (!c) return "";
-        const isFirst = c.rank === 1;
+        const isFirst = c.filteredRank === 1;
         const initials = c.name.split(/[-.]/).map(s => s[0]).join("").slice(0, 2).toUpperCase();
         return ''
           + '<div class="pod ' + (isFirst ? "first" : "") + '">'
-          + '<div class="rank">' + c.rank + '</div>'
+          + '<div class="rank">' + c.filteredRank + '</div>'
           + '<div class="avatar">' + escapeHtml(initials || "?") + '</div>'
           + '<div class="name">' + escapeHtml(c.name) + '</div>'
           + '<div class="type">' + escapeHtml(kindLabel(c.kind)) + '</div>'
@@ -244,6 +340,196 @@
       + '<div class="areas">' + (c.areas || []).map(a => '<span>' + escapeHtml(a) + '</span>').join("") + '</div>'
       + '</div>').join("");
     table.insertAdjacentHTML("beforeend", rowsHtml);
+  }
+
+  // ── Activity tab — cross-project recent-run feed ─────────────────────
+  //
+  // Data: payload.recent_activity (emitted by web_data.py _recent_activity).
+  // Filter chips: "all" / "personality" / "pipeline" / "reviews".
+  //   - personality → agent_name == "personality"
+  //   - pipeline    → agent_name is one of the pipeline drivers
+  //                   (brainstorm, flesh_out, specifier, clarifier, planner,
+  //                   tasker, implementer, plus paper-stage equivalents)
+  //   - reviews     → agent_name starts with "research_reviewer" or
+  //                   "paper_reviewer"
+  //   - all         → no agent filter
+  // Plus a free-text search over project_id / agent / display_name.
+  let activityFilter = "all";
+  let activitySearch = "";
+
+  const _ACTIVITY_PIPELINE_AGENTS = new Set([
+    "brainstorm", "flesh_out", "research_question_validator", "idea_selector",
+    "project_initializer", "librarian", "specifier", "clarifier", "planner",
+    "tasker", "implementer", "advancement",
+    "paper_initializer", "paper_specifier", "paper_clarifier",
+    "paper_planner", "paper_tasker", "paper_implementer",
+    "latex_build", "latex_fix", "reference_validator",
+    "submission_intake", "status_reporter", "repository_hygiene",
+  ]);
+
+  function _activityCategory(entry) {
+    const a = entry.agent || "";
+    if (a === "personality") return "personality";
+    if (a.startsWith("research_reviewer") || a.startsWith("paper_reviewer")) return "reviews";
+    if (_ACTIVITY_PIPELINE_AGENTS.has(a)) return "pipeline";
+    return "other";
+  }
+
+  function _relTime(iso) {
+    if (!iso) return "—";
+    try {
+      const dt = new Date(iso);
+      const ms = Date.now() - dt.getTime();
+      const s = Math.round(ms / 1000);
+      if (s < 60) return s + "s ago";
+      const m = Math.round(s / 60);
+      if (m < 60) return m + "m ago";
+      const h = Math.round(m / 60);
+      if (h < 48) return h + "h ago";
+      const d = Math.round(h / 24);
+      return d + "d ago";
+    } catch (e) { return "—"; }
+  }
+
+  function _outcomeBadge(outcome) {
+    // success/committed → ok; abstained → muted; failures → bad.
+    const bad = ["rate_limited", "model_error", "malformed_response",
+                 "target_missing", "librarian_held", "timeout", "failure", "failed"];
+    let cls = "ok";
+    if (bad.includes(outcome)) cls = "bad";
+    if (outcome === "abstained") cls = "muted";
+    return '<span class="outcome ' + cls + '">' + escapeHtml(outcome || "—") + '</span>';
+  }
+
+  function renderActivity() {
+    const root = document.getElementById("activity-list");
+    if (!root) return;
+    let rows = (payload.recent_activity || []).slice();
+    if (activityFilter !== "all") {
+      rows = rows.filter(r => _activityCategory(r) === activityFilter);
+    }
+    if (activitySearch) {
+      const needle = activitySearch.toLowerCase();
+      rows = rows.filter(r => {
+        const hay = [r.project_id, r.agent, r.display_name, r.personality_slug,
+                     r.action, r.outcome, r.model].filter(Boolean).join(" ").toLowerCase();
+        return hay.includes(needle);
+      });
+    }
+    root.replaceChildren();
+    if (!rows.length) {
+      root.insertAdjacentHTML("beforeend",
+        '<div class="activity-empty">No activity matching the current filter.</div>');
+      return;
+    }
+    const html = rows.map(r => {
+      // Display the persona's "(simulated)" display_name when present,
+      // else the agent name — same FR-010 invariant the contributor list
+      // honors.
+      const who = r.display_name || r.agent || "—";
+      const actor = '<span class="actor">' + escapeHtml(who) + '</span>';
+      const project = r.project_id
+        ? '<span class="project" data-pid="' + escapeHtml(r.project_id) + '">'
+            + escapeHtml(r.project_id) + '</span>'
+        : '<span class="project muted">(no project)</span>';
+      const actionTag = r.action
+        ? '<span class="atag">' + escapeHtml(r.action) + '</span>'
+        : '';
+      const dur = r.duration_s
+        ? '<span class="dur">' + (r.duration_s).toFixed(1) + 's</span>'
+        : '';
+      return '<div class="activity-row" data-cat="' + _activityCategory(r) + '">'
+        + '<span class="when" title="' + escapeHtml(r.ended_at || r.started_at || "") + '">'
+        + escapeHtml(_relTime(r.ended_at || r.started_at)) + '</span>'
+        + actor + actionTag + project + _outcomeBadge(r.outcome) + dur
+        + '</div>';
+    }).join("");
+    root.insertAdjacentHTML("beforeend", html);
+    // Clicking a project pill opens that project's modal.
+    root.querySelectorAll(".project[data-pid]").forEach(el => {
+      el.addEventListener("click", () => {
+        const pid = el.dataset.pid;
+        const proj = (payload.projects || []).find(p => p.id === pid);
+        if (proj) Dialog.open(proj);
+      });
+    });
+  }
+
+  function setupActivity() {
+    // Filter chips
+    document.querySelectorAll("[data-activity-filter]").forEach(chip => {
+      chip.addEventListener("click", () => {
+        activityFilter = chip.dataset.activityFilter;
+        document.querySelectorAll("[data-activity-filter]").forEach(c =>
+          c.classList.toggle("active", c.dataset.activityFilter === activityFilter));
+        renderActivity();
+      });
+    });
+    // Search input
+    const searchInput = document.querySelector("[data-activity-search]");
+    if (searchInput) {
+      let timer = null;
+      searchInput.addEventListener("input", () => {
+        clearTimeout(timer);
+        timer = setTimeout(() => {
+          activitySearch = (searchInput.value || "").trim();
+          renderActivity();
+        }, 100);
+      });
+      searchInput.addEventListener("keydown", e => {
+        if (e.key === "Escape" && searchInput.value) {
+          searchInput.value = "";
+          activitySearch = "";
+          renderActivity();
+        }
+      });
+    }
+  }
+
+  function setupSearch() {
+    // Wire every `<input data-search="LANE">` in index.html to filter that
+    // lane's cards (or kanban columns for backlog) by the typed term.
+    // The `searchState` map and `matchesSearch` predicate above are the
+    // canonical filter — every render-lane call already honors them.
+    //
+    // Inputs (per index.html):
+    //   data-search="papers"     → renderCards("papers")
+    //   data-search="paper"      → renderCards("paper")
+    //   data-search="inProgress" → renderCards("inProgress")
+    //   data-search="backlog"    → renderBacklog()
+    //
+    // Debounce keystrokes lightly (100ms) so we don't re-render on every
+    // single character for users typing quickly. The render path is fast
+    // (≤ ~600 projects, plain DOM strings), but the debounce keeps the
+    // UI feeling smooth.
+    document.querySelectorAll("[data-search]").forEach(input => {
+      const lane = input.dataset.search;
+      if (!lane) return;
+      let timer = null;
+      input.addEventListener("input", () => {
+        clearTimeout(timer);
+        timer = setTimeout(() => {
+          searchState[lane] = input.value || "";
+          if (lane === "backlog") {
+            renderBacklog();
+          } else {
+            // The other four (papers / paper / inProgress / plans / designs)
+            // each have their own `<div id="${lane}-cards">` rendered by
+            // renderCards.
+            renderCards(lane);
+          }
+        }, 100);
+      });
+      // Esc clears the input + re-renders.
+      input.addEventListener("keydown", e => {
+        if (e.key === "Escape" && input.value) {
+          input.value = "";
+          searchState[lane] = "";
+          if (lane === "backlog") renderBacklog();
+          else renderCards(lane);
+        }
+      });
+    });
   }
 
   function setupTabs() {
@@ -664,8 +950,11 @@
     ["papers", "paper", "inProgress", "plans", "designs"].forEach(renderCards);
     renderBacklog();
     renderContributors();
+    renderActivity();
 
     setupTabs();
+    setupSearch();
+    setupActivity();
     setupModals();
     setupAboutModals();
 

--- a/src/llmxive/web_data.py
+++ b/src/llmxive/web_data.py
@@ -563,6 +563,80 @@ def _last_run_log(repo: Path, project_id: str, *, limit: int = 10) -> list[dict[
     return out
 
 
+def _recent_activity(repo: Path, *, limit: int = 60) -> list[dict[str, Any]]:
+    """Aggregate the most recent agent runs across ALL projects.
+
+    Walks ``state/run-log/<YYYY-MM>/*.jsonl`` newest-first, accumulates run
+    entries (regardless of project), and returns the ``limit`` most-recent
+    ones for the website's Activity tab. Each entry carries the same
+    fields as :func:`_last_run_log` plus the ``project_id`` (since this
+    is cross-project) and — for the personality agent (spec 008) — the
+    ``personality_slug`` and ``display_name`` so the UI can render
+    "Daniel Kahneman (simulated)" correctly.
+    """
+    log_root = repo / "state" / "run-log"
+    if not log_root.is_dir():
+        return []
+    entries: list[dict[str, Any]] = []
+    # Walk months newest-first; stop once we have plenty of headroom
+    # over `limit` (we sort + truncate at the end).
+    months = sorted(
+        [d for d in log_root.iterdir() if d.is_dir() and not d.name.startswith(".")],
+        reverse=True,
+    )
+    for month_dir in months:
+        for jsonl in sorted(month_dir.glob("*.jsonl"), reverse=True):
+            try:
+                lines = jsonl.read_text(encoding="utf-8").splitlines()
+            except OSError:
+                continue
+            for line in lines:
+                if not line.strip():
+                    continue
+                try:
+                    e = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                entries.append(e)
+        # We over-collect 4×limit to give the sort room — if the latest
+        # month has only `limit//4` ticks, we still want to surface the
+        # tail from the prior month.
+        if len(entries) >= limit * 4:
+            break
+    entries.sort(key=lambda e: e.get("ended_at") or e.get("started_at") or "", reverse=True)
+    out: list[dict[str, Any]] = []
+    for e in entries[:limit]:
+        try:
+            t0 = datetime.fromisoformat(e["started_at"].replace("Z", "+00:00"))
+            t1 = datetime.fromisoformat(e["ended_at"].replace("Z", "+00:00"))
+            dur = (t1 - t0).total_seconds()
+        except Exception:
+            dur = float(e.get("duration_s") or 0.0)
+        row: dict[str, Any] = {
+            "agent": e.get("agent_name", ""),
+            "model": _normalize_model_name(e.get("model_name", "") or ""),
+            "project_id": e.get("project_id"),
+            "started_at": e.get("started_at", ""),
+            "ended_at": e.get("ended_at", ""),
+            "outcome": e.get("outcome", ""),
+            "duration_s": float(dur),
+        }
+        # Personality-agent extra fields (spec 008) so the UI can render
+        # "<Name> (simulated)" — flow them through verbatim.
+        if e.get("personality_slug"):
+            row["personality_slug"] = e["personality_slug"]
+        if e.get("display_name"):
+            row["display_name"] = e["display_name"]
+        if e.get("model_kind"):
+            row["model_kind"] = e["model_kind"]
+        # Surface a tiny action-specific hint (the persona's "action" field
+        # — comment / contribute / propose_arxiv / abstain) for the feed.
+        if e.get("action"):
+            row["action"] = e["action"]
+        out.append(row)
+    return out
+
+
 def _project_keywords(repo: Path, project_id: str) -> list[str]:
     """Heuristic: pull keywords/tags from the idea Markdown frontmatter."""
     pdir = _project_dir(repo, project_id)
@@ -1172,6 +1246,7 @@ def build_payload(repo: Path) -> dict[str, Any]:
         "agents": _build_agents_block(repo),
         "personalities": _build_personalities_block(repo),
         "pipeline_steps": _build_pipeline_steps_block(repo, projects, registry_names),
+        "recent_activity": _recent_activity(repo),
     }
 
 

--- a/tests/unit/test_web_data_recent_activity.py
+++ b/tests/unit/test_web_data_recent_activity.py
@@ -1,0 +1,128 @@
+"""Tests for `_recent_activity` cross-project aggregator (Activity tab).
+
+Drives the function against tmp-dir fixture run-logs with multiple
+projects + multiple agents (incl. simulated personality entries) and
+asserts:
+
+- Latest-first ordering by `ended_at`.
+- ``limit`` truncation.
+- Personality-specific fields (display_name, personality_slug, action,
+  model_kind) flow through verbatim.
+- Empty / missing run-log root returns an empty list (no crash).
+- The function tolerates malformed JSONL lines (skips, doesn't error).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from llmxive.web_data import _recent_activity
+
+
+def _write_jsonl(path: Path, entries: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
+
+
+def _entry(*, agent: str, project: str, ts: str, outcome: str = "success",
+           **extra) -> dict:
+    return {
+        "agent_name": agent,
+        "model_name": "qwen.qwen3.5-122b",
+        "project_id": project,
+        "started_at": ts,
+        "ended_at": ts,
+        "outcome": outcome,
+        **extra,
+    }
+
+
+class TestRecentActivity:
+    def test_empty_when_no_runlog_dir(self, tmp_path: Path) -> None:
+        assert _recent_activity(tmp_path) == []
+
+    def test_aggregates_across_projects(self, tmp_path: Path) -> None:
+        _write_jsonl(tmp_path / "state" / "run-log" / "2026-05" / "a.jsonl", [
+            _entry(agent="brainstorm", project="PROJ-001-foo", ts="2026-05-10T10:00:00+00:00"),
+            _entry(agent="flesh_out",  project="PROJ-002-bar", ts="2026-05-10T11:00:00+00:00"),
+        ])
+        out = _recent_activity(tmp_path)
+        assert len(out) == 2
+        # newest first.
+        assert out[0]["project_id"] == "PROJ-002-bar"
+        assert out[1]["project_id"] == "PROJ-001-foo"
+
+    def test_walks_multiple_months_newest_first(self, tmp_path: Path) -> None:
+        _write_jsonl(tmp_path / "state" / "run-log" / "2026-04" / "a.jsonl", [
+            _entry(agent="implementer", project="PROJ-001-foo", ts="2026-04-15T10:00:00+00:00"),
+        ])
+        _write_jsonl(tmp_path / "state" / "run-log" / "2026-05" / "a.jsonl", [
+            _entry(agent="flesh_out", project="PROJ-002-bar", ts="2026-05-10T10:00:00+00:00"),
+        ])
+        out = _recent_activity(tmp_path)
+        assert out[0]["project_id"] == "PROJ-002-bar"
+        assert out[1]["project_id"] == "PROJ-001-foo"
+
+    def test_truncates_to_limit(self, tmp_path: Path) -> None:
+        # Write 100 entries; default limit is 60.
+        entries = [
+            _entry(agent="brainstorm", project=f"PROJ-{i:03d}-x",
+                   ts=f"2026-05-10T{i % 24:02d}:00:00+00:00")
+            for i in range(100)
+        ]
+        _write_jsonl(tmp_path / "state" / "run-log" / "2026-05" / "a.jsonl", entries)
+        out = _recent_activity(tmp_path, limit=60)
+        assert len(out) == 60
+
+    def test_personality_fields_propagated(self, tmp_path: Path) -> None:
+        _write_jsonl(tmp_path / "state" / "run-log" / "2026-05" / "a.jsonl", [
+            {
+                "agent_name": "personality",
+                "model_name": "qwen.qwen3.5-122b",
+                "model_kind": "personality_simulator",
+                "personality_slug": "daniel-kahneman",
+                "display_name": "Daniel Kahneman (simulated)",
+                "project_id": "PROJ-001-foo",
+                "started_at": "2026-05-10T10:00:00+00:00",
+                "ended_at": "2026-05-10T10:00:11+00:00",
+                "outcome": "committed",
+                "action": "comment",
+            },
+        ])
+        out = _recent_activity(tmp_path)
+        assert len(out) == 1
+        row = out[0]
+        assert row["display_name"] == "Daniel Kahneman (simulated)"
+        assert row["personality_slug"] == "daniel-kahneman"
+        assert row["model_kind"] == "personality_simulator"
+        assert row["action"] == "comment"
+        assert row["outcome"] == "committed"
+
+    def test_skips_malformed_lines(self, tmp_path: Path) -> None:
+        log = tmp_path / "state" / "run-log" / "2026-05" / "a.jsonl"
+        log.parent.mkdir(parents=True)
+        log.write_text(
+            json.dumps(_entry(agent="brainstorm", project="PROJ-001-x", ts="2026-05-10T10:00:00+00:00")) + "\n"
+            + "this is not json\n"
+            + json.dumps(_entry(agent="flesh_out", project="PROJ-002-y", ts="2026-05-10T11:00:00+00:00")) + "\n",
+            encoding="utf-8",
+        )
+        out = _recent_activity(tmp_path)
+        # Two valid entries, one bad line skipped.
+        assert len(out) == 2
+
+    def test_duration_computed_from_timestamps(self, tmp_path: Path) -> None:
+        _write_jsonl(tmp_path / "state" / "run-log" / "2026-05" / "a.jsonl", [
+            {
+                "agent_name": "implementer",
+                "model_name": "qwen.qwen3.5-122b",
+                "project_id": "PROJ-001-foo",
+                "started_at": "2026-05-10T10:00:00+00:00",
+                "ended_at": "2026-05-10T10:00:42+00:00",
+                "outcome": "success",
+            },
+        ])
+        out = _recent_activity(tmp_path)
+        assert out[0]["duration_s"] == 42.0

--- a/web/css/site.css
+++ b/web/css/site.css
@@ -1141,3 +1141,67 @@ a:hover { color: var(--accent-2); }
 .artifact-dialog .ad-fb-msg.ok { color: oklch(0.4 0.15 150); }
 .artifact-dialog .ad-fb-msg.err { color: oklch(0.5 0.18 30); }
 .artifact-dialog .ad-fb-msg a { color: var(--accent); text-decoration: underline; }
+
+/* ── Activity tab (spec-008-followup recent-runs feed) ───────────────── */
+.activity-list {
+  display: flex; flex-direction: column;
+  background: var(--bg);
+  border: 1px solid var(--line-soft);
+  border-radius: var(--r-md);
+  overflow: hidden;
+  margin-top: 12px;
+}
+.activity-row {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line-soft);
+  font-size: 12.5px;
+}
+.activity-row:last-child { border-bottom: 0; }
+.activity-row:hover { background: var(--bg-2); }
+.activity-row .when {
+  font-family: var(--mono); font-size: 11px; color: var(--muted);
+  flex: 0 0 64px;
+}
+.activity-row .actor {
+  font-weight: 500; color: var(--text);
+  font-family: var(--mono); font-size: 12px;
+  flex: 0 0 auto;
+}
+.activity-row .atag {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: var(--bg-2);
+  border: 1px solid var(--line-soft);
+  border-radius: 4px;
+  padding: 1px 6px;
+  color: var(--text-2);
+  flex: 0 0 auto;
+}
+.activity-row .project {
+  font-family: var(--mono); font-size: 11px; color: var(--accent);
+  cursor: pointer;
+  flex: 1 1 200px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.activity-row .project:hover { text-decoration: underline; }
+.activity-row .project.muted { color: var(--muted); cursor: default; }
+.activity-row .outcome {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 1px 6px; border-radius: 4px;
+  flex: 0 0 auto;
+}
+.activity-row .outcome.ok { background: oklch(0.95 0.05 150); color: oklch(0.4 0.15 150); }
+.activity-row .outcome.bad { background: oklch(0.95 0.05 30);  color: oklch(0.5 0.18 30); }
+.activity-row .outcome.muted { background: var(--bg-2); color: var(--muted); }
+.activity-row .dur {
+  font-family: var(--mono); font-size: 10.5px; color: var(--muted);
+  flex: 0 0 auto;
+}
+.activity-empty {
+  text-align: center; padding: 40px; color: var(--muted);
+}
+[data-panel="activity"] .bar input[type="search"] {
+  margin-left: auto; min-width: 220px;
+}

--- a/web/data/projects.json
+++ b/web/data/projects.json
@@ -1047,7 +1047,7 @@
       "name": "Qwen2.5-1.5B-Instruct"
     }
   ],
-  "generated_at": "2026-05-14T03:23:29.526848+00:00",
+  "generated_at": "2026-05-14T03:55:25.116086+00:00",
   "personalities": [
     {
       "display_name": "Ada Lovelace",
@@ -45282,6 +45282,552 @@
       "submitter": "jeremymanning",
       "title": "A Stylometric Application of Large Language Models",
       "updated_at": "2026-05-13T13:15:00+00:00"
+    }
+  ],
+  "recent_activity": [
+    {
+      "agent": "flesh_out",
+      "duration_s": 26.290644,
+      "ended_at": "2026-05-14T03:23:26.861233Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-14T03:23:00.570589Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 25.782505,
+      "ended_at": "2026-05-14T03:18:11.258276Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-14T03:17:45.475771Z"
+    },
+    {
+      "action": "comment",
+      "agent": "personality",
+      "display_name": "Ada Lovelace (simulated)",
+      "duration_s": 15.270944,
+      "ended_at": "2026-05-14T03:04:24.523780+00:00",
+      "model": "qwen.qwen3.5-122b",
+      "model_kind": "personality_simulator",
+      "outcome": "committed",
+      "personality_slug": "ada-lovelace",
+      "project_id": "PROJ-559-neuro-symbolic-learning-networks-bridgin",
+      "started_at": "2026-05-14T03:04:09.252836+00:00"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 31.76699,
+      "ended_at": "2026-05-14T01:15:24.770822Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-14T01:14:53.003832Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 30.139904,
+      "ended_at": "2026-05-14T01:06:52.424507Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-14T01:06:22.284603Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 28.935503,
+      "ended_at": "2026-05-13T23:31:46.659496Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T23:31:17.723993Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 32.612011,
+      "ended_at": "2026-05-13T22:42:29.585722Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T22:41:56.973711Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 24.269646,
+      "ended_at": "2026-05-13T22:35:05.983680Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T22:34:41.714034Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 33.220469,
+      "ended_at": "2026-05-13T21:38:44.410783Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T21:38:11.190314Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 7.125095,
+      "ended_at": "2026-05-13T21:06:02.228913Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T21:05:55.103818Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 5.023659,
+      "ended_at": "2026-05-13T21:05:54.308393Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T21:05:49.284734Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 6.865143,
+      "ended_at": "2026-05-13T21:05:48.483659Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T21:05:41.618516Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 24.3017,
+      "ended_at": "2026-05-13T21:05:40.833805Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T21:05:16.532105Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 5.74452,
+      "ended_at": "2026-05-13T21:05:15.737968Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T21:05:09.993448Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 72.661392,
+      "ended_at": "2026-05-13T21:05:09.192835Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T21:03:56.531443Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 76.660187,
+      "ended_at": "2026-05-13T21:03:55.682188Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T21:02:39.022001Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 51.847655,
+      "ended_at": "2026-05-13T21:02:38.221077Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T21:01:46.373422Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 31.841421,
+      "ended_at": "2026-05-13T20:51:15.670807Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T20:50:43.829386Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 26.474917,
+      "ended_at": "2026-05-13T20:42:22.106120Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T20:41:55.631203Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 116.975668,
+      "ended_at": "2026-05-13T19:41:21.588018Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T19:39:24.612350Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 32.410827,
+      "ended_at": "2026-05-13T18:55:24.902467Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T18:54:52.491640Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 43.606178,
+      "ended_at": "2026-05-13T18:49:56.249057Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T18:49:12.642879Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 21.939299,
+      "ended_at": "2026-05-13T17:49:15.115182Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T17:48:53.175883Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 33.743101,
+      "ended_at": "2026-05-13T17:17:02.213350Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T17:16:28.470249Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 5.75165,
+      "ended_at": "2026-05-13T17:16:27.777406Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T17:16:22.025756Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 3.986421,
+      "ended_at": "2026-05-13T17:16:21.334158Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T17:16:17.347737Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 19.170526,
+      "ended_at": "2026-05-13T17:16:16.649694Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T17:15:57.479168Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 6.525911,
+      "ended_at": "2026-05-13T17:15:56.782504Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T17:15:50.256593Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 5.48043,
+      "ended_at": "2026-05-13T17:15:49.561884Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T17:15:44.081454Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 19.670569,
+      "ended_at": "2026-05-13T17:15:43.317984Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T17:15:23.647415Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 8.700796,
+      "ended_at": "2026-05-13T17:15:22.952556Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T17:15:14.251760Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 23.853205,
+      "ended_at": "2026-05-13T17:02:28.416631Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T17:02:04.563426Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 27.477671,
+      "ended_at": "2026-05-13T16:57:27.133192Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T16:56:59.655521Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 32.87436,
+      "ended_at": "2026-05-13T15:16:18.935309Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T15:15:46.060949Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 23.907778,
+      "ended_at": "2026-05-13T15:10:00.562437Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T15:09:36.654659Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 26.393981,
+      "ended_at": "2026-05-13T13:52:09.585384Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T13:51:43.191403Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 13.924339,
+      "ended_at": "2026-05-13T13:17:28.634785Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T13:17:14.710446Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 5.461546,
+      "ended_at": "2026-05-13T13:17:13.886826Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T13:17:08.425280Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 6.661125,
+      "ended_at": "2026-05-13T13:17:07.605794Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T13:17:00.944669Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 90.47539,
+      "ended_at": "2026-05-13T13:17:00.128613Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T13:15:29.653223Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 21.577145,
+      "ended_at": "2026-05-13T13:15:28.840515Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T13:15:07.263370Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 9.973086,
+      "ended_at": "2026-05-13T13:15:06.439208Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T13:14:56.466122Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 14.693137,
+      "ended_at": "2026-05-13T13:14:55.553003Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T13:14:40.859866Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 6.937311,
+      "ended_at": "2026-05-13T13:14:40.040250Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T13:14:33.102939Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 29.733006,
+      "ended_at": "2026-05-13T13:03:23.993055Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T13:02:54.260049Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 26.323885,
+      "ended_at": "2026-05-13T12:58:00.918985Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T12:57:34.595100Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 84.022919,
+      "ended_at": "2026-05-13T11:51:42.978704Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T11:50:18.955785Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 32.178456,
+      "ended_at": "2026-05-13T10:59:01.536144Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T10:58:29.357688Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 20.836627,
+      "ended_at": "2026-05-13T09:30:09.732374Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T09:29:48.895747Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 5.60524,
+      "ended_at": "2026-05-13T09:29:48.094176Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T09:29:42.488936Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 15.4483,
+      "ended_at": "2026-05-13T09:29:41.689538Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T09:29:26.241238Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 4.76232,
+      "ended_at": "2026-05-13T09:29:25.444484Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T09:29:20.682164Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 10.624897,
+      "ended_at": "2026-05-13T09:29:19.886538Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T09:29:09.261641Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 8.813247,
+      "ended_at": "2026-05-13T09:29:08.471645Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T09:28:59.658398Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 70.641441,
+      "ended_at": "2026-05-13T09:28:58.820445Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T09:27:48.179004Z"
+    },
+    {
+      "agent": "implementer",
+      "duration_s": 30.737701,
+      "ended_at": "2026-05-13T09:27:47.369849Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-001-mechanistic-interpretability-of-ctcf-bin",
+      "started_at": "2026-05-13T09:27:16.632148Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 76.808226,
+      "ended_at": "2026-05-13T09:19:42.699092Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T09:18:25.890866Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 28.575738,
+      "ended_at": "2026-05-13T09:14:25.341124Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T09:13:56.765386Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 35.072876,
+      "ended_at": "2026-05-13T07:22:42.825276Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T07:22:07.752400Z"
+    },
+    {
+      "agent": "flesh_out",
+      "duration_s": 30.061652,
+      "ended_at": "2026-05-13T07:17:20.437046Z",
+      "model": "qwen.qwen3.5-122b",
+      "outcome": "success",
+      "project_id": "PROJ-545-the-influence-of-visual-salience-on-atte",
+      "started_at": "2026-05-13T07:16:50.375394Z"
     }
   ],
   "schema_version": "2.0.0"

--- a/web/index.html
+++ b/web/index.html
@@ -75,6 +75,7 @@
       <button class="tab"        data-tab="designs"     role="tab"><i class="fa-regular fa-compass"></i> Research specs <span class="count" data-count="designs"></span></button>
       <button class="tab"        data-tab="backlog"     role="tab"><i class="fa-solid fa-diagram-project"></i> Backlog <span class="count" data-count="backlog"></span></button>
       <button class="tab"        data-tab="contributors"role="tab"><i class="fa-regular fa-user"></i> Contributors</button>
+      <button class="tab"        data-tab="activity"    role="tab"><i class="fa-regular fa-clock"></i> Activity</button>
       <button class="tab"        data-tab="about"       role="tab"><i class="fa-regular fa-circle-question"></i> About</button>
       <span class="tab-underline" id="underline"></span>
     </div>
@@ -190,14 +191,10 @@
         <p>Human and AI collaborators ranked by successful pipeline contributions across spec, plan, code, data, paper, and review work.</p>
       </div>
     </div>
-    <div class="bar">
-      <span class="label">Filter</span>
-      <button class="chip active" data-filter="all">All areas</button>
-      <button class="chip" data-filter="spec">Specs</button>
-      <button class="chip" data-filter="plan">Plans</button>
-      <button class="chip" data-filter="code">Code</button>
-      <button class="chip" data-filter="paper">Papers</button>
-      <button class="chip" data-filter="review">Reviews</button>
+    <div class="bar" id="contrib-filter-bar">
+      <span class="label">Filter by area</span>
+      <!-- chips rendered dynamically by app.js renderContributors() from the
+           areas actually present in payload.contributors[].areas -->
     </div>
 
     <div class="podium" id="podium"></div>
@@ -213,6 +210,26 @@
       <div class="tr head">
         <div>Rank</div><div>Contributor</div><div>Type</div><div>Contributions</div><div>Areas</div>
       </div>
+    </div>
+  </section>
+
+  <section class="panel" data-panel="activity">
+    <div class="panel-head">
+      <div>
+        <h2>Recent activity</h2>
+        <p>The most recent agent runs across every project. Pipeline ticks, reviews, paper submissions, and simulated-personality contributions land here as they happen.</p>
+      </div>
+    </div>
+    <div class="bar">
+      <span class="label">Filter</span>
+      <button class="chip active" data-activity-filter="all">All</button>
+      <button class="chip" data-activity-filter="personality">Personalities</button>
+      <button class="chip" data-activity-filter="pipeline">Pipeline</button>
+      <button class="chip" data-activity-filter="reviews">Reviews</button>
+      <input type="search" data-activity-search="" placeholder="Search by project, agent, persona…" />
+    </div>
+    <div class="activity-list" id="activity-list">
+      <!-- rows rendered by app.js renderActivity() -->
     </div>
   </section>
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -105,17 +105,50 @@
       + '</article>';
   }
 
+  // Per-lane search state (one term per `data-search` input). Empty = no
+  // filter. setupSearch() wires the inputs; matchesSearch() decides which
+  // projects survive the filter for a given lane.
+  const searchState = {};
+
+  function matchesSearch(item, term) {
+    if (!term) return true;
+    const needle = term.trim().toLowerCase();
+    if (!needle) return true;
+    // Searchable haystack: title + description + field + keywords + author
+    // names (so "kahneman" matches a paper authored by Daniel Kahneman, and
+    // "biology" matches every biology project). Built once per card per
+    // keystroke; the catalog is small (≤ ~600 projects) so this is fine.
+    const parts = [
+      item.title,
+      item.description,
+      item.field,
+      ...(item.keywords || []),
+      ...((item.authors || []).map(a => a.name)),
+      item.submitter,
+      item.id,
+    ];
+    const hay = parts.filter(Boolean).join("  ").toLowerCase();
+    return hay.includes(needle);
+  }
+
   function renderCards(kind) {
     const el = document.getElementById(kind + "-cards");
     if (!el) return;
-    const items = (buckets && buckets[kind]) || [];
+    const allItems = (buckets && buckets[kind]) || [];
+    const term = searchState[kind] || "";
+    const items = allItems.filter(it => matchesSearch(it, term));
     if (!items.length) {
       el.replaceChildren();
       const empty = document.createElement("div");
       empty.style.cssText = "grid-column: 1/-1; text-align:center; padding:40px; color:var(--muted);";
+      // Distinguish "empty lane" from "search has no matches" — the user
+      // wants to know which one to act on.
+      const msg = term
+        ? `No matches for &ldquo;${escapeHtml(term)}&rdquo;.`
+        : "No projects in this stage yet.";
       empty.insertAdjacentHTML("beforeend",
         '<i class="fa-regular fa-folder-open" style="font-size:32px; opacity:0.5"></i>' +
-        '<p style="margin-top:12px;">No projects in this stage yet.</p>');
+        '<p style="margin-top:12px;">' + msg + '</p>');
       el.appendChild(empty);
       return;
     }
@@ -155,8 +188,13 @@
   }
 
   function renderBacklogLane(rootEl, lane, stages) {
+    // The Backlog tab has a single search input (`data-search="backlog"`)
+    // that filters BOTH the research and the paper kanban columns. Apply
+    // the same `matchesSearch` predicate per project before rendering.
+    const term = searchState["backlog"] || "";
     const html = stages.map(stage => {
-      const items = lane[stage] || [];
+      const stageItems = lane[stage] || [];
+      const items = stageItems.filter(p => matchesSearch(p, term));
       const label = D.STAGE_LABELS[stage] || stage;
       const issues = items.map(p => {
         const desc = (p.description || "").slice(0, 140) + ((p.description || "").length > 140 ? "…" : "");
@@ -202,28 +240,86 @@
     return "fa-regular fa-circle-question";
   }
 
+  // Current contributor-area filter: "all" → show everyone; otherwise the
+  // exact area string (e.g. "biology", "computer science"). Cleared by
+  // clicking the "All areas" chip; toggled by clicking any other chip.
+  let contributorAreaFilter = "all";
+
   function renderContributors() {
     // The data is already sorted (real contributors by count desc, the single
     // "unattributed" bucket last); keep that order. Rank only real contributors.
-    const list = (payload.contributors || []).slice();
-    list.forEach((c, i) => c.rank = i + 1);
+    const everyone = (payload.contributors || []).slice();
+    everyone.forEach((c, i) => c.rank = i + 1);
+
+    // 1. Render the filter chips ONCE per renderContributors() call. The
+    //    chip set is derived from the actual `areas` strings present in
+    //    payload.contributors — so it's always in sync with the data and
+    //    new fields show up automatically without an HTML edit (matches
+    //    the personality-pool extensibility property).
+    const bar = document.getElementById("contrib-filter-bar");
+    if (bar) {
+      // Collect every area, ranked by how many contributors touch it.
+      const areaCounts = new Map();
+      for (const c of everyone) {
+        if (c.kind === "unattributed") continue;
+        for (const a of (c.areas || [])) {
+          areaCounts.set(a, (areaCounts.get(a) || 0) + 1);
+        }
+      }
+      const orderedAreas = [...areaCounts.entries()]
+        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+        .map(([a]) => a);
+      // Remove any pre-existing chip buttons (label survives) and rebuild.
+      [...bar.querySelectorAll(".chip")].forEach(n => n.remove());
+      const chipsHtml = ['<button class="chip' + (contributorAreaFilter === "all" ? " active" : "") + '" data-area-filter="all">All areas</button>']
+        .concat(orderedAreas.map(a =>
+          '<button class="chip' + (contributorAreaFilter === a ? " active" : "") +
+          '" data-area-filter="' + escapeHtml(a) + '">' + escapeHtml(a) + '</button>'
+        )).join("");
+      bar.insertAdjacentHTML("beforeend", chipsHtml);
+      // Re-bind handlers every time so the closure captures the freshest
+      // renderContributors. Idempotent because we replaced the chip nodes.
+      bar.querySelectorAll(".chip[data-area-filter]").forEach(chip => {
+        chip.addEventListener("click", () => {
+          contributorAreaFilter = chip.dataset.areaFilter;
+          renderContributors();
+        });
+      });
+    }
+
+    // 2. Apply the filter. "all" → everyone; otherwise keep only
+    //    contributors whose `areas` include the selected area. Unattributed
+    //    bucket is always kept (it's the catch-all at the bottom).
+    const matches = c => contributorAreaFilter === "all"
+      || c.kind === "unattributed"
+      || (c.areas || []).includes(contributorAreaFilter);
+    const list = everyone.filter(matches);
     const ranked = list.filter(c => c.kind !== "unattributed");
+
+    // 3. Re-rank within the filter so the podium reflects "top-3 in this
+    //    area" rather than "top-3 overall, possibly absent here". The
+    //    original rank (across all areas) is preserved in `c.rank` for
+    //    the table column so users can see absolute standing too.
+    ranked.forEach((c, i) => c.filteredRank = i + 1);
 
     const podium = document.getElementById("podium");
     podium.replaceChildren();
     if (!ranked.length) {
+      const msg = contributorAreaFilter === "all"
+        ? "No contributors yet."
+        : `No contributors in &ldquo;${escapeHtml(contributorAreaFilter)}&rdquo;.`;
       podium.insertAdjacentHTML("beforeend",
-        '<div style="grid-column: 1/-1; text-align:center; padding:40px; color:var(--muted);">No contributors yet.</div>');
+        '<div style="grid-column: 1/-1; text-align:center; padding:40px; color:var(--muted);">' + msg + '</div>');
     } else {
       const top3 = ranked.slice(0, 3);
       const podiumOrder = [top3[1], top3[0], top3[2]];
       const html = podiumOrder.map((c) => {
         if (!c) return "";
-        const isFirst = c.rank === 1;
+        const isFirst = c.filteredRank === 1;
         const initials = c.name.split(/[-.]/).map(s => s[0]).join("").slice(0, 2).toUpperCase();
         return ''
           + '<div class="pod ' + (isFirst ? "first" : "") + '">'
-          + '<div class="rank">' + c.rank + '</div>'
+          + '<div class="rank">' + c.filteredRank + '</div>'
           + '<div class="avatar">' + escapeHtml(initials || "?") + '</div>'
           + '<div class="name">' + escapeHtml(c.name) + '</div>'
           + '<div class="type">' + escapeHtml(kindLabel(c.kind)) + '</div>'
@@ -244,6 +340,196 @@
       + '<div class="areas">' + (c.areas || []).map(a => '<span>' + escapeHtml(a) + '</span>').join("") + '</div>'
       + '</div>').join("");
     table.insertAdjacentHTML("beforeend", rowsHtml);
+  }
+
+  // ── Activity tab — cross-project recent-run feed ─────────────────────
+  //
+  // Data: payload.recent_activity (emitted by web_data.py _recent_activity).
+  // Filter chips: "all" / "personality" / "pipeline" / "reviews".
+  //   - personality → agent_name == "personality"
+  //   - pipeline    → agent_name is one of the pipeline drivers
+  //                   (brainstorm, flesh_out, specifier, clarifier, planner,
+  //                   tasker, implementer, plus paper-stage equivalents)
+  //   - reviews     → agent_name starts with "research_reviewer" or
+  //                   "paper_reviewer"
+  //   - all         → no agent filter
+  // Plus a free-text search over project_id / agent / display_name.
+  let activityFilter = "all";
+  let activitySearch = "";
+
+  const _ACTIVITY_PIPELINE_AGENTS = new Set([
+    "brainstorm", "flesh_out", "research_question_validator", "idea_selector",
+    "project_initializer", "librarian", "specifier", "clarifier", "planner",
+    "tasker", "implementer", "advancement",
+    "paper_initializer", "paper_specifier", "paper_clarifier",
+    "paper_planner", "paper_tasker", "paper_implementer",
+    "latex_build", "latex_fix", "reference_validator",
+    "submission_intake", "status_reporter", "repository_hygiene",
+  ]);
+
+  function _activityCategory(entry) {
+    const a = entry.agent || "";
+    if (a === "personality") return "personality";
+    if (a.startsWith("research_reviewer") || a.startsWith("paper_reviewer")) return "reviews";
+    if (_ACTIVITY_PIPELINE_AGENTS.has(a)) return "pipeline";
+    return "other";
+  }
+
+  function _relTime(iso) {
+    if (!iso) return "—";
+    try {
+      const dt = new Date(iso);
+      const ms = Date.now() - dt.getTime();
+      const s = Math.round(ms / 1000);
+      if (s < 60) return s + "s ago";
+      const m = Math.round(s / 60);
+      if (m < 60) return m + "m ago";
+      const h = Math.round(m / 60);
+      if (h < 48) return h + "h ago";
+      const d = Math.round(h / 24);
+      return d + "d ago";
+    } catch (e) { return "—"; }
+  }
+
+  function _outcomeBadge(outcome) {
+    // success/committed → ok; abstained → muted; failures → bad.
+    const bad = ["rate_limited", "model_error", "malformed_response",
+                 "target_missing", "librarian_held", "timeout", "failure", "failed"];
+    let cls = "ok";
+    if (bad.includes(outcome)) cls = "bad";
+    if (outcome === "abstained") cls = "muted";
+    return '<span class="outcome ' + cls + '">' + escapeHtml(outcome || "—") + '</span>';
+  }
+
+  function renderActivity() {
+    const root = document.getElementById("activity-list");
+    if (!root) return;
+    let rows = (payload.recent_activity || []).slice();
+    if (activityFilter !== "all") {
+      rows = rows.filter(r => _activityCategory(r) === activityFilter);
+    }
+    if (activitySearch) {
+      const needle = activitySearch.toLowerCase();
+      rows = rows.filter(r => {
+        const hay = [r.project_id, r.agent, r.display_name, r.personality_slug,
+                     r.action, r.outcome, r.model].filter(Boolean).join(" ").toLowerCase();
+        return hay.includes(needle);
+      });
+    }
+    root.replaceChildren();
+    if (!rows.length) {
+      root.insertAdjacentHTML("beforeend",
+        '<div class="activity-empty">No activity matching the current filter.</div>');
+      return;
+    }
+    const html = rows.map(r => {
+      // Display the persona's "(simulated)" display_name when present,
+      // else the agent name — same FR-010 invariant the contributor list
+      // honors.
+      const who = r.display_name || r.agent || "—";
+      const actor = '<span class="actor">' + escapeHtml(who) + '</span>';
+      const project = r.project_id
+        ? '<span class="project" data-pid="' + escapeHtml(r.project_id) + '">'
+            + escapeHtml(r.project_id) + '</span>'
+        : '<span class="project muted">(no project)</span>';
+      const actionTag = r.action
+        ? '<span class="atag">' + escapeHtml(r.action) + '</span>'
+        : '';
+      const dur = r.duration_s
+        ? '<span class="dur">' + (r.duration_s).toFixed(1) + 's</span>'
+        : '';
+      return '<div class="activity-row" data-cat="' + _activityCategory(r) + '">'
+        + '<span class="when" title="' + escapeHtml(r.ended_at || r.started_at || "") + '">'
+        + escapeHtml(_relTime(r.ended_at || r.started_at)) + '</span>'
+        + actor + actionTag + project + _outcomeBadge(r.outcome) + dur
+        + '</div>';
+    }).join("");
+    root.insertAdjacentHTML("beforeend", html);
+    // Clicking a project pill opens that project's modal.
+    root.querySelectorAll(".project[data-pid]").forEach(el => {
+      el.addEventListener("click", () => {
+        const pid = el.dataset.pid;
+        const proj = (payload.projects || []).find(p => p.id === pid);
+        if (proj) Dialog.open(proj);
+      });
+    });
+  }
+
+  function setupActivity() {
+    // Filter chips
+    document.querySelectorAll("[data-activity-filter]").forEach(chip => {
+      chip.addEventListener("click", () => {
+        activityFilter = chip.dataset.activityFilter;
+        document.querySelectorAll("[data-activity-filter]").forEach(c =>
+          c.classList.toggle("active", c.dataset.activityFilter === activityFilter));
+        renderActivity();
+      });
+    });
+    // Search input
+    const searchInput = document.querySelector("[data-activity-search]");
+    if (searchInput) {
+      let timer = null;
+      searchInput.addEventListener("input", () => {
+        clearTimeout(timer);
+        timer = setTimeout(() => {
+          activitySearch = (searchInput.value || "").trim();
+          renderActivity();
+        }, 100);
+      });
+      searchInput.addEventListener("keydown", e => {
+        if (e.key === "Escape" && searchInput.value) {
+          searchInput.value = "";
+          activitySearch = "";
+          renderActivity();
+        }
+      });
+    }
+  }
+
+  function setupSearch() {
+    // Wire every `<input data-search="LANE">` in index.html to filter that
+    // lane's cards (or kanban columns for backlog) by the typed term.
+    // The `searchState` map and `matchesSearch` predicate above are the
+    // canonical filter — every render-lane call already honors them.
+    //
+    // Inputs (per index.html):
+    //   data-search="papers"     → renderCards("papers")
+    //   data-search="paper"      → renderCards("paper")
+    //   data-search="inProgress" → renderCards("inProgress")
+    //   data-search="backlog"    → renderBacklog()
+    //
+    // Debounce keystrokes lightly (100ms) so we don't re-render on every
+    // single character for users typing quickly. The render path is fast
+    // (≤ ~600 projects, plain DOM strings), but the debounce keeps the
+    // UI feeling smooth.
+    document.querySelectorAll("[data-search]").forEach(input => {
+      const lane = input.dataset.search;
+      if (!lane) return;
+      let timer = null;
+      input.addEventListener("input", () => {
+        clearTimeout(timer);
+        timer = setTimeout(() => {
+          searchState[lane] = input.value || "";
+          if (lane === "backlog") {
+            renderBacklog();
+          } else {
+            // The other four (papers / paper / inProgress / plans / designs)
+            // each have their own `<div id="${lane}-cards">` rendered by
+            // renderCards.
+            renderCards(lane);
+          }
+        }, 100);
+      });
+      // Esc clears the input + re-renders.
+      input.addEventListener("keydown", e => {
+        if (e.key === "Escape" && input.value) {
+          input.value = "";
+          searchState[lane] = "";
+          if (lane === "backlog") renderBacklog();
+          else renderCards(lane);
+        }
+      });
+    });
   }
 
   function setupTabs() {
@@ -664,8 +950,11 @@
     ["papers", "paper", "inProgress", "plans", "designs"].forEach(renderCards);
     renderBacklog();
     renderContributors();
+    renderActivity();
 
     setupTabs();
+    setupSearch();
+    setupActivity();
     setupModals();
     setupAboutModals();
 


### PR DESCRIPTION
## Summary

Fixes three user-reported issues with the llmXive website:

1. **Search broken** — search inputs in backlog/inProgress/papers/paper lanes were stubbed in HTML but had no event handlers. Wired them up with a `searchState` map, 100ms debounce, and Esc-to-clear. Filters case-insensitive across title/description/id/contributors.

2. **Contributors filter broken** — static chip bar (Specs/Plans/Code/Papers/Reviews) didn't match the actual data shape; `contributors[].areas` are research-field strings. Replaced with dynamically built area chips ranked by count, with re-ranking within filter.

3. **No way to inspect cron activity** — added an Activity tab. `web_data._recent_activity()` walks `state/run-log/<YYYY-MM>/*.jsonl` newest-first (limit 60), surfaces personality fields verbatim. Front-end renders rows with category filter chips (all/personality/pipeline/reviews), text search, project pill → artifact dialog, outcome badges, and relative timestamps.

## Tests

7 new `test_web_data_recent_activity` cases: empty, multi-project, multi-month, limit, personality fields, malformed-line tolerance, duration. 66/66 web_data + personality tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)