### PR TITLE
submission-intake: regenerate web data + drop skip-ci so new papers publish

### DIFF
--- a/.github/workflows/submission-intake.yml
+++ b/.github/workflows/submission-intake.yml
@@ -38,10 +38,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DARTMOUTH_CHAT_API_KEY: ${{ secrets.DARTMOUTH_CHAT_API_KEY }}
         run: python -m llmxive submissions process
+      - name: Regenerate web data
+        # Submission-intake creates new projects; the website's project lists
+        # are driven by web/data/projects.json. Without regenerating it,
+        # newly-created projects (e.g. papers filed by the HF daily-papers
+        # cron) won't appear in the paper-pipeline lane until the next
+        # full pipeline run. Other pipeline workflows already do this.
+        run: python -c "from llmxive.agents.status_reporter import regenerate_web_data; from pathlib import Path; regenerate_web_data(repo_root=Path('.'))"
       - name: Push file moves if any
+        # No [skip ci] — touching web/data/projects.json must trigger
+        # pages.yml so newly-filed papers actually appear on the site.
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
-          git diff --cached --quiet || git commit -m "submission-intake: process submissions [skip ci]"
+          git diff --cached --quiet || git commit -m "submission-intake: process submissions"
           git push || true


### PR DESCRIPTION
## Problem

When the hourly submission-intake cron created new paper-pipeline projects (e.g. from the HF daily-papers cron filing 5 issues at 23:59 UTC), the new projects were committed to `projects/` but **never appeared on the website**. We hit this immediately after the first HF cron run — PROJ-563 through PROJ-568 were created on disk but invisible at https://context-lab.com/llmXive/#paper until I manually regenerated and pushed.

## Root cause (two bugs, both in `.github/workflows/submission-intake.yml`)

1. The workflow never regenerated `web/data/projects.json`. Every **other** pipeline workflow (`pipeline-brainstorm`, `pipeline-flesh-out`, `pipeline-implement`, etc.) runs:

   ```
   python -c "from llmxive.agents.status_reporter import regenerate_web_data; from pathlib import Path; regenerate_web_data(repo_root=Path('.'))"
   ```

   …intake was the only one missing this step. So newly-created projects landed in `projects/` but the website's project-list payload stayed stale.

2. The commit used `[skip ci]` in its message, which would have blocked `pages.yml` from rebuilding even if `projects.json` had been touched.

## Fix

- Add the standard `regenerate_web_data` step after issue processing.
- Drop `[skip ci]` from the commit message so `pages.yml` fires on the resulting push (it's path-filtered to `web/**`, which now includes the regenerated JSON).

The path is now identical to pipeline-brainstorm / pipeline-flesh-out / etc. — same one-liner, same commit ergonomics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)