### PR TITLE
feat(paper_reviewer): give arxiv-intake reviewers real visual + provenance context

### DIFF
--- a/src/llmxive/agents/paper_reviewer.py
+++ b/src/llmxive/agents/paper_reviewer.py
@@ -67,6 +67,34 @@ def _summarize_figures(fig_dir: Path) -> str:
     return "\n".join(lines) if lines else "(empty)"
 
 
+def _collect_figures_from_arxiv_source(source_dir: Path) -> str:
+    """For arXiv-intake papers, figures live inside the source tarball
+    under conventional subdirs (figures/, figs/, pics/, images/, plots/,
+    Figures/, etc.) — NOT under paper/figures/. Discover them by
+    extension across `source/**` so the reviewer can comment on them.
+
+    Returns a single-line-per-figure listing. Capped at 200 entries to
+    keep the prompt bounded.
+    """
+    if not source_dir.is_dir():
+        return "(no source directory)"
+    fig_exts = {".pdf", ".png", ".jpg", ".jpeg", ".eps", ".svg", ".tikz", ".gif"}
+    lines: list[str] = []
+    for path in sorted(source_dir.rglob("*")):
+        if not path.is_file() or path.suffix.lower() not in fig_exts:
+            continue
+        # Skip top-level paper PDFs (the compiled output goes to
+        # paper/pdf/, but some arxiv tarballs include the source PDF too).
+        rel = path.relative_to(source_dir).as_posix()
+        if rel.endswith(".pdf") and "/" not in rel:
+            continue
+        lines.append(f"- `{rel}` ({path.stat().st_size} bytes)")
+        if len(lines) >= 200:
+            lines.append("- (truncated at 200 entries)")
+            break
+    return "\n".join(lines) if lines else "(no figure-like files found in source)"
+
+
 def _summarize_pdf(pdf_dir: Path) -> str:
     if not pdf_dir.is_dir():
         return "(no pdf directory)"
@@ -126,7 +154,15 @@ class PaperReviewerAgent(Agent):
             )
 
         source_concat = _concat_tex(paper_dir / "source")
+        # For arxiv-intake papers, figures live inside source/ (not
+        # paper/figures/). Fall back to scanning source/ when the
+        # canonical figures dir is empty/missing so the reviewer can
+        # actually see what visual artifacts exist.
         figures_summary = _summarize_figures(paper_dir / "figures")
+        if is_arxiv_intake or figures_summary.startswith("("):
+            arxiv_figs = _collect_figures_from_arxiv_source(paper_dir / "source")
+            if not arxiv_figs.startswith("(no"):
+                figures_summary = arxiv_figs
         pdf_summary = _summarize_pdf(paper_dir / "pdf")
         proofreader_flags = _read_optional(
             paper_dir / ".specify" / "memory" / "proofreader_flags.yaml"
@@ -162,9 +198,38 @@ class PaperReviewerAgent(Agent):
             {"project_id": ctx.project_id, "reviewer_name": self.entry.name},
             repo_root=repo,
         )
+        # arXiv-intake metadata block — surface the upstream context the
+        # LLM needs to review a third-party paper (vs. a home-grown one).
+        intake_block = ""
+        if is_arxiv_intake:
+            import json as _json
+            try:
+                meta = _json.loads((paper_dir / "metadata.json").read_text(encoding="utf-8"))
+            except (OSError, _json.JSONDecodeError):
+                meta = {}
+            authors = ", ".join(meta.get("authors", []) or []) or "(unknown)"
+            arxiv_url = meta.get("arxiv_url") or (
+                f"https://arxiv.org/abs/{meta['arxiv_id']}" if meta.get("arxiv_id") else "(unknown)"
+            )
+            intake_block = (
+                "# Paper provenance — IMPORTANT context\n\n"
+                "This is an arXiv-submitted paper ingested verbatim from the "
+                "public archive. The llmXive pipeline did NOT generate it; you "
+                "are reviewing a third-party manuscript. The paper's authors "
+                "are listed below; the submitter field is the llmXive intake "
+                "agent that filed it, not an author.\n\n"
+                f"- arXiv URL: {arxiv_url}\n"
+                f"- Paper authors: {authors}\n"
+                f"- Title (as recorded by intake): {meta.get('title', '(none)')}\n"
+                f"- Submitter (intake actor): {meta.get('submitter', '(unknown)')}\n\n"
+                "Focus your review on the paper itself — claims, methodology, "
+                "figures, evidence — not on the speckit/plan/tasks artifacts "
+                "that don't exist for arXiv-ingested papers.\n\n"
+            )
         user = (
             f"# project_id\n{ctx.project_id}\n\n"
             f"# title\n{ctx.metadata.get('title', '')}\n\n"
+            f"{intake_block}"
             f"# Paper LaTeX source\n\n{source_concat}\n\n"
             f"# Compiled PDFs\n\n{pdf_summary}\n\n"
             f"# Figures\n\n{figures_summary}\n\n"

--- a/tests/unit/test_paper_reviewer_arxiv_intake.py
+++ b/tests/unit/test_paper_reviewer_arxiv_intake.py
@@ -83,3 +83,81 @@ class TestArxivIntakeFallback:
         assert "and no paper/metadata.json" in text, (
             "the hard-fail message should explain BOTH conditions"
         )
+
+
+class TestArxivIntakeFigureDiscovery:
+    """For arXiv-intake papers, figures live in paper/source/{figs,pics,
+    images,Figures}/ — not paper/figures/. The reviewer must discover
+    them or the LLM has no visual context to review."""
+
+    def test_discovers_pdf_figures_under_pics(self, tmp_path: Path) -> None:
+        from llmxive.agents.paper_reviewer import _collect_figures_from_arxiv_source
+        src = tmp_path / "source"
+        (src / "pics").mkdir(parents=True)
+        (src / "pics" / "figure1.pdf").write_bytes(b"x" * 1234)
+        (src / "pics" / "figure2.png").write_bytes(b"y" * 100)
+        out = _collect_figures_from_arxiv_source(src)
+        assert "pics/figure1.pdf" in out
+        assert "pics/figure2.png" in out
+        assert "1234 bytes" in out
+
+    def test_discovers_figures_in_multiple_subdirs(self, tmp_path: Path) -> None:
+        from llmxive.agents.paper_reviewer import _collect_figures_from_arxiv_source
+        src = tmp_path / "source"
+        # macOS HFS+ is case-insensitive, so don't use both "figures" and
+        # "Figures" — pick distinct subdir names.
+        (src / "figures").mkdir(parents=True)
+        (src / "images").mkdir(parents=True)
+        (src / "logo").mkdir(parents=True)
+        (src / "figures" / "a.pdf").write_bytes(b"a")
+        (src / "images" / "b.eps").write_bytes(b"b")
+        (src / "logo" / "c.svg").write_bytes(b"c")
+        out = _collect_figures_from_arxiv_source(src)
+        assert all(s in out for s in ("figures/a.pdf", "images/b.eps", "logo/c.svg"))
+
+    def test_skips_top_level_pdfs_likely_compiled_output(self, tmp_path: Path) -> None:
+        from llmxive.agents.paper_reviewer import _collect_figures_from_arxiv_source
+        src = tmp_path / "source"
+        src.mkdir(parents=True)
+        (src / "main.pdf").write_bytes(b"compiled output, not a figure")
+        (src / "pics").mkdir()
+        (src / "pics" / "real-figure.pdf").write_bytes(b"actual figure")
+        out = _collect_figures_from_arxiv_source(src)
+        assert "main.pdf" not in out  # top-level PDF skipped
+        assert "pics/real-figure.pdf" in out
+
+    def test_caps_at_200_entries(self, tmp_path: Path) -> None:
+        from llmxive.agents.paper_reviewer import _collect_figures_from_arxiv_source
+        src = tmp_path / "source" / "figs"
+        src.mkdir(parents=True)
+        for i in range(250):
+            (src / f"f{i:03d}.png").write_bytes(b"x")
+        out = _collect_figures_from_arxiv_source(src.parent)
+        assert "truncated at 200 entries" in out
+
+    def test_real_world_proj_564_discovers_10_figures(self) -> None:
+        """Smoke test against the actual PROJ-564 source on disk.
+        Skips if PROJ-564 isn't checked out (e.g., on a fresh clone)."""
+        from llmxive.agents.paper_reviewer import _collect_figures_from_arxiv_source
+        repo = Path(__file__).resolve().parents[2]
+        src = repo / "projects" / "PROJ-564-qwen-image-vae-2-0-technical-report" / "paper" / "source"
+        if not src.is_dir():
+            pytest.skip("PROJ-564 source not checked out")
+        out = _collect_figures_from_arxiv_source(src)
+        lines = [line for line in out.splitlines() if line.startswith("- ")]
+        assert len(lines) >= 5, f"expected ≥5 figures in PROJ-564 source, got {len(lines)}"
+        # At least one figure under pics/
+        assert any("pics/" in line for line in lines)
+
+
+class TestArxivIntakeMetadataBlock:
+    """The reviewer prompt must include a 'paper provenance' header for
+    arxiv-intake papers so the LLM knows it's reviewing a third-party
+    manuscript, not a home-grown one."""
+
+    def test_intake_block_exists_in_source(self) -> None:
+        src = Path(__file__).resolve().parents[2] / "src" / "llmxive" / "agents" / "paper_reviewer.py"
+        text = src.read_text()
+        assert "Paper provenance — IMPORTANT context" in text
+        assert "third-party" in text or "ingested verbatim" in text
+        assert "submitter field is the llmXive intake" in text


### PR DESCRIPTION
Follows up #195. The hard-fail fix wasn't enough — the reviewer must produce **valid + useful** reviews. Two improvements:
1. Figure discovery — `_collect_figures_from_arxiv_source` scans `paper/source/**` for figure-like files (since arXiv tarballs don't use the home-grown `paper/figures/` convention). PROJ-564 went from 0 figures visible → 10.
2. Provenance block — adds an explicit 'this is a third-party arXiv paper' header to the user prompt so the LLM credits the right authors and doesn't confuse the intake bot with the submitter.

9/9 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)