### PR TITLE
cron: remove [skip ci] + rebase-retry; cards: feature PDFs + personality comments

### DIFF
--- a/.github/workflows/paper-compile.yml
+++ b/.github/workflows/paper-compile.yml
@@ -80,13 +80,22 @@ jobs:
       - name: Regenerate web data (project list reflects new PDFs)
         run: python -c "from llmxive.agents.status_reporter import regenerate_web_data; from pathlib import Path; regenerate_web_data(repo_root=Path('.'))"
       - name: Commit + push
+        # Concurrent cron workflows commit to main while this is compiling
+        # (paper compile takes ~5min; other crons run every 30m–1h). A
+        # naive `git push` races and fails ~half the time. Pull --rebase
+        # before each push attempt; retry up to 5 times.
         run: |
+          set -e
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add 'projects/*/paper/pdf/*.pdf' web/data/projects.json 2>/dev/null || true
           if git diff --cached --quiet; then
-            echo "no changes"
-          else
-            git commit -m "paper-compile: produce/refresh paper PDFs"
-            git push
+            echo "no changes"; exit 0
           fi
+          git commit -m "paper-compile: produce/refresh paper PDFs"
+          for i in 1 2 3 4 5; do
+            git pull --rebase origin main && git push && exit 0 || true
+            echo "push attempt $i failed; retrying after backoff..."
+            sleep $((5 * i))
+          done
+          echo "push failed after 5 attempts" >&2; exit 1

--- a/.github/workflows/pipeline-brainstorm.yml
+++ b/.github/workflows/pipeline-brainstorm.yml
@@ -50,6 +50,15 @@ jobs:
           if git diff --cached --quiet; then
             echo "no changes"
           else
-            git commit -m "pipeline(brainstorm): hourly tick [skip ci]"
-            git push
+            git commit -m "pipeline(brainstorm): hourly tick"
+
+            for i in 1 2 3 4 5; do
+
+              git pull --rebase origin main && git push && break
+
+              echo "push attempt $i failed; retrying..." >&2
+
+              sleep $((5 * i))
+
+            done
           fi

--- a/.github/workflows/pipeline-flesh-out.yml
+++ b/.github/workflows/pipeline-flesh-out.yml
@@ -31,4 +31,18 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add state/ projects/ web/data/ || true
-          if git diff --cached --quiet; then echo "no changes"; else git commit -m "pipeline(flesh-out): 2h tick [skip ci]" && git push; fi
+          if git diff --cached --quiet; then echo "no changes"; else
+
+            git commit -m "pipeline(flesh-out): 2h tick"
+
+            for i in 1 2 3 4 5; do
+
+              git pull --rebase origin main && git push && break
+
+              echo "push attempt $i failed; retrying..." >&2
+
+              sleep $((5 * i))
+
+            done
+
+          fi

--- a/.github/workflows/pipeline-implement.yml
+++ b/.github/workflows/pipeline-implement.yml
@@ -31,4 +31,18 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add state/ projects/ web/data/ || true
-          if git diff --cached --quiet; then echo "no changes"; else git commit -m "pipeline(implement): 8h tick [skip ci]" && git push; fi
+          if git diff --cached --quiet; then echo "no changes"; else
+
+            git commit -m "pipeline(implement): 8h tick"
+
+            for i in 1 2 3 4 5; do
+
+              git pull --rebase origin main && git push && break
+
+              echo "push attempt $i failed; retrying..." >&2
+
+              sleep $((5 * i))
+
+            done
+
+          fi

--- a/.github/workflows/pipeline-paper-speckit.yml
+++ b/.github/workflows/pipeline-paper-speckit.yml
@@ -37,4 +37,18 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add state/ projects/ web/data/ || true
-          if git diff --cached --quiet; then echo "no changes"; else git commit -m "pipeline(paper-speckit): 4h tick [skip ci]" && git push; fi
+          if git diff --cached --quiet; then echo "no changes"; else
+
+            git commit -m "pipeline(paper-speckit): 4h tick"
+
+            for i in 1 2 3 4 5; do
+
+              git pull --rebase origin main && git push && break
+
+              echo "push attempt $i failed; retrying..." >&2
+
+              sleep $((5 * i))
+
+            done
+
+          fi

--- a/.github/workflows/pipeline-paper-write.yml
+++ b/.github/workflows/pipeline-paper-write.yml
@@ -33,4 +33,18 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add state/ projects/ web/data/ || true
-          if git diff --cached --quiet; then echo "no changes"; else git commit -m "pipeline(paper-write): 8h tick [skip ci]" && git push; fi
+          if git diff --cached --quiet; then echo "no changes"; else
+
+            git commit -m "pipeline(paper-write): 8h tick"
+
+            for i in 1 2 3 4 5; do
+
+              git pull --rebase origin main && git push && break
+
+              echo "push attempt $i failed; retrying..." >&2
+
+              sleep $((5 * i))
+
+            done
+
+          fi

--- a/.github/workflows/pipeline-personality.yml
+++ b/.github/workflows/pipeline-personality.yml
@@ -58,6 +58,15 @@ jobs:
           if git diff --cached --quiet; then
             echo "no changes"
           else
-            git commit -m "pipeline(personality): 30m tick [skip ci]"
-            git push
+            git commit -m "pipeline(personality): 30m tick"
+
+            for i in 1 2 3 4 5; do
+
+              git pull --rebase origin main && git push && break
+
+              echo "push attempt $i failed; retrying..." >&2
+
+              sleep $((5 * i))
+
+            done
           fi

--- a/.github/workflows/pipeline-research-speckit.yml
+++ b/.github/workflows/pipeline-research-speckit.yml
@@ -31,4 +31,18 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add state/ projects/ web/data/ || true
-          if git diff --cached --quiet; then echo "no changes"; else git commit -m "pipeline(speckit): 4h tick [skip ci]" && git push; fi
+          if git diff --cached --quiet; then echo "no changes"; else
+
+            git commit -m "pipeline(speckit): 4h tick"
+
+            for i in 1 2 3 4 5; do
+
+              git pull --rebase origin main && git push && break
+
+              echo "push attempt $i failed; retrying..." >&2
+
+              sleep $((5 * i))
+
+            done
+
+          fi

--- a/.github/workflows/pipeline-review.yml
+++ b/.github/workflows/pipeline-review.yml
@@ -33,4 +33,18 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add state/ projects/ web/data/ || true
-          if git diff --cached --quiet; then echo "no changes"; else git commit -m "pipeline(review): 16h tick [skip ci]" && git push; fi
+          if git diff --cached --quiet; then echo "no changes"; else
+
+            git commit -m "pipeline(review): 16h tick"
+
+            for i in 1 2 3 4 5; do
+
+              git pull --rebase origin main && git push && break
+
+              echo "push attempt $i failed; retrying..." >&2
+
+              sleep $((5 * i))
+
+            done
+
+          fi

--- a/.github/workflows/submission-intake.yml
+++ b/.github/workflows/submission-intake.yml
@@ -52,5 +52,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
-          git diff --cached --quiet || git commit -m "submission-intake: process submissions"
-          git push || true
+          if git diff --cached --quiet; then echo "no changes"; exit 0; fi
+          git commit -m "submission-intake: process submissions"
+          for i in 1 2 3 4 5; do
+            git pull --rebase origin main && git push && exit 0
+            echo "push attempt $i failed; retrying..." >&2
+            sleep $((5 * i))
+          done
+          exit 1

--- a/docs/css/site.css
+++ b/docs/css/site.css
@@ -1205,3 +1205,33 @@ a:hover { color: var(--accent-2); }
 [data-panel="activity"] .bar input[type="search"] {
   margin-left: auto; min-width: 220px;
 }
+
+/* Featured-artifact row inside cards — paper PDF + personality comment count.
+   Shown above .meta so the most-visible artifact (the PDF) is the natural
+   click target for a finished paper. Click bubbles to the card by default
+   (opens the dialog), but PDF/supplement links stop propagation so they
+   open the PDF directly in a new tab. */
+.card .featured {
+  display: flex; flex-wrap: wrap; gap: 8px;
+  margin: 12px 0 14px;
+}
+.card .feat-badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 10px; border-radius: 999px;
+  font-size: 12px; font-weight: 500;
+  background: var(--bg-2); color: var(--ink-2);
+  border: 1px solid var(--line);
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.card .feat-badge:hover {
+  background: var(--bg-3, var(--bg-2)); color: var(--ink);
+}
+.card .feat-badge.primary {
+  background: var(--accent, oklch(0.45 0.12 150));
+  color: white; border-color: transparent;
+}
+.card .feat-badge.primary:hover {
+  filter: brightness(1.08);
+}
+.card .feat-badge i { font-size: 11px; }

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -52,7 +52,30 @@
     return '<i class="fa-regular fa-circle-question" title="contributor not attributed"></i>';
   }
 
+  // Per-project recent-activity index: project_id → { comments_n, last_personality }.
+  // Built once on boot from payload.recent_activity so card render is O(1).
+  let activityByProject = null;
+  function _buildActivityByProject() {
+    if (activityByProject || !payload) return;
+    activityByProject = {};
+    for (const a of (payload.recent_activity || [])) {
+      const pid = a.project_id;
+      if (!pid) continue;
+      const e = activityByProject[pid] || { comments: 0, latest: null, simulators: [] };
+      // Personality "comment" entries are the ones the user wants surfaced.
+      if (a.action === "comment" && a.display_name) {
+        e.comments++;
+        if (!e.latest || (a.ended_at || "") > (e.latest.ended_at || "")) {
+          e.latest = a;
+        }
+        if (!e.simulators.includes(a.display_name)) e.simulators.push(a.display_name);
+      }
+      activityByProject[pid] = e;
+    }
+  }
+
   function cardHTML(item, kind) {
+    _buildActivityByProject();
     const kicker = ({
       papers:    "Published",
       paper:     "Paper pipeline",
@@ -92,11 +115,40 @@
             + kindIcon(kindOf(item.submitter))
             + ' ' + escapeHtml(item.submitter) + '</span></div>'
           : "");
+    // Featured-artifact strip: shows the paper PDF prominently when one
+    // exists, plus a personality-comment count badge. Both link into the
+    // artifact dialog when present so the click target is consistent.
+    const artifacts = item.artifact_links || {};
+    const pdfPath = artifacts.paper_pdf;
+    const supplementPath = artifacts.paper_supplement;
+    const activity = (activityByProject || {})[item.id];
+    const commentBadge = activity && activity.comments
+      ? '<span class="feat-badge" title="' + escapeHtml(activity.simulators.join(", ")) + '">'
+        + '<i class="fa-regular fa-comment"></i> ' + activity.comments
+        + ' personality ' + (activity.comments === 1 ? 'comment' : 'comments')
+        + '</span>'
+      : "";
+    const pdfBadge = pdfPath
+      ? '<a class="feat-badge primary" href="' + escapeHtml(pdfPath) + '" target="_blank" rel="noopener" '
+        + 'onclick="event.stopPropagation();">'
+        + '<i class="fa-regular fa-file-pdf"></i> PDF'
+        + '</a>'
+      : "";
+    const supplementBadge = supplementPath
+      ? '<a class="feat-badge" href="' + escapeHtml(supplementPath) + '" target="_blank" rel="noopener" '
+        + 'onclick="event.stopPropagation();">'
+        + '<i class="fa-regular fa-file-pdf"></i> supplement'
+        + '</a>'
+      : "";
+    const featuredRow = (pdfBadge || supplementBadge || commentBadge)
+      ? '<div class="featured">' + pdfBadge + supplementBadge + commentBadge + '</div>'
+      : "";
     return ''
       + '<article class="card" tabindex="0" data-pid="' + escapeHtml(item.id) + '">'
       + '<div class="kicker"><span class="dot"></span>' + kicker + '<span class="stage-pill ' + escapeHtml(stage) + '" style="margin-left:auto">' + escapeHtml(stageLabel) + '</span></div>'
       + '<h3>' + escapeHtml(item.title) + '</h3>'
       + '<p class="desc">' + escapeHtml(desc) + '</p>'
+      + featuredRow
       + '<div class="meta">'
       + '<div class="keys">' + keys + '</div>'
       + '<div class="right">' + points + '<span><i class="fa-regular fa-clock"></i> ' + escapeHtml(updated) + '</span></div>'

--- a/web/css/site.css
+++ b/web/css/site.css
@@ -1205,3 +1205,33 @@ a:hover { color: var(--accent-2); }
 [data-panel="activity"] .bar input[type="search"] {
   margin-left: auto; min-width: 220px;
 }
+
+/* Featured-artifact row inside cards — paper PDF + personality comment count.
+   Shown above .meta so the most-visible artifact (the PDF) is the natural
+   click target for a finished paper. Click bubbles to the card by default
+   (opens the dialog), but PDF/supplement links stop propagation so they
+   open the PDF directly in a new tab. */
+.card .featured {
+  display: flex; flex-wrap: wrap; gap: 8px;
+  margin: 12px 0 14px;
+}
+.card .feat-badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 10px; border-radius: 999px;
+  font-size: 12px; font-weight: 500;
+  background: var(--bg-2); color: var(--ink-2);
+  border: 1px solid var(--line);
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.card .feat-badge:hover {
+  background: var(--bg-3, var(--bg-2)); color: var(--ink);
+}
+.card .feat-badge.primary {
+  background: var(--accent, oklch(0.45 0.12 150));
+  color: white; border-color: transparent;
+}
+.card .feat-badge.primary:hover {
+  filter: brightness(1.08);
+}
+.card .feat-badge i { font-size: 11px; }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -52,7 +52,30 @@
     return '<i class="fa-regular fa-circle-question" title="contributor not attributed"></i>';
   }
 
+  // Per-project recent-activity index: project_id → { comments_n, last_personality }.
+  // Built once on boot from payload.recent_activity so card render is O(1).
+  let activityByProject = null;
+  function _buildActivityByProject() {
+    if (activityByProject || !payload) return;
+    activityByProject = {};
+    for (const a of (payload.recent_activity || [])) {
+      const pid = a.project_id;
+      if (!pid) continue;
+      const e = activityByProject[pid] || { comments: 0, latest: null, simulators: [] };
+      // Personality "comment" entries are the ones the user wants surfaced.
+      if (a.action === "comment" && a.display_name) {
+        e.comments++;
+        if (!e.latest || (a.ended_at || "") > (e.latest.ended_at || "")) {
+          e.latest = a;
+        }
+        if (!e.simulators.includes(a.display_name)) e.simulators.push(a.display_name);
+      }
+      activityByProject[pid] = e;
+    }
+  }
+
   function cardHTML(item, kind) {
+    _buildActivityByProject();
     const kicker = ({
       papers:    "Published",
       paper:     "Paper pipeline",
@@ -92,11 +115,40 @@
             + kindIcon(kindOf(item.submitter))
             + ' ' + escapeHtml(item.submitter) + '</span></div>'
           : "");
+    // Featured-artifact strip: shows the paper PDF prominently when one
+    // exists, plus a personality-comment count badge. Both link into the
+    // artifact dialog when present so the click target is consistent.
+    const artifacts = item.artifact_links || {};
+    const pdfPath = artifacts.paper_pdf;
+    const supplementPath = artifacts.paper_supplement;
+    const activity = (activityByProject || {})[item.id];
+    const commentBadge = activity && activity.comments
+      ? '<span class="feat-badge" title="' + escapeHtml(activity.simulators.join(", ")) + '">'
+        + '<i class="fa-regular fa-comment"></i> ' + activity.comments
+        + ' personality ' + (activity.comments === 1 ? 'comment' : 'comments')
+        + '</span>'
+      : "";
+    const pdfBadge = pdfPath
+      ? '<a class="feat-badge primary" href="' + escapeHtml(pdfPath) + '" target="_blank" rel="noopener" '
+        + 'onclick="event.stopPropagation();">'
+        + '<i class="fa-regular fa-file-pdf"></i> PDF'
+        + '</a>'
+      : "";
+    const supplementBadge = supplementPath
+      ? '<a class="feat-badge" href="' + escapeHtml(supplementPath) + '" target="_blank" rel="noopener" '
+        + 'onclick="event.stopPropagation();">'
+        + '<i class="fa-regular fa-file-pdf"></i> supplement'
+        + '</a>'
+      : "";
+    const featuredRow = (pdfBadge || supplementBadge || commentBadge)
+      ? '<div class="featured">' + pdfBadge + supplementBadge + commentBadge + '</div>'
+      : "";
     return ''
       + '<article class="card" tabindex="0" data-pid="' + escapeHtml(item.id) + '">'
       + '<div class="kicker"><span class="dot"></span>' + kicker + '<span class="stage-pill ' + escapeHtml(stage) + '" style="margin-left:auto">' + escapeHtml(stageLabel) + '</span></div>'
       + '<h3>' + escapeHtml(item.title) + '</h3>'
       + '<p class="desc">' + escapeHtml(desc) + '</p>'
+      + featuredRow
       + '<div class="meta">'
       + '<div class="keys">' + keys + '</div>'
       + '<div class="right">' + points + '<span><i class="fa-regular fa-clock"></i> ' + escapeHtml(updated) + '</span></div>'


### PR DESCRIPTION
## Problem 1: 7+ hour stale website

Every cron pipeline workflow committed with `[skip ci]`, which blocks `pages.yml` (path-filtered to `web/**`) from firing. So even when cron jobs touched `web/data/projects.json` on main, `docs/` (GitHub Pages source) never resynced. Live site showed 1 personality from 9 hours ago instead of all 8 that ran overnight.

**Fix**: removed `[skip ci]` from all 8 pipeline workflows (brainstorm, flesh-out, implement, paper-speckit, paper-write, personality, research-speckit, review). They're cron-only (no `on: push`), so removing the marker doesn't cascade — only `pages.yml` picks up the change and the site auto-refreshes within ~1 min of every tick.

## Problem 2: Paper Compile failed every run from push race

Paper Compile takes ~5 min; other crons run every 30 min-1 h and commit during that window. Naive `git push` fails when remote moved. Last 2 paper-compile runs (10:16, 11:15) both failed on push rejection.

**Fix**: rebase + retry loop in EVERY workflow that pushes (paper-compile, all 8 pipelines, submission-intake). Up to 5 attempts with linear backoff.

```
for i in 1 2 3 4 5; do
  git pull --rebase origin main && git push && break
  echo "push attempt $i failed; retrying..." >&2
  sleep $((5 * i))
done
```

## Problem 3: Cards didn't surface featured artifacts

- **Paper PDFs were buried** — only accessible via the artifact dialog. Added a primary green "PDF" badge in each card's new `.featured` row that opens the PDF directly in a new tab (with `event.stopPropagation` so it doesn't accidentally open the dialog).
- **Personality comments were invisible** — Activity tab listed them but project cards gave no hint per-project. Added a comment-count badge per card built from `payload.recent_activity` (filtered to `action=comment` + `display_name` set). Hovering the badge shows the simulated personality names.
- Built `activityByProject` index once on boot so card render stays O(1).

## Verification

- Manually triggered `pages.yml` after the fix → live site at https://context-lab.com/llmXive now shows all 8 personalities in the Activity tab.
- 80/80 existing unit tests still pass.
- Will keep monitoring `Paper Compile` runs after this lands — the rebase-retry loop should fix the race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)