### PR TITLE
feat(scheduler): probabilistic stage+comment-weighted prioritization + comment-aware speckit prompts

### DIFF
--- a/src/llmxive/pipeline/scheduler.py
+++ b/src/llmxive/pipeline/scheduler.py
@@ -1,18 +1,45 @@
-"""Project scheduler — picks the next project to act on per FR-001 priority order.
+"""Project scheduler — picks the next project to act on.
 
-Priority tiers (T060 / FR-001):
-  in_progress > analyzed > clarified > specified > flesh_out_complete >
-  brainstormed > paper_in_progress > paper_analyzed > paper_clarified >
-  paper_specified > paper_drafting_init > research_complete
+**Spec 011 / user-directed prioritization (2026-05-15):**
 
-Within a tier, oldest updated_at wins.
+The previous FIFO-within-tier policy biased toward keeping early-stage
+projects rotating slowly. The user wants the opposite: projects that
+are FURTHER along the pipeline (closer to published papers) should get
+priority for edits + advancement, and projects with MORE COMMENTS
+(personality + reviewer contributions) should also be prioritized.
 
-Projects with active locks are skipped (FR-005). Projects in
-human_input_needed or terminal stages are skipped silently.
+Implementation: a `priority_score()` function combines two factors:
+
+  - **Stage-depth weight**: higher for stages closer to POSTED. We use
+    the canonical stage progression (see `STAGE_PROGRESSION` below) and
+    score each stage exponentially by its rank. The fall-off is gentle
+    enough that early-stage projects still have a non-zero chance of
+    being picked (so the queue keeps draining), but late-stage projects
+    are typically picked first.
+  - **Comment-count multiplier**: every personality / reviewer comment
+    on the project increases its weight. We cap the bonus at 20 comments
+    to prevent runaway popularity dominance (the bottom-of-queue must
+    still get some attention).
+
+Selection is **roulette-wheel** (probabilistic) over these weights, not
+deterministic. Two reasons:
+
+  1. The user explicitly asked for "probabilistically" prioritized.
+  2. Deterministic picks let a single popular project monopolize every
+     tick. Probabilistic picks give every project nonzero chance.
+
+When `stage=` is provided, the pool is restricted to that stage and the
+same probabilistic logic still applies (within-stage comment-count
+weighting). When `stage=None`, the pool is every non-terminal,
+non-locked project.
+
+Locked projects (per `pipeline/lock.py`) and terminal stages
+(human_input_needed / blocked / posted) are always excluded.
 """
 
 from __future__ import annotations
 
+import random
 from pathlib import Path
 
 from llmxive.pipeline import lock as lockmod
@@ -20,62 +47,186 @@ from llmxive.state import project as project_store
 from llmxive.types import Project, Stage
 
 
-# Higher priority first. The Implementer's bias toward in_progress /
-# analyzed satisfies FR-006.
-PRIORITY: list[Stage] = [
-    Stage.IN_PROGRESS,
-    Stage.ANALYZED,
-    Stage.CLARIFIED,
-    Stage.SPECIFIED,
-    Stage.FLESH_OUT_COMPLETE,
+# Canonical stage progression — earliest → latest. The further down the
+# list a stage is, the higher its base priority score (closer to a
+# published paper = more valuable to advance).
+#
+# Stages not in this list (e.g. RESEARCH_REVIEW review-cycle states) get
+# their own dedicated reviewer cron and are handled outside the standard
+# scheduler.
+STAGE_PROGRESSION: list[Stage] = [
     Stage.BRAINSTORMED,
-    Stage.PAPER_IN_PROGRESS,
-    Stage.PAPER_ANALYZED,
-    Stage.PAPER_CLARIFIED,
-    Stage.PAPER_SPECIFIED,
-    Stage.PAPER_DRAFTING_INIT,
+    Stage.FLESH_OUT_COMPLETE,
+    Stage.PROJECT_INITIALIZED,
+    Stage.SPECIFIED,
+    Stage.CLARIFIED,
+    Stage.PLANNED,
+    Stage.TASKED,
+    Stage.ANALYZED,
+    Stage.IN_PROGRESS,
     Stage.RESEARCH_COMPLETE,
-    # Other intermediate / review states are picked up by their dedicated
-    # workflows; the scheduler does not gate on them here.
+    Stage.PAPER_DRAFTING_INIT,
+    Stage.PAPER_SPECIFIED,
+    Stage.PAPER_CLARIFIED,
+    Stage.PAPER_PLANNED,
+    Stage.PAPER_TASKED,
+    Stage.PAPER_ANALYZED,
+    Stage.PAPER_IN_PROGRESS,
+    Stage.PAPER_COMPLETE,
+    Stage.PAPER_REVIEW,
+    Stage.PAPER_ACCEPTED,
 ]
 
+# Backwards-compat alias for existing callers that imported `PRIORITY`.
+PRIORITY: list[Stage] = STAGE_PROGRESSION
 
-def pick_next(
-    *, repo_root: Path | None = None, stage: Stage | None = None
-) -> Project | None:
-    """Pick the highest-priority project to act on.
 
-    When `stage` is provided, restrict to projects currently at that
-    stage and pick the oldest. This is used by cron jobs that only
-    handle one stage (e.g. flesh-out cron picks the oldest brainstormed
-    project even when there are higher-priority in_progress projects).
+# Stages a project can sit at that should NEVER be picked by the
+# scheduler: explicit human-only handoffs and terminal end states.
+_NEVER_PICK: set[Stage] = {
+    Stage.HUMAN_INPUT_NEEDED,
+    Stage.BLOCKED,
+    Stage.POSTED,
+}
+
+
+# Exponential-decay base for the stage-depth score. Larger values =
+# *steeper* preference for late-stage projects. 1.5 gives roughly:
+#   brainstormed         → 1.0x
+#   project_initialized  → 3.4x
+#   tasked               → 17x
+#   in_progress          → 57x
+#   paper_in_progress    → 1500x
+# which approximates "papers close to publication get strong preference,
+# but earlier-stage projects still get picked every several ticks."
+STAGE_GROWTH_BASE: float = 1.5
+
+# Comment-count bonus: every personality/reviewer comment file in
+# projects/<id>/reviews/research/ adds this much to the multiplier,
+# capped at MAX_COMMENT_BONUS comments.
+COMMENT_BONUS_PER: float = 0.10
+MAX_COMMENT_BONUS: int = 20
+
+
+def _comment_count(project_id: str, repo_root: Path) -> int:
+    """Count personality / reviewer markdown files for a project."""
+    reviews_dir = repo_root / "projects" / project_id / "reviews" / "research"
+    if not reviews_dir.is_dir():
+        return 0
+    try:
+        return sum(1 for _ in reviews_dir.glob("*.md"))
+    except OSError:
+        return 0
+
+
+def priority_score(project: Project, *, repo_root: Path | None = None) -> float:
+    """Compute the project's scheduling weight.
+
+    Returns a non-negative float. Higher = more likely to be picked next.
+
+    Composition:
+      base = STAGE_GROWTH_BASE ** stage_depth_rank
+      multiplier = 1 + COMMENT_BONUS_PER * min(comment_count, MAX_COMMENT_BONUS)
+      score = base * multiplier
+
+    Stages outside STAGE_PROGRESSION (review states, etc.) are scored as
+    rank 0 (lowest). Terminal / human-input stages return 0 (never picked).
     """
+    if project.current_stage in _NEVER_PICK:
+        return 0.0
+    try:
+        rank = STAGE_PROGRESSION.index(project.current_stage)
+    except ValueError:
+        rank = 0  # unknown stage scores as low priority but non-zero
+    base = STAGE_GROWTH_BASE ** rank
+
+    rr = Path(repo_root) if repo_root is not None else Path.cwd()
+    cc = _comment_count(project.id, rr)
+    multiplier = 1.0 + COMMENT_BONUS_PER * min(cc, MAX_COMMENT_BONUS)
+    return base * multiplier
+
+
+def _eligible_candidates(
+    *,
+    repo_root: Path | None,
+    stage: Stage | None,
+) -> list[Project]:
+    """Return projects eligible for scheduling: non-terminal, non-locked,
+    and (if `stage` is given) at that exact stage."""
     projects = project_store.list_all(repo_root=repo_root)
-    by_stage: dict[Stage, list[Project]] = {s: [] for s in PRIORITY}
+    out: list[Project] = []
     for p in projects:
-        if p.current_stage in {Stage.HUMAN_INPUT_NEEDED, Stage.BLOCKED, Stage.POSTED}:
+        if p.current_stage in _NEVER_PICK:
             continue
         if lockmod.is_locked(p.id, repo_root=repo_root):
             continue
-        if p.current_stage in by_stage:
-            by_stage[p.current_stage].append(p)
-        # Stages outside PRIORITY (e.g., RESEARCH_REVIEW, PAPER_REVIEW) are
-        # handled by their reviewer agents on a different cadence.
-
-    if stage is not None:
-        bucket = by_stage.get(stage, [])
-        if not bucket:
-            return None
-        bucket.sort(key=lambda p: p.updated_at)
-        return bucket[0]
-
-    for prio_stage in PRIORITY:
-        bucket = by_stage[prio_stage]
-        if not bucket:
+        if stage is not None and p.current_stage != stage:
             continue
-        bucket.sort(key=lambda p: p.updated_at)
-        return bucket[0]
-    return None
+        out.append(p)
+    return out
 
 
-__all__ = ["pick_next", "PRIORITY"]
+def pick_next(
+    *, repo_root: Path | None = None, stage: Stage | None = None,
+    rng: random.Random | None = None,
+) -> Project | None:
+    """Pick the next project to act on via priority-weighted random choice.
+
+    `rng` lets tests inject a seeded `random.Random` for determinism.
+    Production callers should pass None (uses the module-level RNG).
+    """
+    candidates = _eligible_candidates(repo_root=repo_root, stage=stage)
+    if not candidates:
+        return None
+    weights = [priority_score(p, repo_root=repo_root) for p in candidates]
+    total = sum(weights)
+    if total <= 0:
+        # All weights zero (shouldn't happen given _NEVER_PICK filter, but
+        # be defensive). Fall back to oldest-first within the candidate pool.
+        candidates.sort(key=lambda p: p.updated_at)
+        return candidates[0]
+    rand = rng if rng is not None else random
+    return rand.choices(candidates, weights=weights, k=1)[0]
+
+
+def pick_next_n(
+    n: int,
+    *, repo_root: Path | None = None, stage: Stage | None = None,
+    rng: random.Random | None = None,
+) -> list[Project]:
+    """Pick up to N distinct projects, weighted by `priority_score`.
+
+    Used when a cron tick wants to advance several projects in one pass
+    (FR-012 / PIPELINE_PARALLELISM). Sampling is without replacement:
+    once a project is picked, it's removed from the pool before the next
+    pick.
+    """
+    if n <= 0:
+        return []
+    candidates = _eligible_candidates(repo_root=repo_root, stage=stage)
+    picked: list[Project] = []
+    rand = rng if rng is not None else random
+    while candidates and len(picked) < n:
+        weights = [priority_score(p, repo_root=repo_root) for p in candidates]
+        total = sum(weights)
+        if total <= 0:
+            # Degenerate: append oldest, exit.
+            candidates.sort(key=lambda p: p.updated_at)
+            picked.append(candidates.pop(0))
+            continue
+        choice = rand.choices(candidates, weights=weights, k=1)[0]
+        picked.append(choice)
+        candidates = [c for c in candidates if c.id != choice.id]
+    return picked
+
+
+__all__ = [
+    "pick_next",
+    "pick_next_n",
+    "priority_score",
+    "PRIORITY",
+    "STAGE_PROGRESSION",
+    "STAGE_GROWTH_BASE",
+    "COMMENT_BONUS_PER",
+    "MAX_COMMENT_BONUS",
+]

--- a/src/llmxive/speckit/_comments_context.py
+++ b/src/llmxive/speckit/_comments_context.py
@@ -1,0 +1,79 @@
+"""Inject recent personality / reviewer comments into a speckit prompt.
+
+The user's rule (spec 011 / 2026-05-15): comments must affect future
+agent behavior — i.e. when a stage agent runs on a project, the agent
+should be aware of what reviewers and personalities have said about
+the work so far. The standard `Agent` base class injects an
+`activity.jsonl` feed (`runner.py:50–89`), but `SlashCommandAgent`
+bypasses that flow entirely. This module provides a single helper that
+each speckit `*_cmd.py` calls when building its user prompt.
+
+Comments live in `projects/<id>/reviews/research/<file>.md` and follow
+the convention `<persona-or-reviewer>__<YYYY-MM-DD>__research.md`. We
+read the most recent N of them (newest-first by filename, which sorts
+naturally by date) and emit a single Markdown block the LLM can read
+verbatim.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Maximum number of comments to inject. Five strikes a balance between
+# enough signal for the agent and not bloating the prompt.
+DEFAULT_LIMIT = 5
+
+# Per-comment body length cap. Some reviewers write multi-page essays;
+# we want the gist, not the full text. Truncated bodies are clearly
+# marked so the LLM doesn't hallucinate the cut-off content.
+PER_COMMENT_MAX_CHARS = 1500
+
+
+def render_recent_comments_block(
+    project_dir: Path,
+    *,
+    limit: int = DEFAULT_LIMIT,
+) -> str:
+    """Return a Markdown block summarizing the most recent comments on
+    a project, or `""` if none exist.
+
+    The block always opens with a `# Recent reviewer / personality
+    comments` heading so prompt templates can search for and remove it
+    safely on re-render. Each comment is preceded by its filename
+    (which encodes persona + date) so the LLM can attribute correctly.
+    """
+    reviews_dir = project_dir / "reviews" / "research"
+    if not reviews_dir.is_dir():
+        return ""
+    # Newest-first. Filenames look like
+    # `ada-lovelace-simulated__2026-05-15__research.md`, which sorts
+    # naturally by date — lexicographic descending = newest first.
+    files = sorted(reviews_dir.glob("*.md"), reverse=True)
+    if not files:
+        return ""
+
+    lines: list[str] = [
+        "# Recent reviewer / personality comments",
+        "",
+        ("These are the most recent comments left on this project. Read them "
+         "carefully and let them shape your decisions — call out any concrete "
+         "objections, integrate concrete suggestions, and feel free to push "
+         "back on weak or contradictory feedback. The aim is to evolve the "
+         "project, not to mechanically execute every comment."),
+        "",
+    ]
+    for f in files[:limit]:
+        try:
+            body = f.read_text(encoding="utf-8", errors="replace").strip()
+        except OSError:
+            continue
+        if len(body) > PER_COMMENT_MAX_CHARS:
+            body = body[:PER_COMMENT_MAX_CHARS].rstrip() + "\n\n*[truncated]*"
+        lines.append(f"## `{f.name}`")
+        lines.append("")
+        lines.append(body)
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+__all__ = ["render_recent_comments_block", "DEFAULT_LIMIT", "PER_COMMENT_MAX_CHARS"]

--- a/src/llmxive/speckit/analyze_cmd.py
+++ b/src/llmxive/speckit/analyze_cmd.py
@@ -29,6 +29,7 @@ def run_analyze(
     fallback_backends: list[BackendName],
     default_model: str,
     repo_root: Path | None = None,
+    project_dir: Path | None = None,
 ) -> str:
     """Issue an analyze pass over the three artifacts; return raw report text.
 
@@ -44,11 +45,20 @@ def run_analyze(
         "(severity: CRITICAL|HIGH|MEDIUM|LOW), (file:section), and a one-sentence summary. "
         "If no issues are found, return the literal string 'CLEAN' on its own line."
     )
+    # Spec 011 / FR-013: inject recent personality + reviewer comments
+    # so the analyzer's flagged issues reflect existing feedback. The
+    # caller passes project_dir (optional, kept None for legacy callsites).
+    comments_block = ""
+    if project_dir is not None:
+        from llmxive.speckit._comments_context import render_recent_comments_block
+        comments_block = render_recent_comments_block(project_dir)
+
     user = (
         f"# spec.md\n\n{spec_text}\n\n"
         f"# plan.md\n\n{plan_text}\n\n"
         f"# tasks.md\n\n{tasks_text}\n\n"
-        "Now produce the analyze report."
+        + (comments_block + "\n\n" if comments_block else "")
+        + "Now produce the analyze report."
     )
     response = chat_with_fallback(
         [ChatMessage(role="system", content=system), ChatMessage(role="user", content=user)],

--- a/src/llmxive/speckit/clarify_cmd.py
+++ b/src/llmxive/speckit/clarify_cmd.py
@@ -79,11 +79,18 @@ class ClarifierAgent(SlashCommandAgent):
             {"project_id": ctx.project_id},
             repo_root=repo,
         )
+        # Spec 011 / FR-013: inject recent personality + reviewer comments
+        # so the clarifier's question selection reflects what reviewers
+        # have already flagged on this project.
+        from llmxive.speckit._comments_context import render_recent_comments_block
+        comments_block = render_recent_comments_block(ctx.project_dir)
+
         user = (
             f"# Current spec.md\n\n{mechanical_output['spec_text']}\n\n"
             f"# Markers\n\n{yaml.safe_dump(mechanical_output['markers'])}\n\n"
             f"# Attempts so far\n{mechanical_output['attempts_so_far']}\n\n"
-            "# Task\n\nReturn the YAML clarification report per the contract."
+            + (comments_block + "\n\n" if comments_block else "")
+            + "# Task\n\nReturn the YAML clarification report per the contract."
         )
         return [
             ChatMessage(role="system", content=system),

--- a/src/llmxive/speckit/implement_cmd.py
+++ b/src/llmxive/speckit/implement_cmd.py
@@ -135,6 +135,12 @@ class ImplementerAgent(SlashCommandAgent):
                 "(extend / modify these EXACTLY — do not invent new APIs)\n\n"
                 + referenced
             )
+        # Spec 011 / FR-013: inject recent personality + reviewer comments
+        # so the implementer's design choices reflect accumulated feedback.
+        from llmxive.speckit._comments_context import render_recent_comments_block
+        comments_block = render_recent_comments_block(ctx.project_dir)
+        if comments_block:
+            user_parts.append(comments_block)
         user_parts.append(
             "# Task\n\nReturn the YAML implementation report. "
             "If your script imports from sibling modules, the imported "

--- a/src/llmxive/speckit/paper_clarify_cmd.py
+++ b/src/llmxive/speckit/paper_clarify_cmd.py
@@ -67,13 +67,16 @@ class PaperClarifierAgent(SlashCommandAgent):
             {"project_id": ctx.project_id},
             repo_root=repo,
         )
+        from llmxive.speckit._comments_context import render_recent_comments_block
+        comments_block = render_recent_comments_block(ctx.project_dir)
         user = (
             f"# Current paper spec.md\n\n{mechanical_output['spec_text']}\n\n"
             f"# Markers\n\n{yaml.safe_dump(mechanical_output['markers'])}\n\n"
             f"# Attempts so far\n{mechanical_output['attempts_so_far']}\n\n"
             f"# Paper constitution\n\n{paper_constitution}\n\n"
             f"# Research-stage spec (source of truth for methodology)\n\n{research_spec}\n\n"
-            "# Task\n\nReturn the YAML clarification report per the contract."
+            + (comments_block + "\n\n" if comments_block else "")
+            + "# Task\n\nReturn the YAML clarification report per the contract."
         )
         return [
             ChatMessage(role="system", content=system),

--- a/src/llmxive/speckit/paper_implement_cmd.py
+++ b/src/llmxive/speckit/paper_implement_cmd.py
@@ -120,13 +120,16 @@ class PaperImplementerAgent(SlashCommandAgent):
             },
             repo_root=repo,
         )
+        from llmxive.speckit._comments_context import render_recent_comments_block
+        comments_block = render_recent_comments_block(ctx.project_dir)
         user = (
             f"# tasks.md (paper)\n\n{mechanical_output['tasks_text']}\n\n"
             f"# next task\n\n{mechanical_output['next_task_line']}\n\n"
             f"# parsed kind\n\n{mechanical_output['next_task_kind'] or '(none)'}\n\n"
             f"# completed task ids\n\n{mechanical_output['completed_task_ids']}\n\n"
             f"# leaf budget\n\n{LEAF_TASK_BUDGET_SECONDS}\n\n"
-            "# Task\n\nReturn the YAML dispatch document."
+            + (comments_block + "\n\n" if comments_block else "")
+            + "# Task\n\nReturn the YAML dispatch document."
         )
         return [
             ChatMessage(role="system", content=system),

--- a/src/llmxive/speckit/paper_plan_cmd.py
+++ b/src/llmxive/speckit/paper_plan_cmd.py
@@ -71,11 +71,14 @@ class PaperPlannerAgent(SlashCommandAgent):
             {"project_id": ctx.project_id},
             repo_root=repo,
         )
+        from llmxive.speckit._comments_context import render_recent_comments_block
+        comments_block = render_recent_comments_block(ctx.project_dir)
         user = (
             f"# Paper spec.md\n\n{spec_text}\n\n"
             f"# Paper constitution\n\n{paper_constitution}\n\n"
             f"# Plan template\n\n{plan_template}\n\n"
-            "# Task\n\nProduce all five documents per the output contract."
+            + (comments_block + "\n\n" if comments_block else "")
+            + "# Task\n\nProduce all five documents per the output contract."
         )
         return [
             ChatMessage(role="system", content=system),

--- a/src/llmxive/speckit/paper_specify_cmd.py
+++ b/src/llmxive/speckit/paper_specify_cmd.py
@@ -82,12 +82,15 @@ class PaperSpecifierAgent(SlashCommandAgent):
             },
             repo_root=repo,
         )
+        from llmxive.speckit._comments_context import render_recent_comments_block
+        comments_block = render_recent_comments_block(ctx.project_dir)
         user = (
             f"# Research-stage spec.md\n\n{research_spec}\n\n"
             f"# Research-stage plan.md\n\n{research_plan}\n\n"
             f"# Research-stage tasks.md\n\n{research_tasks}\n\n"
             f"# Paper spec template\n\n{spec_template}\n\n"
-            "# Task\n\nProduce the final paper-stage spec.md."
+            + (comments_block + "\n\n" if comments_block else "")
+            + "# Task\n\nProduce the final paper-stage spec.md."
         )
         return [
             ChatMessage(role="system", content=system),

--- a/src/llmxive/speckit/paper_tasks_cmd.py
+++ b/src/llmxive/speckit/paper_tasks_cmd.py
@@ -69,12 +69,15 @@ class PaperTaskerAgent(SlashCommandAgent):
             {"project_id": ctx.project_id, "mode": "A"},
             repo_root=repo,
         )
+        from llmxive.speckit._comments_context import render_recent_comments_block
+        comments_block = render_recent_comments_block(ctx.project_dir)
         user = (
             "Mode: A (generate paper tasks.md)\n\n"
             f"# Paper spec.md\n\n{spec_text}\n\n"
             f"# Paper plan.md\n\n{plan_text}\n\n"
             f"# Tasks template\n\n{tasks_template}\n\n"
-            "# Task\n\nReturn the full paper tasks.md Markdown. "
+            + (comments_block + "\n\n" if comments_block else "")
+            + "# Task\n\nReturn the full paper tasks.md Markdown. "
             "EVERY task line MUST include a `[kind:<value>]` token."
         )
         return [

--- a/src/llmxive/speckit/plan_cmd.py
+++ b/src/llmxive/speckit/plan_cmd.py
@@ -102,11 +102,14 @@ class PlannerAgent(SlashCommandAgent):
             {"project_id": ctx.project_id},
             repo_root=repo,
         )
+        from llmxive.speckit._comments_context import render_recent_comments_block
+        comments_block = render_recent_comments_block(ctx.project_dir)
         user = (
             f"# spec.md\n\n{spec_text}\n\n"
             f"# Project constitution\n\n{project_constitution}\n\n"
             f"# Plan template\n\n{plan_template}\n\n"
-            "# Task\n\nProduce all five documents per the output contract."
+            + (comments_block + "\n\n" if comments_block else "")
+            + "# Task\n\nProduce all five documents per the output contract."
         )
         return [
             ChatMessage(role="system", content=system),

--- a/src/llmxive/speckit/specify_cmd.py
+++ b/src/llmxive/speckit/specify_cmd.py
@@ -85,12 +85,20 @@ class SpecifierAgent(SlashCommandAgent):
             },
             repo_root=repo,
         )
+        # Spec 011 / FR-013: inject recent personality + reviewer
+        # comments into the user prompt so the agent's output reflects
+        # accumulated feedback (single source of truth — every speckit
+        # command pulls this from `_comments_context.render_recent_comments_block`).
+        from llmxive.speckit._comments_context import render_recent_comments_block
+        comments_block = render_recent_comments_block(ctx.project_dir)
+
         user = (
             "# Idea Markdown\n\n"
             f"{idea_md}\n\n"
             "# Spec template (canonical Spec Kit)\n\n"
             f"{spec_template}\n\n"
-            "# Task\n\n"
+            + (comments_block + "\n\n" if comments_block else "")
+            + "# Task\n\n"
             "Produce the final spec.md content."
         )
         return [

--- a/tests/integration/test_scheduler_priority.py
+++ b/tests/integration/test_scheduler_priority.py
@@ -63,26 +63,54 @@ def _bootstrap_state(repo: Path) -> None:
         (repo / "state" / sub).mkdir(parents=True, exist_ok=True)
 
 
-def test_in_progress_preempts_analyzed(tmp_path: Path) -> None:
+import random
+
+
+def _picked_distribution(repo: Path, *, n_samples: int = 400) -> dict[str, int]:
+    """Sample pick_next() `n_samples` times with a fresh seeded RNG and
+    return a histogram of project_ids. Used for probabilistic assertions."""
+    counts: dict[str, int] = {}
+    for seed in range(n_samples):
+        rng = random.Random(seed)
+        p = scheduler.pick_next(repo_root=repo, rng=rng)
+        if p is None:
+            continue
+        counts[p.id] = counts.get(p.id, 0) + 1
+    return counts
+
+
+def test_in_progress_strongly_preempts_analyzed(tmp_path: Path) -> None:
+    """IN_PROGRESS is one rank deeper than ANALYZED in STAGE_PROGRESSION;
+    its base weight is STAGE_GROWTH_BASE^1 ≈ 1.5× higher. Over many
+    samples, IN_PROGRESS should win the strong majority of picks."""
     _bootstrap_state(tmp_path)
     _make(tmp_path, "PROJ-001-fresh", Stage.ANALYZED, age_days=10)
     _make(tmp_path, "PROJ-002-active", Stage.IN_PROGRESS, age_days=1)
 
-    picked = scheduler.pick_next(repo_root=tmp_path)
-    assert picked is not None
-    assert picked.id == "PROJ-002-active", (
-        f"in_progress should preempt analyzed; got {picked.id}"
+    counts = _picked_distribution(tmp_path)
+    total = sum(counts.values())
+    # IN_PROGRESS / (IN_PROGRESS + ANALYZED) = 1.5 / 2.5 = 60%. Allow 50% floor.
+    assert counts.get("PROJ-002-active", 0) / total > 0.5, (
+        f"in_progress should win majority of picks; got {counts}"
     )
+    # ANALYZED still gets non-zero share — the queue keeps draining.
+    assert counts.get("PROJ-001-fresh", 0) > 0
 
 
-def test_oldest_updated_at_wins_within_tier(tmp_path: Path) -> None:
+def test_same_stage_yields_roughly_uniform_picks(tmp_path: Path) -> None:
+    """Three projects at the same stage with identical comment counts
+    should produce roughly uniform picks (within sampling noise)."""
     _bootstrap_state(tmp_path)
     _make(tmp_path, "PROJ-100-newest", Stage.ANALYZED, age_days=1)
     _make(tmp_path, "PROJ-101-oldest", Stage.ANALYZED, age_days=20)
     _make(tmp_path, "PROJ-102-middle", Stage.ANALYZED, age_days=10)
 
-    picked = scheduler.pick_next(repo_root=tmp_path)
-    assert picked is not None and picked.id == "PROJ-101-oldest"
+    counts = _picked_distribution(tmp_path)
+    total = sum(counts.values())
+    # Each should get ~33% ± sampling noise; allow 20-50% per project.
+    for pid in ("PROJ-100-newest", "PROJ-101-oldest", "PROJ-102-middle"):
+        share = counts.get(pid, 0) / total
+        assert 0.20 < share < 0.50, f"{pid} share {share:.2%} outside band; counts={counts}"
 
 
 def test_locked_projects_skipped(tmp_path: Path) -> None:
@@ -91,9 +119,10 @@ def test_locked_projects_skipped(tmp_path: Path) -> None:
     _make(tmp_path, "PROJ-201-free", Stage.ANALYZED, age_days=10)
     lockmod.acquire(p.id, holder_run_id="other-run", ttl_seconds=3600, repo_root=tmp_path)
 
-    picked = scheduler.pick_next(repo_root=tmp_path)
-    assert picked is not None
-    assert picked.id == "PROJ-201-free", "locked in_progress should be skipped"
+    # Across many samples, the locked PROJ-200 must NEVER be picked.
+    counts = _picked_distribution(tmp_path)
+    assert "PROJ-200-locked" not in counts, "locked project must never be picked"
+    assert counts.get("PROJ-201-free", 0) > 0, "free project should be pickable"
 
 
 @pytest.mark.parametrize("stage", [Stage.HUMAN_INPUT_NEEDED, Stage.BLOCKED, Stage.POSTED])
@@ -102,19 +131,49 @@ def test_excluded_stages_never_picked(tmp_path: Path, stage: Stage) -> None:
     _make(tmp_path, "PROJ-300-stuck", stage, age_days=1)
     _make(tmp_path, "PROJ-301-ready", Stage.IN_PROGRESS, age_days=10)
 
-    picked = scheduler.pick_next(repo_root=tmp_path)
-    assert picked is not None and picked.id == "PROJ-301-ready"
+    counts = _picked_distribution(tmp_path)
+    assert "PROJ-300-stuck" not in counts, "terminal/human-input must never be picked"
+    assert counts.get("PROJ-301-ready", 0) > 0
 
 
-def test_full_priority_order(tmp_path: Path) -> None:
-    """Plant one project at each priority tier; assert the highest-priority is picked."""
+def test_deepest_stage_dominates_picks(tmp_path: Path) -> None:
+    """With projects at BRAINSTORMED, CLARIFIED, and PAPER_IN_PROGRESS,
+    the paper-stage project should win the majority of picks — it's
+    further along the pipeline so closer to publication."""
     _bootstrap_state(tmp_path)
-    # Fill in only a subset of tiers (full enum is too large to test
-    # exhaustively in one pass). Pick three points along the order.
     _make(tmp_path, "PROJ-401-clarified", Stage.CLARIFIED, age_days=1)
     _make(tmp_path, "PROJ-402-brainstormed", Stage.BRAINSTORMED, age_days=1)
     _make(tmp_path, "PROJ-403-paper-progress", Stage.PAPER_IN_PROGRESS, age_days=1)
-    # The highest-priority among these (per the PRIORITY list) is CLARIFIED
-    # — IN_PROGRESS / ANALYZED tiers are empty.
-    picked = scheduler.pick_next(repo_root=tmp_path)
-    assert picked is not None and picked.id == "PROJ-401-clarified"
+
+    counts = _picked_distribution(tmp_path)
+    total = sum(counts.values())
+    # PAPER_IN_PROGRESS has the deepest rank (16 in STAGE_PROGRESSION),
+    # so its weight (1.5^16 ≈ 657) dwarfs CLARIFIED (1.5^4 ≈ 5) and
+    # BRAINSTORMED (1.5^0 = 1). Should win >85%.
+    paper_share = counts.get("PROJ-403-paper-progress", 0) / total
+    assert paper_share > 0.85, (
+        f"deepest-stage project should dominate picks; got {counts}"
+    )
+
+
+def test_comments_boost_priority(tmp_path: Path) -> None:
+    """Two projects at the same stage; the one with more comments should
+    get a noticeable share boost."""
+    _bootstrap_state(tmp_path)
+    p_quiet = _make(tmp_path, "PROJ-500-quiet", Stage.ANALYZED, age_days=1)
+    p_busy = _make(tmp_path, "PROJ-501-busy", Stage.ANALYZED, age_days=1)
+    # Plant 10 comments on PROJ-501.
+    reviews_dir = tmp_path / "projects" / p_busy.id / "reviews" / "research"
+    reviews_dir.mkdir(parents=True, exist_ok=True)
+    for i in range(10):
+        (reviews_dir / f"persona-{i}__2026-05-01__research.md").write_text("body")
+
+    counts = _picked_distribution(tmp_path)
+    total = sum(counts.values())
+    # busy multiplier = 1 + 0.10*10 = 2.0; quiet = 1.0. Busy share ≈ 2/3.
+    busy_share = counts.get("PROJ-501-busy", 0) / total
+    assert busy_share > 0.55, (
+        f"commented project should be picked more often; got {counts}"
+    )
+    # Quiet still non-zero.
+    assert counts.get("PROJ-500-quiet", 0) > 0

--- a/tests/unit/test_speckit_comments_context.py
+++ b/tests/unit/test_speckit_comments_context.py
@@ -1,0 +1,80 @@
+"""Unit tests for llmxive.speckit._comments_context.
+
+Spec 011 / FR-013: comments must propagate from `reviews/research/*.md`
+into the speckit user prompt so subsequent agent runs are aware of
+prior feedback.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from llmxive.speckit._comments_context import (
+    DEFAULT_LIMIT,
+    PER_COMMENT_MAX_CHARS,
+    render_recent_comments_block,
+)
+
+
+class TestRenderRecentCommentsBlock(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.project_dir = Path(self.tmp.name) / "PROJ-001-test"
+        self.reviews = self.project_dir / "reviews" / "research"
+        self.reviews.mkdir(parents=True, exist_ok=True)
+
+    def _write(self, name: str, body: str) -> None:
+        (self.reviews / name).write_text(body, encoding="utf-8")
+
+    def test_empty_reviews_dir_returns_empty_string(self) -> None:
+        self.assertEqual(render_recent_comments_block(self.project_dir), "")
+
+    def test_no_reviews_dir_returns_empty_string(self) -> None:
+        empty = Path(self.tmp.name) / "PROJ-002-empty"
+        empty.mkdir()
+        self.assertEqual(render_recent_comments_block(empty), "")
+
+    def test_single_comment_renders_heading_and_body(self) -> None:
+        self._write("alice__2026-05-01__research.md", "Alice's review of the spec.")
+        out = render_recent_comments_block(self.project_dir)
+        self.assertIn("# Recent reviewer / personality comments", out)
+        self.assertIn("alice__2026-05-01__research.md", out)
+        self.assertIn("Alice's review of the spec.", out)
+
+    def test_newest_first_ordering(self) -> None:
+        self._write("alice__2026-05-01__research.md", "older")
+        self._write("bob__2026-05-15__research.md", "newer")
+        out = render_recent_comments_block(self.project_dir)
+        bob_idx = out.find("bob__2026-05-15")
+        alice_idx = out.find("alice__2026-05-01")
+        self.assertGreater(alice_idx, bob_idx, "newer comment should appear first")
+
+    def test_limit_caps_at_default(self) -> None:
+        for i in range(DEFAULT_LIMIT + 3):
+            self._write(f"persona{i}__2026-05-{i + 1:02d}__research.md", f"body {i}")
+        out = render_recent_comments_block(self.project_dir)
+        # Count comment headings
+        n_h2 = out.count("\n## `")
+        self.assertEqual(n_h2, DEFAULT_LIMIT)
+
+    def test_custom_limit_overrides_default(self) -> None:
+        for i in range(5):
+            self._write(f"persona{i}__2026-05-{i + 1:02d}__research.md", "body")
+        out = render_recent_comments_block(self.project_dir, limit=2)
+        n_h2 = out.count("\n## `")
+        self.assertEqual(n_h2, 2)
+
+    def test_long_body_gets_truncated(self) -> None:
+        long_body = "x" * (PER_COMMENT_MAX_CHARS * 2)
+        self._write("alice__2026-05-01__research.md", long_body)
+        out = render_recent_comments_block(self.project_dir)
+        self.assertIn("*[truncated]*", out)
+        # The full untruncated body must NOT appear in full
+        self.assertLess(out.count("x"), PER_COMMENT_MAX_CHARS * 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three user-directed changes to how cron jobs pick projects:

## (a) Projects further along the pipeline get priority — probabilistically

`scheduler.py` rewritten. The previous policy was deterministic-FIFO-within-stage (oldest in the highest-priority bucket wins). New policy: roulette-wheel weighted pick where each project's weight is:

```
priority_score = STAGE_GROWTH_BASE ** stage_rank  *  (1 + 0.1 * min(comment_count, 20))
```

with `STAGE_GROWTH_BASE = 1.5`. The deepest stages (paper_in_progress, paper_complete) score ~657× a brainstormed project, so they win the majority of picks — but every eligible project still has nonzero chance, so the queue keeps draining.

## (b) Projects with more comments get priority

The comment-count multiplier above (`1 + 0.1 * min(N, 20)`) means a project with 10 comments has 2× the weight of a same-stage project with 0 comments. Capped at 20 comments to prevent runaway dominance.

## (c) Comments affect agent behavior

New helper `src/llmxive/speckit/_comments_context.render_recent_comments_block()` reads the 5 most recent `projects/<id>/reviews/research/*.md` files (newest-first by date in filename) and emits a Markdown block. Wired into all 10 speckit command builders:

- `specify`, `clarify`, `plan`, `analyze`, `implement` (research-stage)
- `paper_specify`, `paper_clarify`, `paper_plan`, `paper_tasks`, `paper_implement` (paper-stage)
- `tasks` already had a similar (un-capped, un-truncated) review-injection block — left untouched.

## API additions

- `scheduler.priority_score(project)` — public weight function for callers that want to inspect.
- `scheduler.pick_next_n(n)` — sample up to N distinct projects with weighted-without-replacement (for FR-012 / PIPELINE_PARALLELISM).
- All scheduler functions accept an optional `rng=random.Random(seed)` for deterministic tests.

## Tests

- 8 new scheduler tests (with seeded RNG histograms) covering: stage-depth preempts shallower; same-stage roughly uniform; locked + terminal projects never picked; deepest-stage dominates; comments boost priority.
- 7 new `_comments_context` tests covering: empty dir, single comment, newest-first ordering, default + custom limit, body truncation.
- All 164 tests pass.

## Note on HF cron

The user mentioned the HF cron "didn't run again". PR #150 moved its schedule from `59 23 * * *` (23:59 UTC, post-midnight-crossover failures) to `0 8 * * *` (08:00 UTC). The last *scheduled* run we observed was the pre-fix failure; the next 08:00 UTC slot is tomorrow morning. Three manual `workflow_dispatch` runs since the fix all succeeded. **Not broken — just hasn't fired its first scheduled tick yet.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)