### PR TITLE
fix(authors): skip github-actions[bot]; filter junk; prefer metadata.json

### DIFF
--- a/projects/PROJ-566-mint-managed-infrastructure-for-training/paper/metadata.json
+++ b/projects/PROJ-566-mint-managed-infrastructure-for-training/paper/metadata.json
@@ -4,7 +4,6 @@
   "title": "MinT: Managed Infrastructure for Training and Serving Millions of LLMs",
   "authors": [
     "Mind Lab",
-    ":",
     "Song Cao",
     "Vic Cao",
     "Andrew Chen",

--- a/projects/PROJ-578-mint-managed-infrastructure-for-training/paper/metadata.json
+++ b/projects/PROJ-578-mint-managed-infrastructure-for-training/paper/metadata.json
@@ -4,7 +4,6 @@
   "title": "MinT: Managed Infrastructure for Training and Serving Millions of LLMs",
   "authors": [
     "Mind Lab",
-    ":",
     "Song Cao",
     "Vic Cao",
     "Andrew Chen",

--- a/projects/PROJ-583-mint-managed-infrastructure-for-training/paper/metadata.json
+++ b/projects/PROJ-583-mint-managed-infrastructure-for-training/paper/metadata.json
@@ -4,7 +4,6 @@
   "title": "MinT: Managed Infrastructure for Training and Serving Millions of LLMs",
   "authors": [
     "Mind Lab",
-    ":",
     "Song Cao",
     "Vic Cao",
     "Andrew Chen",

--- a/src/llmxive/web_data.py
+++ b/src/llmxive/web_data.py
@@ -869,8 +869,15 @@ def _project_authors(repo: Path, project_id: str) -> list[dict[str, str]]:
     pdir = _project_dir(repo, project_id)
 
     # 1. Idea submitter
+    #    Skip bot submitters (github-actions[bot] etc.) — the user's rule:
+    #    bots that act on behalf of the platform never count as authors. The
+    #    paper's actual authors come from `paper_authors:` (block 1b below).
     submitter = _project_submitter(repo, project_id)
-    if submitter and not submitter.startswith(("system:", "legacy:", "agent:")):
+    if (
+        submitter
+        and not submitter.startswith(("system:", "legacy:", "agent:"))
+        and not _is_bot_submitter(submitter)
+    ):
         kind = "llm" if (
             "/" in submitter
             or any(p in submitter.lower() for p in ("qwen", "gemma", "claude", "tinyllama", "gpt", "mistral", "llama"))
@@ -880,9 +887,21 @@ def _project_authors(repo: Path, project_id: str) -> list[dict[str, str]]:
 
     # 1b. Paper authors (parsed from the paper itself by `submission_intake`)
     #     — the user's rule: credit on a submitted paper goes to its *authors*,
-    #     separately from whoever submitted it. The `paper_authors:` list lives
-    #     in the idea front-matter and gets surfaced here as kind="human"
-    #     contributors with a `paper_author` role.
+    #     separately from whoever submitted it. We prefer
+    #     `paper/metadata.json::authors` (the canonical arXiv-parsed list) and
+    #     fall back to the idea front-matter `paper_authors:` for projects whose
+    #     intake predates the metadata.json shape.
+    paper_meta = pdir / "paper" / "metadata.json"
+    metadata_authors: list[str] = []
+    if paper_meta.is_file():
+        try:
+            meta = json.loads(paper_meta.read_text(encoding="utf-8", errors="replace"))
+            if isinstance(meta, dict) and isinstance(meta.get("authors"), list):
+                metadata_authors = [str(a).strip() for a in meta["authors"]]
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    frontmatter_authors: list[str] = []
     idea = next(iter(pdir.glob("idea/*.md")), None) if pdir.exists() else None
     if idea is not None and idea.exists():
         text = idea.read_text(encoding="utf-8", errors="replace")
@@ -891,10 +910,25 @@ def _project_authors(repo: Path, project_id: str) -> list[dict[str, str]]:
                 fm = yaml.safe_load(text[3:text.index("---", 3)]) or {}
             except (ValueError, yaml.YAMLError):
                 fm = {}
-            for author in (fm.get("paper_authors") or []):
-                name = str(author).strip()
-                if name:
-                    add(name, "human", "paper_author")
+            frontmatter_authors = [str(a).strip() for a in (fm.get("paper_authors") or [])]
+
+    # Filter junk entries — colons, commas, periods, semicolons sometimes leak
+    # from arXiv parses where a label like "Mind Lab :" gets split into "Mind
+    # Lab" + ":". Also skip bots and empty strings.
+    _JUNK_AUTHORS = {":", ",", ".", ";", "-", "—", "–"}
+    raw_authors = metadata_authors or frontmatter_authors
+    seen_norm: set[str] = set()
+    for author in raw_authors:
+        name = (author or "").strip().strip(":,.;-—–").strip()
+        if not name or name in _JUNK_AUTHORS:
+            continue
+        if _is_bot_submitter(name):
+            continue
+        norm = name.lower()
+        if norm in seen_norm:
+            continue
+        seen_norm.add(norm)
+        add(name, "human", "paper_author")
 
     # 2. Run-log: every successful agent invocation contributes its model
     runlog_root = repo / "state" / "run-log"
@@ -1243,33 +1277,57 @@ def _paper_author_contributors(repo: Path, projects: list) -> list[dict[str, Any
     the paper's authors not just the submitter" rule). Surfaced in the
     top-level contributors list as kind="human".
     """
+    # Junk-author filter (arXiv label-parse glitches sometimes emit `:`,
+    # `,`, or other lone punctuation as an "author"). Applied per-entry.
+    _JUNK_AUTHORS = {":", ",", ".", ";", "-", "—", "–"}
+
     rows: dict[tuple[str, str], dict[str, Any]] = {}
     for p in projects:
-        idea_dir = repo / "projects" / p.id / "idea"
-        if not idea_dir.is_dir():
-            continue
-        for md in idea_dir.glob("*.md"):
-            text = md.read_text(encoding="utf-8", errors="replace")
-            if not text.startswith("---"):
-                continue
+        proj_dir = repo / "projects" / p.id
+        # Prefer paper/metadata.json (canonical arXiv-parsed list) when present;
+        # fall back to idea/*.md frontmatter for legacy intakes.
+        raw_authors: list[str] = []
+        meta_path = proj_dir / "paper" / "metadata.json"
+        if meta_path.is_file():
             try:
-                fm = yaml.safe_load(text[3:text.index("---", 3)]) or {}
-            except (ValueError, yaml.YAMLError):
+                meta = json.loads(meta_path.read_text(encoding="utf-8", errors="replace"))
+                if isinstance(meta, dict) and isinstance(meta.get("authors"), list):
+                    raw_authors = [str(a) for a in meta["authors"]]
+            except (json.JSONDecodeError, OSError):
+                pass
+        if not raw_authors:
+            idea_dir = proj_dir / "idea"
+            if not idea_dir.is_dir():
                 continue
-            for author in (fm.get("paper_authors") or []):
-                name = str(author).strip()
-                if not name:
+            for md in idea_dir.glob("*.md"):
+                text = md.read_text(encoding="utf-8", errors="replace")
+                if not text.startswith("---"):
                     continue
-                # Merge GH-username submitter ↔ paper-author display name.
-                canon, kind = _resolve_alias(name, "human", repo)
-                key = (canon, kind)
-                row = rows.setdefault(
-                    key, {"name": canon, "kind": kind, "contribution_count": 0, "areas": set()}
-                )
-                row["contribution_count"] += 1
-                field = (p.field or "").strip().lower()
-                if field and field != "general":
-                    row["areas"].add(field)
+                try:
+                    fm = yaml.safe_load(text[3:text.index("---", 3)]) or {}
+                except (ValueError, yaml.YAMLError):
+                    continue
+                raw_authors.extend(str(a) for a in (fm.get("paper_authors") or []))
+        seen_for_project: set[str] = set()
+        for author in raw_authors:
+            name = (author or "").strip().strip(":,.;-—–").strip()
+            if not name or name in _JUNK_AUTHORS:
+                continue
+            if _is_bot_submitter(name):
+                continue
+            if name.lower() in seen_for_project:
+                continue
+            seen_for_project.add(name.lower())
+            # Merge GH-username submitter ↔ paper-author display name.
+            canon, kind = _resolve_alias(name, "human", repo)
+            key = (canon, kind)
+            row = rows.setdefault(
+                key, {"name": canon, "kind": kind, "contribution_count": 0, "areas": set()}
+            )
+            row["contribution_count"] += 1
+            field = (p.field or "").strip().lower()
+            if field and field != "general":
+                row["areas"].add(field)
     return [
         {"name": r["name"], "kind": r["kind"],
          "contribution_count": r["contribution_count"], "areas": sorted(r["areas"])}

--- a/web/data/projects.json
+++ b/web/data/projects.json
@@ -901,11 +901,11 @@
   "aggregates": {
     "active_projects": 591,
     "ai_contributors": 7,
-    "human_contributors": 125,
+    "human_contributors": 187,
     "papers_posted": 0,
     "total_collaborations": 0,
-    "total_contributions": 1490,
-    "total_contributors": 132
+    "total_contributions": 1676,
+    "total_contributors": 194
   },
   "contributors": [
     {
@@ -1004,7 +1004,135 @@
       ],
       "contribution_count": 3,
       "kind": "human",
+      "name": "Aaron Guan"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Ada Zhou"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Alexy Li"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Andrew Chen"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Andrew Lei"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Anson Qiu"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Anya Zhang"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Arthur Fu"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Carrie Ye"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Changhai Zhou"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Charles Huang"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Cleon Cheng"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Danney Zeng"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Di Zhang"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Fancy Kong"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
       "name": "Guian Fang"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Hailee Hou"
     },
     {
       "areas": [
@@ -1020,7 +1148,207 @@
       ],
       "contribution_count": 3,
       "kind": "human",
+      "name": "Hera Feng"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Hongquan Gu"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Huan Feng"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Irvine Lu"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Jiayi Lin"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Josh Ying"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Jun Gao"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Kaijie Chen"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Kairus Liu"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Kaixuan Fan"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Kieran Liu"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Kyrie Lei"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Logan Liu"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Lucian Li"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Maeve Luo"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Maxwell Yao"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
       "name": "Mike Zheng Shou"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Miles Jiang"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Mind Lab"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Murphy Zhuang"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Mutian Hong"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Nolan Ho"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Nora Jiang"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Peixuan Hua"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Pony Ma"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Qiuyu Jin"
     },
     {
       "areas": [
@@ -1038,7 +1366,111 @@
       ],
       "contribution_count": 3,
       "kind": "human",
+      "name": "Ray Li"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Regis Ye"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Rio Yang"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Ruijia Zhang"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Runze Lv"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Song Cao"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
       "name": "Song Han"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Steven Chiang"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Sueky Zhang"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Theo Li"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Verity Niu"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Vic Cao"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Vincent Wang"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Wei Zhao"
     },
     {
       "areas": [
@@ -1054,6 +1486,38 @@
       ],
       "contribution_count": 3,
       "kind": "human",
+      "name": "Wenlin Ye"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Xiang Liu"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Xinyue Zhu"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Ya Zhang"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
       "name": "Yuchao Gu"
     },
     {
@@ -1062,7 +1526,39 @@
       ],
       "contribution_count": 3,
       "kind": "human",
+      "name": "Yuhan Zhan"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Yuhua Zhou"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
       "name": "Yuxin Jiang"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Yuyi Jiang"
+    },
+    {
+      "areas": [
+        "computer science"
+      ],
+      "contribution_count": 3,
+      "kind": "human",
+      "name": "Zhihui Li"
     },
     {
       "areas": [
@@ -2009,7 +2505,7 @@
       "name": "Zilyu Ye"
     }
   ],
-  "generated_at": "2026-05-15T15:35:30.045222+00:00",
+  "generated_at": "2026-05-15T15:48:37.582627+00:00",
   "personalities": [
     {
       "display_name": "Ada Lovelace",
@@ -46834,14 +47330,6 @@
         {
           "contributions": 1,
           "kind": "human",
-          "name": "github-actions[bot]",
-          "roles": [
-            "brainstorm_submitter"
-          ]
-        },
-        {
-          "contributions": 1,
-          "kind": "human",
           "name": "Tsz Ting Chung",
           "roles": [
             "paper_author"
@@ -46921,14 +47409,6 @@
         "tasks": null
       },
       "authors": [
-        {
-          "contributions": 1,
-          "kind": "human",
-          "name": "github-actions[bot]",
-          "roles": [
-            "brainstorm_submitter"
-          ]
-        },
         {
           "contributions": 1,
           "kind": "human",
@@ -47222,14 +47702,6 @@
         {
           "contributions": 1,
           "kind": "human",
-          "name": "github-actions[bot]",
-          "roles": [
-            "brainstorm_submitter"
-          ]
-        },
-        {
-          "contributions": 1,
-          "kind": "human",
           "name": "Xuehai Bai",
           "roles": [
             "paper_author"
@@ -47356,7 +47828,504 @@
         "spec": null,
         "tasks": null
       },
-      "authors": [],
+      "authors": [
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Mind Lab",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Song Cao",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Vic Cao",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Andrew Chen",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Kaijie Chen",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Cleon Cheng",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Steven Chiang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Kaixuan Fan",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Hera Feng",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Huan Feng",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Arthur Fu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Jun Gao",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Hongquan Gu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Aaron Guan",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Nolan Ho",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Mutian Hong",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Hailee Hou",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Peixuan Hua",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Charles Huang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Miles Jiang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Nora Jiang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Yuyi Jiang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Qiuyu Jin",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Fancy Kong",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Andrew Lei",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Kyrie Lei",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Alexy Li",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Lucian Li",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Ray Li",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Theo Li",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Zhihui Li",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Jiayi Lin",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Kairus Liu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Kieran Liu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Logan Liu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Xiang Liu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Irvine Lu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Maeve Luo",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Runze Lv",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Pony Ma",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Verity Niu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Anson Qiu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Vincent Wang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Rio Yang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Maxwell Yao",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Carrie Ye",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Regis Ye",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Wenlin Ye",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Josh Ying",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Danney Zeng",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Yuhan Zhan",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Anya Zhang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Di Zhang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Ruijia Zhang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Sueky Zhang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Ya Zhang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Wei Zhao",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Ada Zhou",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Changhai Zhou",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Yuhua Zhou",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Xinyue Zhu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Murphy Zhuang",
+          "roles": [
+            "paper_author"
+          ]
+        }
+      ],
       "citation_summary": {
         "mismatch": 0,
         "pending": 0,
@@ -47406,14 +48375,6 @@
         "tasks": null
       },
       "authors": [
-        {
-          "contributions": 1,
-          "kind": "human",
-          "name": "github-actions[bot]",
-          "roles": [
-            "brainstorm_submitter"
-          ]
-        },
         {
           "contributions": 1,
           "kind": "human",
@@ -47599,14 +48560,6 @@
         {
           "contributions": 1,
           "kind": "human",
-          "name": "github-actions[bot]",
-          "roles": [
-            "brainstorm_submitter"
-          ]
-        },
-        {
-          "contributions": 1,
-          "kind": "human",
           "name": "Yujun Wu",
           "roles": [
             "paper_author"
@@ -47769,14 +48722,6 @@
         {
           "contributions": 1,
           "kind": "human",
-          "name": "github-actions[bot]",
-          "roles": [
-            "brainstorm_submitter"
-          ]
-        },
-        {
-          "contributions": 1,
-          "kind": "human",
           "name": "Hanzhong Guo",
           "roles": [
             "paper_author"
@@ -47896,14 +48841,6 @@
         "tasks": null
       },
       "authors": [
-        {
-          "contributions": 1,
-          "kind": "human",
-          "name": "github-actions[bot]",
-          "roles": [
-            "brainstorm_submitter"
-          ]
-        },
         {
           "contributions": 1,
           "kind": "human",
@@ -48033,16 +48970,7 @@
         "spec": null,
         "tasks": null
       },
-      "authors": [
-        {
-          "contributions": 1,
-          "kind": "human",
-          "name": "github-actions[bot]",
-          "roles": [
-            "brainstorm_submitter"
-          ]
-        }
-      ],
+      "authors": [],
       "citation_summary": {
         "mismatch": 0,
         "pending": 0,
@@ -48091,16 +49019,7 @@
         "spec": null,
         "tasks": null
       },
-      "authors": [
-        {
-          "contributions": 1,
-          "kind": "human",
-          "name": "github-actions[bot]",
-          "roles": [
-            "brainstorm_submitter"
-          ]
-        }
-      ],
+      "authors": [],
       "citation_summary": {
         "mismatch": 0,
         "pending": 0,
@@ -48150,14 +49069,6 @@
         "tasks": null
       },
       "authors": [
-        {
-          "contributions": 1,
-          "kind": "human",
-          "name": "github-actions[bot]",
-          "roles": [
-            "brainstorm_submitter"
-          ]
-        },
         {
           "contributions": 1,
           "kind": "human",
@@ -48315,14 +49226,6 @@
         {
           "contributions": 1,
           "kind": "human",
-          "name": "github-actions[bot]",
-          "roles": [
-            "brainstorm_submitter"
-          ]
-        },
-        {
-          "contributions": 1,
-          "kind": "human",
           "name": "Zhaowei Wang",
           "roles": [
             "paper_author"
@@ -48469,14 +49372,6 @@
         {
           "contributions": 1,
           "kind": "human",
-          "name": "github-actions[bot]",
-          "roles": [
-            "brainstorm_submitter"
-          ]
-        },
-        {
-          "contributions": 1,
-          "kind": "human",
           "name": "Yuchao Gu",
           "roles": [
             "paper_author"
@@ -48580,14 +49475,6 @@
         "tasks": null
       },
       "authors": [
-        {
-          "contributions": 1,
-          "kind": "human",
-          "name": "github-actions[bot]",
-          "roles": [
-            "brainstorm_submitter"
-          ]
-        },
         {
           "contributions": 1,
           "kind": "human",
@@ -48725,7 +49612,504 @@
         "spec": null,
         "tasks": null
       },
-      "authors": [],
+      "authors": [
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Mind Lab",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Song Cao",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Vic Cao",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Andrew Chen",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Kaijie Chen",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Cleon Cheng",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Steven Chiang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Kaixuan Fan",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Hera Feng",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Huan Feng",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Arthur Fu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Jun Gao",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Hongquan Gu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Aaron Guan",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Nolan Ho",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Mutian Hong",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Hailee Hou",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Peixuan Hua",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Charles Huang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Miles Jiang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Nora Jiang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Yuyi Jiang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Qiuyu Jin",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Fancy Kong",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Andrew Lei",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Kyrie Lei",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Alexy Li",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Lucian Li",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Ray Li",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Theo Li",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Zhihui Li",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Jiayi Lin",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Kairus Liu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Kieran Liu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Logan Liu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Xiang Liu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Irvine Lu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Maeve Luo",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Runze Lv",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Pony Ma",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Verity Niu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Anson Qiu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Vincent Wang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Rio Yang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Maxwell Yao",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Carrie Ye",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Regis Ye",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Wenlin Ye",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Josh Ying",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Danney Zeng",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Yuhan Zhan",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Anya Zhang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Di Zhang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Ruijia Zhang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Sueky Zhang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Ya Zhang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Wei Zhao",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Ada Zhou",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Changhai Zhou",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Yuhua Zhou",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Xinyue Zhu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Murphy Zhuang",
+          "roles": [
+            "paper_author"
+          ]
+        }
+      ],
       "citation_summary": {
         "mismatch": 0,
         "pending": 0,
@@ -48775,14 +50159,6 @@
         "tasks": null
       },
       "authors": [
-        {
-          "contributions": 1,
-          "kind": "human",
-          "name": "github-actions[bot]",
-          "roles": [
-            "brainstorm_submitter"
-          ]
-        },
         {
           "contributions": 1,
           "kind": "human",
@@ -48940,14 +50316,6 @@
         {
           "contributions": 1,
           "kind": "human",
-          "name": "github-actions[bot]",
-          "roles": [
-            "brainstorm_submitter"
-          ]
-        },
-        {
-          "contributions": 1,
-          "kind": "human",
           "name": "Zhaowei Wang",
           "roles": [
             "paper_author"
@@ -49094,14 +50462,6 @@
         {
           "contributions": 1,
           "kind": "human",
-          "name": "github-actions[bot]",
-          "roles": [
-            "brainstorm_submitter"
-          ]
-        },
-        {
-          "contributions": 1,
-          "kind": "human",
           "name": "Yuchao Gu",
           "roles": [
             "paper_author"
@@ -49205,14 +50565,6 @@
         "tasks": null
       },
       "authors": [
-        {
-          "contributions": 1,
-          "kind": "human",
-          "name": "github-actions[bot]",
-          "roles": [
-            "brainstorm_submitter"
-          ]
-        },
         {
           "contributions": 1,
           "kind": "human",
@@ -49350,7 +50702,504 @@
         "spec": null,
         "tasks": null
       },
-      "authors": [],
+      "authors": [
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Mind Lab",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Song Cao",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Vic Cao",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Andrew Chen",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Kaijie Chen",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Cleon Cheng",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Steven Chiang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Kaixuan Fan",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Hera Feng",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Huan Feng",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Arthur Fu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Jun Gao",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Hongquan Gu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Aaron Guan",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Nolan Ho",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Mutian Hong",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Hailee Hou",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Peixuan Hua",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Charles Huang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Miles Jiang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Nora Jiang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Yuyi Jiang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Qiuyu Jin",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Fancy Kong",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Andrew Lei",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Kyrie Lei",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Alexy Li",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Lucian Li",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Ray Li",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Theo Li",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Zhihui Li",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Jiayi Lin",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Kairus Liu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Kieran Liu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Logan Liu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Xiang Liu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Irvine Lu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Maeve Luo",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Runze Lv",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Pony Ma",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Verity Niu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Anson Qiu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Vincent Wang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Rio Yang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Maxwell Yao",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Carrie Ye",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Regis Ye",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Wenlin Ye",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Josh Ying",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Danney Zeng",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Yuhan Zhan",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Anya Zhang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Di Zhang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Ruijia Zhang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Sueky Zhang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Ya Zhang",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Wei Zhao",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Ada Zhou",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Changhai Zhou",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Yuhua Zhou",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Xinyue Zhu",
+          "roles": [
+            "paper_author"
+          ]
+        },
+        {
+          "contributions": 1,
+          "kind": "human",
+          "name": "Murphy Zhuang",
+          "roles": [
+            "paper_author"
+          ]
+        }
+      ],
       "citation_summary": {
         "mismatch": 0,
         "pending": 0,


### PR DESCRIPTION
## Issues

1. **PROJ-583 (MinT) shows "no detected authors"** — the paper has 62+ real authors in arXiv, but `web_data._project_authors` was reading only from the idea frontmatter `paper_authors:` list (empty for MinT — intake wrote authors only to `paper/metadata.json`). Plus a stray colon `:` author entry from arXiv's group-label parse.
2. **github-actions[bot] listed as an author** on cards. The submitter-skip check in `_project_authors` filtered `system:`/`legacy:`/`agent:` prefixes but not bot identities. The companion contributors-leaderboard function correctly skips bots via `_is_bot_submitter()`; the per-project author list was missing the same check.

## Fix

**`_project_authors()`** (`src/llmxive/web_data.py:831`):

- Bot guard at the submitter-add step.
- **Prefer `paper/metadata.json::authors`** (canonical arXiv-parsed list) over idea frontmatter (legacy fallback).
- Strip lone-punctuation glitches (`:,.;-—–`) before adding.
- Dedup by lowercased name.

**`_paper_author_contributors()`** (`src/llmxive/web_data.py:1274`): same metadata.json preference + junk filter + bot skip + dedup.

**Backfill**: cleaned 3 `metadata.json` files (the three MinT variants PROJ-566/578/583) — removed the stray `:` author entry that arXiv emitted.

## Verification

After regenerating `web/data/projects.json`:

- **PROJ-583**: 62 valid human authors (Mind Lab + 61 named members).
- **0 of 84 PROJ-5\* papers** have github-actions in their author list.
- 40 web-data + intake tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)