### PR TITLE
fix(crons): add 'actions: write' so Trigger Pages deploy step works

### DIFF
--- a/.github/workflows/paper-compile.yml
+++ b/.github/workflows/paper-compile.yml
@@ -38,6 +38,7 @@ on:
         default: "20"
 
 permissions:
+  actions: write             # workflow_dispatch to pages.yml
   contents: write
 
 concurrency:

--- a/.github/workflows/pipeline-brainstorm.yml
+++ b/.github/workflows/pipeline-brainstorm.yml
@@ -4,6 +4,7 @@ on:
     - cron: '0 * * * *'   # every hour
   workflow_dispatch:
 permissions:
+  actions: write             # workflow_dispatch to pages.yml
   contents: write
   issues: write
 concurrency:

--- a/.github/workflows/pipeline-flesh-out.yml
+++ b/.github/workflows/pipeline-flesh-out.yml
@@ -4,6 +4,7 @@ on:
     - cron: '15 */2 * * *'   # every 2 hours, offset 15min
   workflow_dispatch:
 permissions:
+  actions: write             # workflow_dispatch to pages.yml
   contents: write
   issues: write
 concurrency:

--- a/.github/workflows/pipeline-implement.yml
+++ b/.github/workflows/pipeline-implement.yml
@@ -4,6 +4,7 @@ on:
     - cron: '45 */8 * * *'   # every 8 hours
   workflow_dispatch:
 permissions:
+  actions: write             # workflow_dispatch to pages.yml
   contents: write
   issues: write
 concurrency:

--- a/.github/workflows/pipeline-paper-speckit.yml
+++ b/.github/workflows/pipeline-paper-speckit.yml
@@ -4,6 +4,7 @@ on:
     - cron: '20 */4 * * *'   # every 4 hours, offset 20min
   workflow_dispatch:
 permissions:
+  actions: write             # workflow_dispatch to pages.yml
   contents: write
   issues: write
 concurrency:

--- a/.github/workflows/pipeline-paper-write.yml
+++ b/.github/workflows/pipeline-paper-write.yml
@@ -4,6 +4,7 @@ on:
     - cron: '50 */8 * * *'   # every 8 hours
   workflow_dispatch:
 permissions:
+  actions: write             # workflow_dispatch to pages.yml
   contents: write
   issues: write
 concurrency:

--- a/.github/workflows/pipeline-personality.yml
+++ b/.github/workflows/pipeline-personality.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write             # workflow_dispatch to pages.yml
   contents: write
   issues: write
 

--- a/.github/workflows/pipeline-research-speckit.yml
+++ b/.github/workflows/pipeline-research-speckit.yml
@@ -4,6 +4,7 @@ on:
     - cron: '30 */4 * * *'   # every 4 hours, offset 30min
   workflow_dispatch:
 permissions:
+  actions: write             # workflow_dispatch to pages.yml
   contents: write
   issues: write
 concurrency:

--- a/.github/workflows/pipeline-review.yml
+++ b/.github/workflows/pipeline-review.yml
@@ -4,6 +4,7 @@ on:
     - cron: '0 */16 * * *'   # every 16 hours
   workflow_dispatch:
 permissions:
+  actions: write             # workflow_dispatch to pages.yml
   contents: write
   issues: write
 concurrency:

--- a/.github/workflows/submission-intake.yml
+++ b/.github/workflows/submission-intake.yml
@@ -14,6 +14,7 @@ on:
   workflow_dispatch: {}       # for the one-time manual exercise + ad-hoc runs
 
 permissions:
+  actions: write             # workflow_dispatch to pages.yml
   contents: write             # commit staged-PDF moves / inbox cleanup
   issues: write               # comment on + close human-submission issues
 


### PR DESCRIPTION
## Root cause

Personality cron run 25922639648 (2026-05-15T14:17Z) failed at the new `Trigger Pages deploy` step (introduced in PR #149) with:

```
could not create workflow dispatch event:
HTTP 403: Resource not accessible by integration
```

`GITHUB_TOKEN` needs the `actions: write` scope to dispatch another workflow via `gh workflow run pages.yml`. None of the 10 cron workflows declared it (they only had `contents: write` + `issues: write`), so every dispatch attempt 403'd — the commit step succeeded but Pages was never re-deployed.

## Fix

Added `actions: write` to the permissions block of all 10 crons:
- `pipeline-{personality,brainstorm,flesh-out,implement,paper-speckit,paper-write,research-speckit,review}.yml`
- `submission-intake.yml`, `paper-compile.yml`

YAML re-validated.

## Verification path

Once merged, the next personality cron tick (every 30 min) will:
1. Generate a contribution → commit → push.
2. `Trigger Pages deploy` will now have permission to dispatch.
3. `pages.yml` will sync `web/ → docs/` and the new contribution will appear on the live site.

This is the missing piece from PR #149; the dispatch step itself was correct but lacked the permission to fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)