### PR TITLE
Issue #295: orchestration-pilot decision, MCP server for librarian/claim tools, credit-managed paid backend (spec 022)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -11,19 +11,10 @@ check_untyped_defs = True
 no_implicit_optional = True
 ignore_missing_imports = False
 
-[mypy-langchain.*]
-ignore_missing_imports = True
-
 [mypy-langchain_dartmouth.*]
 ignore_missing_imports = True
 
-[mypy-langgraph.*]
-ignore_missing_imports = True
-
 [mypy-arxiv]
-ignore_missing_imports = True
-
-[mypy-crossref_commons.*]
 ignore_missing_imports = True
 
 [mypy-scipy.*]

--- a/notes/2026-06-10-issue-295-phase3-followup.md
+++ b/notes/2026-06-10-issue-295-phase3-followup.md
@@ -1,0 +1,62 @@
+# Issue #295 (audit Phase 3 follow-up) — session note (2026-06-10)
+
+Branch: `022-audit-phase3-followup`. Spec: `specs/022-audit-phase3-followup/`.
+Commits: `3a54a28a` (credits), `79c9af21` (MCP + pilot + observability).
+
+## What landed (all three #295 scope items)
+
+1. **Orchestration-harness pilot → DECISION: KEEP BESPOKE.** smolagents
+   CodeAgent ran the implementer micro-lane through a RouterModel
+   adapter (all calls inside `chat_with_fallback`). Run 1 failed
+   (sandbox blocks execute-what-you-wrote; step cap); run 2 passed only
+   after authorizing `subprocess` (sandbox forfeited). Net orchestration
+   LOC would increase. Evidence:
+   `specs/022-audit-phase3-followup/pilot/RESULTS.md`. smolagents NOT a
+   dependency; unused `langgraph` dep removed (bootstrap-era, zero
+   imports).
+2. **MCP server** (`src/llmxive/mcp_server/`, extra `llmxive[mcp]`,
+   `python -m llmxive.mcp_server`): 8 tools wrapping librarian
+   (semantic scholar / arXiv / theoremsearch / resolve_reference) +
+   claims (register_and_resolve, claim_status) + credit_balance.
+   Unit (tool inventory) + real stdio-client tests green.
+3. **Credit-managed paid path** (maintainer-directed): measured live —
+   `GET /api/v1/credits/balance`; **1 credit = $0.001 list-price USD**
+   (1000× ratio measured via a real haiku call); 2000 credits/day ≈
+   $2.00/day; reset 03:45Z (11:45 PM ET); metering is ASYNC (seconds–
+   tens of seconds lag). Implementation: `backends/credits.py`
+   (LLMXIVE_PAID_OPT_IN master switch default OFF;
+   LLMXIVE_PAID_BUDGET_FRACTION cap default 0.75; 30s TTL cache;
+   FAIL-CLOSED), guard wired into `DartmouthBackend.chat` (replaces the
+   v1 hard block), real cost estimates in run-log (cost invariant
+   relaxed ONLY under the switch), `llmxive credits` CLI,
+   `paid_opt_in` schema/types const-false → boolean default false
+   (registry pin test = visible friction; flipping an agent needs a
+   written justification — see
+   `specs/022-audit-phase3-followup/paid-backend-justification.md`).
+   17 unit + 3 real-call tests (tiny haiku e2e ≈ 0.03 credits).
+
+## As-you-go fixes
+
+- Observability (notes/spec-015 item 5): `<missing>` reviser padding now
+  records WHY (zero-parse vs skip) in `what_changed` →
+  `_reviser_response.build_concern_responses` + 2 contract tests.
+- mypy.ini stale sections pruned; ruff/mypy clean.
+- The audit note's "silent [] on missing extraction prompt" follow-up
+  was ALREADY fixed on main (extract.py raises since spec 021).
+
+## Pipeline goal status (per notes/spec-015-review-status.md)
+
+- Offline gate at baseline: 2323/16/0; post-change gate re-run this
+  session (see below for final numbers in the PR).
+- PROJ-552 still `clarified` since 06-02 (crons work other projects).
+  Dispatched a SCOPED run: `gh run` id **27306941191** (330-min budget,
+  main). Check on resume: `git pull` + PROJ-552 `current_stage` +
+  whether a plan trail / honest kickback persisted.
+
+## Open / next
+
+- Merge PR for `022-audit-phase3-followup` once CI green.
+- After dispatch 27306941191: inspect plan-stage progress (notes item 4
+  — persist-before-abort + reasoning-volume levers if it still stalls).
+- Future policy decisions (each needs its own justification): flipping
+  specific agents (e.g. deep paper review) to `paid_opt_in: true`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ authors = [{ name = "Contextual Dynamics Lab", email = "research.computing@dartm
 dependencies = [
   # LLM / agent framework
   "langchain>=0.3",
-  "langgraph>=0.2",
   "langchain-dartmouth>=0.3.1",
   "huggingface_hub",
   # Data validation
@@ -53,6 +52,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+mcp = [
+  "mcp>=1.0",
+]
 dev = [
   "pytest>=8",
   "pytest-asyncio",

--- a/specs/001-agentic-pipeline-refactor/contracts/agent-registry.schema.yaml
+++ b/specs/001-agentic-pipeline-refactor/contracts/agent-registry.schema.yaml
@@ -101,4 +101,9 @@ properties:
           maximum: 1800
         paid_opt_in:
           type: boolean
-          const: false  # v1 invariant: Constitution Principle IV
+          # Default false (Constitution Principle IV free-first). `true` is
+          # sanctioned ONLY via the credit-managed Dartmouth daily-budget
+          # path (issue #295): calls require LLMXIVE_PAID_OPT_IN=1 at
+          # runtime AND live headroom under the daily credit cap
+          # (src/llmxive/backends/credits.py), and must carry a written
+          # justification in the introducing PR.

--- a/specs/022-audit-phase3-followup/paid-backend-justification.md
+++ b/specs/022-audit-phase3-followup/paid-backend-justification.md
@@ -1,0 +1,51 @@
+# Written cost justification — credit-managed paid Dartmouth models
+
+Constitution Principle IV requires that any paid path be (a) technically
+necessary, (b) justified in writing, and (c) encapsulated. This document
+is the written justification for the credit-managed `paid_opt_in`
+backend path (issue #295, scope item 3).
+
+## What was measured (live, 2026-06-10)
+
+| Fact | Value | Evidence |
+|-|-|-|
+| Balance endpoint | `GET https://chat.dartmouth.edu/api/v1/credits/balance` | returns `{"account":"Personal","spend":…,"max_budget":2000.0,"budget_duration":"1d","budget_reset_at":"2026-06-11T03:45:00Z"}` |
+| Daily budget | 2000.00 credits, renews daily 03:45Z (11:45 PM ET) | matches maintainer's report on #295 |
+| Credit unit | **1 credit = $0.001 USD list-price equivalent** | a real claude-haiku call (12 prompt + 4 completion tokens, catalog $1/M-in $5/M-out → $0.000032) moved `spend` by exactly 0.032 credits — ratio 1000.0 |
+| Daily ceiling | ≈ **$2.00/day** of list-price usage | 2000 × $0.001 |
+| Catalog prices | real list prices in `model_info` (haiku $1/$5, sonnet $3/$15, opus $5/$25, gpt-5.5 $5/$30 per Mtok) | `GET /api/models` |
+| Metering | asynchronous, lags seconds–tens of seconds | poll in `test_tiny_paid_call_end_to_end` |
+| Actual dollars charged to the project | **$0.00** | credits are an institutional daily allocation; unused credits do not roll over |
+
+## Why this satisfies Constitution IV
+
+- **(a) Necessity:** the audit (#294) identified the hardest stages
+  (deep paper review) as quality-limited on free models; the maintainer
+  explicitly directed (issue #295 comment) that daily credits "could
+  still satisfy the 'free' requirement, as long as the credits are
+  (a) managed carefully and (b) not exceeded."
+- **(b) Written justification:** this document; per-agent flips of
+  `paid_opt_in: true` each require their own justification in the
+  introducing PR (enforced by the registry pin test
+  `test_every_agent_is_paid_opt_in_false`).
+- **(c) Encapsulation:** the entire paid path is contained in
+  `src/llmxive/backends/credits.py` + one guard block in
+  `DartmouthBackend.chat`. Removing the env switch restores strict
+  free-only behavior with zero other changes; no agent, router, or
+  lifecycle code knows about credits.
+
+## Management controls ("carefully managed, never exceeded")
+
+1. **Default OFF** — paid calls require `LLMXIVE_PAID_OPT_IN=1` at the
+   process level; nothing in CI or cron sets it.
+2. **Budget cap with reserve** — calls are refused once `spend` reaches
+   `LLMXIVE_PAID_BUDGET_FRACTION` (default 0.75) × `max_budget`,
+   leaving a 25% reserve so accounting lag / concurrent runs cannot
+   overshoot the daily budget.
+3. **Fail-closed** — if the balance endpoint is unreachable or returns
+   an unexpected shape, paid calls are refused. Free models never
+   consult the credit layer.
+4. **Honest accounting** — opted-in calls log their real list-price
+   estimate (`cost_estimate_usd = tokens × catalog price`); the run-log
+   invariant still hard-fails any non-zero cost outside the opt-in.
+5. **Observability** — `llmxive credits` shows live spend / cap / reset.

--- a/specs/022-audit-phase3-followup/pilot/RESULTS.md
+++ b/specs/022-audit-phase3-followup/pilot/RESULTS.md
@@ -1,0 +1,73 @@
+# Orchestration-harness pilot — results + decision (issue #295, scope item 1)
+
+**Decision: KEEP THE BESPOKE PIPELINE.** The pilot does not meet the
+audit's adoption threshold ("adopt only if a one-lane pilot reduces
+orchestration LOC and passes the same eval/real-call gates").
+
+## What was run (2026-06-10, real Dartmouth calls)
+
+`smolagents_pilot.py`: the representative implementer micro-lane (read
+tasks.md → implement artifact → write file → validate by executing →
+mark checkbox → report) through a smolagents 1.26.0 `CodeAgent` whose
+`RouterModel` adapter delegates every model call to llmXive's
+`chat_with_fallback` (free-model guard, per-model breakers, peer
+fallback all active). Model: `qwen.qwen3.5-122b` (the pipeline's free
+default). The bespoke lane's gate for the same shape of work is the
+nightly-green `tests/real_call/test_implementer_e2e.py`.
+
+| Run | Config | Outcome |
+|-|-|-|
+| 1 | max_steps=6, default sandbox | **FAILED** — wrote a correct `fib.py` but the sandbox blocked importing/executing the just-written file (its own report: "direct imports and exec/compile are restricted in this environment"); burned steps working around it; hit the step cap before the checkbox + final_answer protocol. 7 LLM calls, 73.4 s. |
+| 2 | max_steps=8, `subprocess` authorized, explicit final_answer instruction | **PASSED** — full protocol (file correct, validated via subprocess, checkbox marked, `T001 COMPLETE`). 7 LLM calls, 62.4 s. |
+
+## Findings against the threshold
+
+1. **Orchestration LOC: net INCREASE, not reduction.** The
+   router-delegating adapter is ~55 LOC and pilot glue ~100 LOC;
+   production wiring (flag at `graph.py:439`, verdict mapping,
+   checkpoint bridging) would add ~150–250 LOC. What it could replace
+   is only the pure step/retry loop of `speckit/implement_cmd.py`
+   (~60–80 of its ~222 LOC) — the rest is llmXive *semantics*
+   (completed/failed/atomize/skipped verdict taxonomy, tasks.md
+   checkbox checkpointing, FAILED-IN-EXECUTION gating) that smolagents
+   does not provide and which would be reimplemented as tools/callbacks
+   around `CodeAgent`. Stage-level orchestration (~580 LOC:
+   run_one_step, kickback cap, scheduler, locks) and the convergence
+   protocol stay in-house regardless (Constitution I).
+
+2. **The audit's headline benefit for this lane — the sandboxed
+   CodeAgent — evaporates in practice.** The implementer's core
+   validation pattern is "execute the file you just wrote"; the default
+   sandbox blocks exactly that (run 1's failure). Making the lane work
+   required authorizing `subprocess` (run 2), i.e. forfeiting the
+   sandbox guarantee that motivated smolagents for this lane.
+
+3. **Gate parity is doubtful:** 1/2 runs completed the protocol; the
+   failure mode (step-cap + sandbox friction) is inherent to the
+   harness's interaction with this lane, not a transient.
+
+4. **What DOES carry forward:** the `RouterModel` adapter pattern is
+   proven — a harness can run entirely inside llmXive's router (guard,
+   breakers, peer fallback intact, honest token/cost accounting). If a
+   future lane genuinely suits a harness (e.g. a long-horizon planning
+   lane on LangGraph), this adapter is the template, and the MCP server
+   (scope item 2) exposes the librarian/claim tools to any such harness
+   without router coupling.
+
+## Dependency hygiene outcomes
+
+- `smolagents` is NOT added to pyproject (pilot-only; installed
+  transiently, uninstalled after the pilot).
+- As-you-go finding: `langgraph>=0.2` had been a *declared but entirely
+  unused* dependency since the original bootstrap commit (`e9814dfc`) —
+  zero imports anywhere in src/ or tests/. Removed (same spirit as the
+  audit's Phase-0 legacy cleanup); if a planning-lane pilot is ever
+  attempted, it should re-add the dependency alongside actual usage.
+
+## Reproduce
+
+```bash
+.venv/bin/pip install smolagents
+.venv/bin/python specs/022-audit-phase3-followup/pilot/smolagents_pilot.py
+.venv/bin/pip uninstall -y smolagents
+```

--- a/specs/022-audit-phase3-followup/pilot/smolagents_pilot.py
+++ b/specs/022-audit-phase3-followup/pilot/smolagents_pilot.py
@@ -1,0 +1,173 @@
+"""One-lane orchestration-harness pilot (issue #295, scope item 1).
+
+Runs the representative implementer micro-lane through a smolagents
+``CodeAgent`` whose model adapter delegates EVERY model call to
+llmXive's router (``chat_with_fallback``: free-model guard, per-model
+circuit breakers, peer-model fallback) — the disqualifying condition is
+a harness that bypasses the router, so the adapter is the heart of the
+pilot.
+
+The micro-lane mirrors what ``speckit/implement_cmd.py`` orchestrates
+for one task: read tasks.md → implement the described artifact → write
+it → validate by executing it → mark the checkbox. The bespoke lane's
+gate for the same shape of work is the existing (nightly-green)
+``tests/real_call/test_implementer_e2e.py``.
+
+Usage (real Dartmouth call, ~1-3 min):
+    .venv/bin/python specs/022-audit-phase3-followup/pilot/smolagents_pilot.py
+
+Decision + measurements: see RESULTS.md next to this file. This pilot
+deliberately lives OUTSIDE src/ — per the audit's adoption threshold it
+is wired into production only if it reduces orchestration LOC and
+passes the same gates.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from smolagents import CodeAgent
+from smolagents.models import ChatMessage as SmolChatMessage
+from smolagents.models import MessageRole, Model
+
+from llmxive.backends.base import ChatMessage
+from llmxive.backends.router import chat_with_fallback
+
+PILOT_MODEL = "qwen.qwen3.5-122b"  # the pipeline's free default
+
+
+class RouterModel(Model):
+    """smolagents Model adapter that delegates to llmXive's router.
+
+    This is the ONLY integration code a smolagents lane needs to stay
+    inside the router (Constitution I + IV: free-model guard, breakers,
+    peer fallback all still apply). Token/cost accounting flows through
+    the normal backend path.
+    """
+
+    def __init__(self, model_id: str = PILOT_MODEL) -> None:
+        super().__init__(model_id=model_id)
+        self.calls: list[dict] = []
+
+    def generate(
+        self,
+        messages: list[SmolChatMessage],
+        stop_sequences: list[str] | None = None,
+        response_format: dict[str, str] | None = None,
+        tools_to_call_from=None,
+        **kwargs,
+    ) -> SmolChatMessage:
+        converted: list[ChatMessage] = []
+        for m in messages:
+            role = str(getattr(m.role, "value", m.role))
+            content = m.content
+            if isinstance(content, list):  # smolagents content blocks
+                content = "\n".join(
+                    str(part.get("text", "")) for part in content
+                    if isinstance(part, dict)
+                )
+            converted.append(ChatMessage(role=role, content=str(content)))
+
+        start = time.monotonic()
+        response = chat_with_fallback(
+            converted,
+            default_backend="dartmouth",
+            fallback_backends=[],
+            model=self.model_id,
+            max_tokens=32_768,  # reasoning-safe budget (see notes/spec-015)
+        )
+        elapsed = time.monotonic() - start
+        text = response.text
+        # smolagents' code parser needs the model's code block; qwen
+        # reasoning models sometimes wrap thoughts — the parser handles
+        # the standard ```python fences itself.
+        if stop_sequences:
+            for stop in stop_sequences:
+                idx = text.find(stop)
+                if idx != -1:
+                    text = text[:idx]
+        self.calls.append(
+            {"seconds": round(elapsed, 1), "chars_out": len(text)}
+        )
+        return SmolChatMessage(role=MessageRole.ASSISTANT, content=text)
+
+
+TASK_TEMPLATE = """You are the implementer for a research-code task. Work
+directory: {workdir}
+
+The file {workdir}/tasks.md contains:
+
+- [ ] T001 Create {workdir}/fib.py defining fib(n) returning the n-th
+  Fibonacci number (fib(0)=0, fib(1)=1), plus an executable check that
+  fib(10) == 55 when the module is run directly.
+
+Complete T001:
+1. Write the implementation to {workdir}/fib.py (use open()/write).
+2. Validate it by importing/executing it and checking fib(10) == 55.
+3. Update {workdir}/tasks.md, replacing "- [ ]" with "- [X]" for T001.
+4. You MUST finish by calling final_answer("T001 COMPLETE") if
+   validation passed; otherwise final_answer with the failure. Do not
+   stop without calling final_answer. To validate the written file you
+   may run it with subprocess ([sys.executable, str(path)]).
+"""
+
+
+def run_pilot() -> dict:
+    workdir = Path(tempfile.mkdtemp(prefix="smolagents-pilot-"))
+    (workdir / "tasks.md").write_text(
+        "- [ ] T001 Create fib.py with fib(n) + self-check\n",
+        encoding="utf-8",
+    )
+
+    model = RouterModel()
+    # Run 2 tuning (recorded in RESULTS.md): run 1 hit the step cap before
+    # the checkbox step, and the default sandbox blocked importing the
+    # just-written module (the implementer's core validate-by-executing
+    # pattern). `subprocess` must be explicitly authorized for file-level
+    # validation — i.e., the sandbox value evaporates for this lane.
+    agent = CodeAgent(
+        tools=[],
+        model=model,
+        max_steps=8,
+        additional_authorized_imports=["pathlib", "importlib", "sys", "subprocess"],
+        verbosity_level=1,
+    )
+
+    start = time.monotonic()
+    result = agent.run(TASK_TEMPLATE.format(workdir=workdir))
+    wall = time.monotonic() - start
+
+    fib_path = workdir / "fib.py"
+    tasks_after = (workdir / "tasks.md").read_text(encoding="utf-8")
+    fib_ok = False
+    if fib_path.exists():
+        ns: dict = {}
+        exec(fib_path.read_text(encoding="utf-8"), ns)  # pilot validation
+        fib_ok = ns["fib"](10) == 55
+
+    return {
+        "final_answer": str(result),
+        "wall_seconds": round(wall, 1),
+        "llm_calls": model.calls,
+        "fib_py_written": fib_path.exists(),
+        "fib_correct": fib_ok,
+        "checkbox_marked": "- [X] T001" in tasks_after or "- [x] T001" in tasks_after,
+        "workdir": str(workdir),
+    }
+
+
+if __name__ == "__main__":
+    outcome = run_pilot()
+    print("\n=== PILOT OUTCOME ===")
+    for key, value in outcome.items():
+        print(f"{key}: {value}")
+    ok = (
+        outcome["fib_correct"]
+        and outcome["checkbox_marked"]
+        and "COMPLETE" in outcome["final_answer"].upper()
+    )
+    print(f"\nPILOT {'PASSED' if ok else 'FAILED'}")
+    sys.exit(0 if ok else 1)

--- a/specs/022-audit-phase3-followup/spec.md
+++ b/specs/022-audit-phase3-followup/spec.md
@@ -1,0 +1,95 @@
+# Spec 022 — Audit #294 Phase 3 follow-up (issue #295)
+
+**Status:** in progress (2026-06-10)
+**Issue:** #295 — orchestration-harness pilot + MCP exposure of librarian/claim
+tools + paid `paid_opt_in` backend policy.
+**Branch:** `022-audit-phase3-followup`
+
+Issue #295 tracks the deliberately-deferred optional phase of audit #294
+(Phases 0–2 landed via spec 021). Three scope items, each with its own
+acceptance bar:
+
+## Scope item 1 — One-lane orchestration-harness pilot
+
+Evaluate replacing parts of the bespoke `src/llmxive/pipeline/` loop
+(checkpointing, retries, context offload) with a harness (`smolagents`
+preferred for the implementer/code-execution lane; LangGraph noted for
+planning lanes).
+
+**Adoption threshold (verbatim intent from the audit):** adopt only if a
+one-lane pilot reduces orchestration LOC and passes the same
+eval/real-call gates; otherwise keep the bespoke pipeline.
+
+**Constraints:**
+- Constitution I: the pilot must not fork the lifecycle state machine —
+  the harness runs the loop, llmXive owns the semantics (stage dicts,
+  convergence protocol, claim layer, git-as-database stay in-house).
+- The pilot must keep ALL model calls inside llmXive's router
+  (`backends/router.py` chat_with_fallback: free-model guard, per-model
+  circuit breakers, peer-model fallback) — a harness that bypasses the
+  router is disqualified outright.
+
+**Method:** the pilot lives in `specs/022-audit-phase3-followup/pilot/`
+(NOT in `src/`) until/unless the adoption threshold is met — wiring a
+permanent flag into production for a rejected harness would itself add
+the orchestration LOC the threshold exists to reduce. The pilot runs the
+representative implementer micro-lane (pick task → LLM implements →
+write file → validate → check off) twice on the same fixture with the
+same free Dartmouth model: once through the bespoke seam, once through a
+smolagents `CodeAgent` whose model adapter delegates to
+`chat_with_fallback`. Measured: orchestration LOC delta; gate parity
+(does the harness lane complete the task the bespoke lane completes).
+Result + decision recorded in `pilot/RESULTS.md`.
+
+**Lane mapping (from the code survey):**
+- Bespoke implementer orchestration: ~222 LOC
+  (`speckit/implement_cmd.py` task picker :52-76, verdict handling
+  :212-456, checkbox checkpointing :412-420; dispatched from
+  `pipeline/graph.py:439`).
+- Stage-level orchestration that stays in-house regardless: ~580 LOC
+  (`graph.py` run_one_step + _decide_next_stage, `_kickback.py`,
+  `scheduler.py`, `lock.py`).
+- Semantics that stay in-house regardless: ~515 LOC (stage dicts,
+  convergence gates, escalation markers, kickback persistence).
+
+## Scope item 2 — MCP servers for librarian + claim-verifier tools
+
+Expose the Semantic Scholar / arXiv / TheoremSearch search-and-verify
+tools and the claims register→resolve→cache layer once via MCP
+(`src/llmxive/mcp_server/`, optional dependency extra `mcp`), so they
+are reusable across whichever harness (or none) is chosen, decoupled
+from the bespoke router.
+
+**Acceptance:** `python -m llmxive.mcp_server` serves stdio MCP; tools
+wrap the existing librarian/claims functions (no reimplementation);
+offline unit test asserts the tool inventory; real-call test drives the
+server over stdio with a real arXiv query + live credit balance.
+
+## Scope item 3 — Credit-managed `paid_opt_in` backend
+
+Maintainer decision (issue #295 comment, 2026-06-10): the Dartmouth
+Chat daily credit allocation may be used for paid models and still
+satisfies free-first, provided credits are (a) managed carefully and
+(b) never exceeded. The exploration the maintainer requested was
+performed live on 2026-06-10 — findings in
+`paid-backend-justification.md` (1 credit = $0.001 list-price
+equivalent; 2000 credits/day ≈ $2.00/day; balance endpoint
+`GET /api/v1/credits/balance`; reset 03:45Z = 11:45 PM ET).
+
+**Acceptance (landed in commit 3a54a28a):**
+- `backends/credits.py`: live balance fetch + FAIL-CLOSED guard;
+  master switch `LLMXIVE_PAID_OPT_IN` (default OFF); budget cap
+  `LLMXIVE_PAID_BUDGET_FRACTION` (default 75% of max_budget).
+- `DartmouthBackend.chat`: paid models pass through the guard instead
+  of the unconditional v1 hard block; opted-in calls log REAL cost
+  estimates.
+- Run-log cost invariant relaxed ONLY under the same switch.
+- Registry schema/types: `paid_opt_in` const-false → boolean default
+  false; the all-false registry pin test remains as visible friction.
+- `llmxive credits` CLI; 17 offline + 3 real-call tests (incl. a tiny
+  opted-in haiku e2e measuring server-side metering).
+
+**Out of scope (future, needs separate justification per agent):**
+actually flipping any registry agent to `paid_opt_in: true` (e.g. deep
+paper review). The machinery is ready; each flip is its own reviewed
+decision.

--- a/src/llmxive/backends/credits.py
+++ b/src/llmxive/backends/credits.py
@@ -1,0 +1,241 @@
+"""Dartmouth Chat daily-credit accounting + the paid-model guard.
+
+Issue #295 scope item 3 (audit #294 Phase 3): Dartmouth Chat grants each
+user a *daily* budget of paid-model credits — measured live on 2026-06-10:
+
+- ``GET {chat base}/api/v1/credits/balance`` returns
+  ``{"account": "Personal", "spend": <credits>, "max_budget": 2000.0,
+  "budget_duration": "1d", "budget_reset_at": "<iso8601>"}``.
+- **1 credit == $0.001 USD-equivalent** (measured: a 12-in/4-out-token
+  claude-haiku call with catalog prices $1/M-in $5/M-out moved ``spend`` by
+  exactly 0.032 credits — a 1000x credits-per-USD ratio). The full daily
+  2000.00 credits therefore correspond to ~$2.00/day of list-price usage.
+- The budget renews daily (observed reset 03:45Z = 11:45 PM ET, matching
+  the maintainer's report on issue #295).
+
+Because the credits cost the project $0 in actual money and renew daily,
+spending them carefully still satisfies Constitution IV (free-first), per
+the maintainer's direction on #295: credits must be (a) managed carefully
+and (b) never exceeded. This module is that management layer:
+
+- Paid calls are OFF by default. They require BOTH the process-level
+  master switch ``LLMXIVE_PAID_OPT_IN=1`` AND headroom under the daily
+  budget cap (``LLMXIVE_PAID_BUDGET_FRACTION``, default 0.75 — paid calls
+  stop once spend reaches 75% of ``max_budget``, leaving a reserve so
+  concurrent runs / accounting lag can never blow the budget).
+- FAIL-CLOSED: if the balance endpoint is unreachable or returns
+  something unparseable, paid calls are refused (free models are wholly
+  unaffected — they never consult this module).
+- The balance is cached briefly (``LLMXIVE_CREDIT_BALANCE_TTL_S``,
+  default 30s) so bursts of paid calls don't hammer the endpoint; the
+  reserve fraction is what makes the short staleness window safe.
+
+Per-agent opt-in remains declared in ``agents/registry.yaml`` via
+``paid_opt_in: true`` (the only sanctioned way to *configure* a paid
+default model — pinned by tests/unit/test_config_consistency.py); this
+module enforces the *runtime* budget side of that contract.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+#: Master switch for paid-model calls (process level). Default OFF.
+PAID_OPT_IN_ENV = "LLMXIVE_PAID_OPT_IN"
+
+#: Fraction of the daily max_budget paid calls may consume (default 0.75).
+BUDGET_FRACTION_ENV = "LLMXIVE_PAID_BUDGET_FRACTION"
+DEFAULT_BUDGET_FRACTION = 0.75
+
+#: How long a fetched balance may be reused before re-fetching (seconds).
+BALANCE_TTL_ENV = "LLMXIVE_CREDIT_BALANCE_TTL_S"
+DEFAULT_BALANCE_TTL_S = 30.0
+
+
+@dataclass(frozen=True)
+class CreditBalance:
+    """A point-in-time snapshot of the Dartmouth daily credit budget."""
+
+    account: str
+    spend: float
+    max_budget: float
+    budget_duration: str
+    budget_reset_at: str
+
+    @property
+    def remaining(self) -> float:
+        return max(0.0, self.max_budget - self.spend)
+
+    @property
+    def usd_equivalent_spend(self) -> float:
+        """Approximate USD value of ``spend`` (1 credit == $0.001)."""
+        return self.spend / 1000.0
+
+
+def _credits_url() -> str:
+    """The credit-balance endpoint, derived from the same chat base URL
+    (and key) used for completions — see dartmouth._cloud_models_url."""
+    try:
+        from langchain_dartmouth.definitions import CLOUD_BASE_URL
+
+        base = CLOUD_BASE_URL
+    except Exception:
+        base = os.environ.get("LCD_CLOUD_BASE_URL", "https://chat.dartmouth.edu/api/")
+    return base.rstrip("/") + "/v1/credits/balance"
+
+
+def fetch_credit_balance(*, timeout: float = 30.0) -> CreditBalance:
+    """Fetch the live daily-credit balance for the configured chat key.
+
+    Raises on any failure (network, auth, unexpected shape) — callers that
+    must not crash use :func:`paid_call_allowed`, which converts every
+    failure into a fail-closed refusal.
+    """
+    from llmxive.backends.dartmouth import _ensure_api_key_env
+
+    _ensure_api_key_env()
+    key = os.environ.get("DARTMOUTH_CHAT_API_KEY")
+    if not key:
+        raise RuntimeError(
+            "DARTMOUTH_CHAT_API_KEY is not set (required to read the "
+            "credit balance)"
+        )
+    import requests  # type: ignore[import-untyped]  # no stubs installed
+
+    resp = requests.get(
+        _credits_url(),
+        headers={"Authorization": f"Bearer {key}"},
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return CreditBalance(
+        account=str(data["account"]),
+        spend=float(data["spend"]),
+        max_budget=float(data["max_budget"]),
+        budget_duration=str(data.get("budget_duration", "")),
+        budget_reset_at=str(data.get("budget_reset_at", "")),
+    )
+
+
+def paid_opt_in_enabled() -> bool:
+    """Whether the process-level paid-model master switch is on."""
+    return os.environ.get(PAID_OPT_IN_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def budget_fraction() -> float:
+    """The fraction of max_budget paid calls may consume (clamped to [0, 1])."""
+    raw = os.environ.get(BUDGET_FRACTION_ENV, "").strip()
+    try:
+        value = float(raw) if raw else DEFAULT_BUDGET_FRACTION
+    except ValueError:
+        logger.warning(
+            "%s=%r is not a number; using default %.2f",
+            BUDGET_FRACTION_ENV,
+            raw,
+            DEFAULT_BUDGET_FRACTION,
+        )
+        value = DEFAULT_BUDGET_FRACTION
+    return min(1.0, max(0.0, value))
+
+
+_BALANCE_CACHE: tuple[float, CreditBalance] | None = None
+
+
+def reset_balance_cache() -> None:
+    """Drop the cached balance (tests; or after a known large spend)."""
+    global _BALANCE_CACHE
+    _BALANCE_CACHE = None
+
+
+def _cached_balance(
+    fetch: Callable[[], CreditBalance],
+    *,
+    now: Callable[[], float] = time.monotonic,
+) -> CreditBalance:
+    global _BALANCE_CACHE
+    raw_ttl = os.environ.get(BALANCE_TTL_ENV, "").strip()
+    try:
+        ttl = float(raw_ttl) if raw_ttl else DEFAULT_BALANCE_TTL_S
+    except ValueError:
+        ttl = DEFAULT_BALANCE_TTL_S
+    t = now()
+    if _BALANCE_CACHE is not None and (t - _BALANCE_CACHE[0]) < ttl:
+        return _BALANCE_CACHE[1]
+    balance = fetch()
+    _BALANCE_CACHE = (t, balance)
+    return balance
+
+
+def paid_call_allowed(
+    model: str,
+    *,
+    fetch: Callable[[], CreditBalance] | None = None,
+) -> tuple[bool, str]:
+    """Decide whether a paid-model call to ``model`` may proceed right now.
+
+    Returns ``(allowed, reason)``. FAIL-CLOSED: any doubt (opt-in off,
+    balance unreachable, budget cap reached, nonsensical budget) refuses.
+    Free models never reach this function — the backend consults it only
+    after :func:`llmxive.backends.dartmouth.is_free_model` says False.
+    """
+    if not paid_opt_in_enabled():
+        return (
+            False,
+            f"paid model {model!r} refused: {PAID_OPT_IN_ENV} is not set "
+            "(Constitution IV: paid credits are opt-in only)",
+        )
+    try:
+        balance = _cached_balance(fetch or fetch_credit_balance)
+    except Exception as exc:
+        return (
+            False,
+            f"paid model {model!r} refused: credit balance unavailable "
+            f"({type(exc).__name__}: {exc}) — failing closed",
+        )
+    if balance.max_budget <= 0:
+        return (
+            False,
+            f"paid model {model!r} refused: daily max_budget is "
+            f"{balance.max_budget!r} (no paid budget on this account)",
+        )
+    cap = budget_fraction() * balance.max_budget
+    if balance.spend >= cap:
+        return (
+            False,
+            f"paid model {model!r} refused: daily credit spend "
+            f"{balance.spend:.2f} has reached the cap {cap:.2f} "
+            f"(= {budget_fraction():.0%} of max_budget "
+            f"{balance.max_budget:.2f}; resets at {balance.budget_reset_at})",
+        )
+    return (
+        True,
+        f"paid model {model!r} allowed: spend {balance.spend:.2f} / cap "
+        f"{cap:.2f} credits (resets at {balance.budget_reset_at})",
+    )
+
+
+__all__ = [
+    "BALANCE_TTL_ENV",
+    "BUDGET_FRACTION_ENV",
+    "CreditBalance",
+    "DEFAULT_BALANCE_TTL_S",
+    "DEFAULT_BUDGET_FRACTION",
+    "PAID_OPT_IN_ENV",
+    "budget_fraction",
+    "fetch_credit_balance",
+    "paid_call_allowed",
+    "paid_opt_in_enabled",
+    "reset_balance_cache",
+]

--- a/src/llmxive/backends/dartmouth.py
+++ b/src/llmxive/backends/dartmouth.py
@@ -449,6 +449,28 @@ def free_chat_models(*, force_refresh: bool = False) -> frozenset[str] | None:
     return _FREE_MODELS_CACHE
 
 
+_MODEL_COSTS_CACHE: dict[str, tuple[float | None, float | None]] = {}
+
+
+def model_token_costs(model: str) -> tuple[float | None, float | None]:
+    """Catalog ``(input, output)`` USD cost-per-token for ``model``.
+
+    Process-cached. Returns ``(None, None)`` when the catalog is
+    unreachable or the model is unlisted — callers treat that as
+    "cost unknown" (never as free).
+    """
+    if model in _MODEL_COSTS_CACHE:
+        return _MODEL_COSTS_CACHE[model]
+    try:
+        for m in _fetch_cloud_models():
+            mid = str(m.get("id") or "")
+            if mid:
+                _MODEL_COSTS_CACHE[mid] = _model_token_costs(m)
+    except Exception:
+        return (None, None)
+    return _MODEL_COSTS_CACHE.get(model, (None, None))
+
+
 def is_free_model(model: str) -> bool:
     """Whether ``model`` is a free Dartmouth chat model (cost-per-token == 0).
 
@@ -571,18 +593,23 @@ class DartmouthBackend(BaseBackend):
         except ImportError as exc:
             raise PermanentBackendError("langchain-core is not installed") from exc
 
-        # Free-only guard (Constitution Principle IV: v1 uses free backends,
-        # cost_estimate_usd == 0). Dartmouth's catalog mixes free self-hosted
-        # models with paid external providers (gpt-5, claude, gemini, ...);
-        # calling a paid model would incur real cost the cost=0.0 invariant
-        # hides. Refuse anything not confirmed free by the live pricing catalog
-        # (or the KNOWN_FREE_MODELS fail-safe).
-        if not is_free_model(model):
-            raise PermanentBackendError(
-                f"Dartmouth model {model!r} is not a free model "
-                "(v1 forbids paid models — Constitution Principle IV); "
-                "see chat.dartmouth.edu/api/models pricing"
-            )
+        # Free-first guard (Constitution Principle IV). Dartmouth's catalog
+        # mixes free self-hosted models with paid external providers (gpt-5,
+        # claude, gemini, ...). Paid models are refused UNLESS the
+        # credit-managed opt-in path approves the call: the process-level
+        # LLMXIVE_PAID_OPT_IN master switch must be on AND the live daily
+        # credit budget must have headroom (issue #295: 2000 credits/day =
+        # ~$2.00 list-price equivalent, renewing daily — costing the project
+        # $0 in actual money when managed within budget). The guard FAILS
+        # CLOSED (balance unreachable -> refuse). See backends/credits.py.
+        paid_call = not is_free_model(model)
+        if paid_call:
+            from llmxive.backends.credits import paid_call_allowed
+
+            allowed, reason = paid_call_allowed(model)
+            if not allowed:
+                raise PermanentBackendError(f"Dartmouth: {reason}")
+            _log.info("dartmouth: %s", reason)
 
         client = self._client(model)
         from langchain_core.messages import BaseMessage as _BaseMessage
@@ -682,11 +709,23 @@ class DartmouthBackend(BaseBackend):
                     f"(finish_reason={finish_reason!r}, additional_kwargs={getattr(reply, 'additional_kwargs', {})})"
                 )
 
+            # Free models cost 0.0; an opted-in paid call reports its real
+            # list-price estimate from the catalog pricing x token usage so
+            # run logs account honestly for credit consumption (#295).
+            cost_estimate = 0.0
+            if paid_call:
+                usage = meta.get("token_usage", {}) or {}
+                in_cost, out_cost = model_token_costs(model)
+                cost_estimate = (
+                    float(usage.get("prompt_tokens") or 0) * (in_cost or 0.0)
+                    + float(usage.get("completion_tokens") or 0) * (out_cost or 0.0)
+                )
+
             return ChatResponse(
                 text=text_out,
                 model=model,
                 backend=self.name,
-                cost_estimate_usd=0.0,  # Dartmouth Chat is free for community members
+                cost_estimate_usd=cost_estimate,
             )
 
         # Centralized retry — absorbs brief transient failures (Dartmouth
@@ -723,4 +762,5 @@ __all__ = [
     "DartmouthBackend",
     "free_chat_models",
     "is_free_model",
+    "model_token_costs",
 ]

--- a/src/llmxive/backends/router.py
+++ b/src/llmxive/backends/router.py
@@ -146,11 +146,13 @@ def chat_with_model_fallback(
     that is the fix for the per-model breaker composing with fallback. A
     NON-Unavailable ``PermanentBackendError`` on the primary (paid-model guard, a
     hard refusal) still aborts immediately (no peer walk). When the whole chain
-    is exhausted, if ANY failure was ``BackendUnavailable`` we raise
+    is exhausted, if ANY failure was ``BackendUnavailable`` OR transient-class
+    (``ModelDownError`` / ``TransientBackendError``) we raise
     ``BackendUnavailable`` (a true full-endpoint outage → the run loop's existing
-    clean-abort path fires, preserving the breaker's anti-thrash purpose);
-    otherwise we raise the aggregate ``BackendError``. On a ``model=None`` call
-    there is no chain to walk — it is a single signature-degrading ``chat``.
+    clean-abort path fires with state preserved — NEVER a human escalation);
+    only an all-permanent exhaustion raises the aggregate ``BackendError``. On a
+    ``model=None`` call there is no chain to walk — it is a single
+    signature-degrading ``chat``.
     """
     import time as _time
 
@@ -163,6 +165,7 @@ def chat_with_model_fallback(
     models_to_try = [model] + [m for m in MODEL_FALLBACKS.get(model, []) if m != model]
     errors: list[str] = []
     saw_unavailable = False
+    saw_transient = False
     for model_idx, m in enumerate(models_to_try):
         attempts = 3 if model_idx == 0 else 1
         for attempt in range(attempts):
@@ -187,9 +190,11 @@ def chat_with_model_fallback(
                 # maintenance redirect) — not flickering. Retrying the SAME model
                 # burns another full deadline / will just re-redirect; skip the
                 # remaining same-model attempts and fall straight to the next peer.
+                saw_transient = True
                 errors.append(f"{m}(model-down attempt {attempt + 1}): {exc}")
                 break
             except TransientBackendError as exc:
+                saw_transient = True
                 errors.append(f"{m}(transient attempt {attempt + 1}): {exc}")
                 if "reasoning budget exhausted" in str(exc):
                     break
@@ -217,6 +222,19 @@ def chat_with_model_fallback(
     # true full-endpoint outage (rather than as a recoverable BackendError).
     if saw_unavailable:
         raise BackendUnavailable(detail)
+    # An all-failed chain whose failures were TRANSIENT-class (deadline hangs,
+    # 302→outage.dartmouth.edu redirects, 5xx flaps on EVERY model) is a
+    # full-endpoint outage that will heal on its own — the run must abort
+    # cleanly with state preserved, exactly like the breaker-open case. Before
+    # this clause, such an exhaustion raised plain BackendError, which the
+    # stage-panel's generic engine-failure handler escalated to
+    # human_input_needed — observed live on PROJ-552 (dispatch 27306941191,
+    # 2026-06-10: qwen deadline-hang + gpt-oss/gemma both 302→outage). A
+    # transient infrastructure outage is NOT human-actionable (bug-#8 family).
+    if saw_transient:
+        raise BackendUnavailable(detail)
+    # All-permanent exhaustion (every peer hard-rejected) — genuinely
+    # engine/config-actionable, keep the recoverable aggregate error.
     raise BackendError(detail)
 
 

--- a/src/llmxive/cli.py
+++ b/src/llmxive/cli.py
@@ -183,6 +183,24 @@ def _cmd_backends_list_models(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_credits(args: argparse.Namespace) -> int:
+    """Show the live Dartmouth daily paid-credit balance + guard status."""
+    from llmxive.backends import credits as credits_mod
+
+    balance = credits_mod.fetch_credit_balance()
+    cap = credits_mod.budget_fraction() * balance.max_budget
+    print(f"account:          {balance.account}")
+    print(
+        f"spend:            {balance.spend:.2f} / {balance.max_budget:.2f} "
+        f"credits (~${balance.usd_equivalent_spend:.4f} of "
+        f"~${balance.max_budget / 1000.0:.2f} list-price equivalent)"
+    )
+    print(f"paid-call cap:    {cap:.2f} credits ({credits_mod.budget_fraction():.0%} of max_budget)")
+    print(f"resets at:        {balance.budget_reset_at} ({balance.budget_duration})")
+    print(f"paid opt-in:      {'ON' if credits_mod.paid_opt_in_enabled() else 'off'} ({credits_mod.PAID_OPT_IN_ENV})")
+    return 0
+
+
 def _cmd_auth_set(args: argparse.Namespace) -> int:
     if args.key:
         key = args.key
@@ -836,6 +854,12 @@ def build_parser() -> argparse.ArgumentParser:
     p_lm = backends_subs.add_parser("list-models", help="list models for a backend")
     p_lm.add_argument("--backend", required=True, choices=["dartmouth", "local"])
     p_lm.set_defaults(func=_cmd_backends_list_models)
+
+    p_credits = subs.add_parser(
+        "credits",
+        help="show the Dartmouth daily paid-credit balance (issue #295)",
+    )
+    p_credits.set_defaults(func=_cmd_credits)
 
     p_auth = subs.add_parser("auth", help="manage local Dartmouth Chat credentials")
     auth_subs = p_auth.add_subparsers(dest="auth_cmd", required=True)

--- a/src/llmxive/convergence/revisers/_reviser_response.py
+++ b/src/llmxive/convergence/revisers/_reviser_response.py
@@ -361,6 +361,27 @@ def build_concern_responses(
         if isinstance(cid, str):
             by_id[cid] = raw
 
+    # Observability (notes/spec-015 follow-up): when concerns get padded
+    # ``<missing>``, record WHY in ``what_changed`` so the convergence trail
+    # distinguishes "the whole reply parsed to zero per-concern responses"
+    # (format drift / truncation — the PROJ-552 plan-009 R2 shape) from "the
+    # model answered other concerns but skipped this one". A total parse
+    # failure raises upstream and never reaches this padding path.
+    if not by_id:
+        missing_reason = (
+            "reviser reply parsed to ZERO per-concern responses "
+            f"({len(responses_raw)} raw entries, none with a concern_id) — "
+            "likely response-format drift or truncation; no response for "
+            "this concern"
+        )
+    else:
+        answered_preview = ", ".join(sorted(by_id)[:5])
+        missing_reason = (
+            "reviser produced no response for this concern (it DID respond "
+            f"to {len(by_id)} other concern(s): {answered_preview}"
+            f"{', …' if len(by_id) > 5 else ''})"
+        )
+
     out: list[ConcernResponse] = []
     for c in concerns:
         r = by_id.get(c.id)
@@ -369,7 +390,7 @@ def build_concern_responses(
                 ConcernResponse(
                     concern_id=c.id,
                     response="<missing>",
-                    what_changed="reviser produced no response for this concern",
+                    what_changed=missing_reason,
                     artifacts_changed=[],
                 )
             )

--- a/src/llmxive/mcp_server/README.md
+++ b/src/llmxive/mcp_server/README.md
@@ -1,0 +1,42 @@
+# llmXive MCP server
+
+Exposes the librarian search-and-verify tools and the claims
+register→resolve→cache layer over the
+[Model Context Protocol](https://modelcontextprotocol.io), decoupled from the
+bespoke pipeline router (issue #295, scope item 2).
+
+## Install & run
+
+```bash
+pip install -e ".[mcp]"        # adds the optional MCP SDK dependency
+python -m llmxive.mcp_server   # stdio MCP server, name "llmxive"
+```
+
+Honors `LLMXIVE_REPO_ROOT` (via `llmxive.config.repo_root()`) for the claim
+register location, and the usual credential resolution (env vars first, then
+`~/.config/llmxive/credentials.toml`).
+
+## Tools
+
+| Tool | Wraps | Needs |
+|-|-|-|
+| `search_semantic_scholar(query, limit=10)` | `librarian.search.SemanticScholarClient.search_papers` | `SEMANTIC_SCHOLAR_API_KEY` |
+| `search_arxiv(query, max_results=10)` | `librarian.search.ArxivClient.search` | — |
+| `get_arxiv_paper(arxiv_id)` | `librarian.search.ArxivClient.get_by_id` | — |
+| `search_theorems(term, limit=10)` | `librarian.theoremsearch.TheoremSearchClient.search` | — |
+| `resolve_reference(kind, value)` | `librarian.verify.resolve_reference` | — |
+| `register_and_resolve_claims(text, artifact_path="mcp-adhoc.md")` | `claims.service.process_document` (project `mcp-adhoc`) | Dartmouth Chat key |
+| `claim_status(claim_id)` | `state.claims.get` (scans all registers) | — |
+| `credit_balance()` | `backends.credits.fetch_credit_balance` | Dartmouth Chat key |
+
+Missing keys / failures return an `{"error": "..."}` payload instead of
+crashing the server.
+
+## Claude Code client config
+
+```bash
+claude mcp add llmxive -- python -m llmxive.mcp_server
+```
+
+(Use the python interpreter of the environment where `llmxive[mcp]` is
+installed, e.g. `claude mcp add llmxive -- /path/to/.venv/bin/python -m llmxive.mcp_server`.)

--- a/src/llmxive/mcp_server/__init__.py
+++ b/src/llmxive/mcp_server/__init__.py
@@ -1,0 +1,16 @@
+"""MCP server exposing llmXive librarian + claims tools (issue #295, item 2).
+
+This package is named ``mcp_server`` (not ``mcp``) so it never shadows the
+official MCP python SDK package. The SDK itself is an *optional* dependency
+(``pip install llmxive[mcp]``) and is imported lazily inside
+:func:`llmxive.mcp_server.server.create_server`, so ``import llmxive`` (and
+``import llmxive.mcp_server``) stays light and works without the SDK.
+
+Run a stdio server with::
+
+    python -m llmxive.mcp_server
+"""
+
+from llmxive.mcp_server.server import create_server, main
+
+__all__ = ["create_server", "main"]

--- a/src/llmxive/mcp_server/__main__.py
+++ b/src/llmxive/mcp_server/__main__.py
@@ -1,0 +1,23 @@
+"""Entry point: ``python -m llmxive.mcp_server`` runs a stdio MCP server."""
+
+from __future__ import annotations
+
+import sys
+
+
+def _run() -> None:
+    try:
+        import mcp  # noqa: F401 — presence check for a clear install hint
+    except ImportError:
+        from llmxive.mcp_server.server import MISSING_MCP_SDK_MSG
+
+        print(f"error: {MISSING_MCP_SDK_MSG}", file=sys.stderr)
+        raise SystemExit(1) from None
+
+    from llmxive.mcp_server import main
+
+    main()
+
+
+if __name__ == "__main__":
+    _run()

--- a/src/llmxive/mcp_server/server.py
+++ b/src/llmxive/mcp_server/server.py
@@ -1,0 +1,287 @@
+"""llmXive MCP server — librarian search/verify + claims register→resolve→cache.
+
+Issue #295 scope item 2: expose the librarian's search-and-verify tools and
+the claim layer (spec 016/020) over the Model Context Protocol, decoupled
+from the bespoke pipeline router, so ANY MCP client (Claude Code, etc.) can
+drive them directly.
+
+Every tool is a thin wrapper over an existing llmxive function — no logic is
+reimplemented here. Results are plain JSON-serializable dicts/lists/strings;
+failures (missing API key, network error) come back as a clear ``{"error":
+...}`` payload instead of crashing the server.
+
+The MCP SDK is imported lazily inside :func:`create_server` so importing
+``llmxive`` (or this module) never requires the optional ``mcp`` extra.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover — typing only; SDK is optional at runtime
+    from mcp.server.fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+#: Abstracts are trimmed to this many characters in tool output.
+_ABSTRACT_SNIPPET_CHARS = 500
+
+#: Ad-hoc MCP calls register claims under this synthetic project id, keeping
+#: them in their own ``state/claims/<id>.yaml`` register, away from real
+#: pipeline projects (the underlying store honors LLMXIVE_REPO_ROOT via
+#: llmxive.config.repo_root()).
+MCP_ADHOC_PROJECT_ID = "mcp-adhoc"
+
+MISSING_MCP_SDK_MSG = (
+    "The MCP python SDK is not installed. Install the optional extra with: "
+    'pip install "llmxive[mcp]"'
+)
+
+
+def _candidate_to_dict(candidate: Any) -> dict[str, Any]:
+    """Convert a librarian ``Candidate`` dataclass to a JSON-friendly dict."""
+    abstract = candidate.claimed_abstract or ""
+    if len(abstract) > _ABSTRACT_SNIPPET_CHARS:
+        abstract = abstract[: _ABSTRACT_SNIPPET_CHARS - 1].rstrip() + "…"
+    return {
+        "backend": candidate.backend,
+        "id": candidate.primary_pointer,
+        "title": candidate.claimed_title,
+        "authors": candidate.claimed_authors,
+        "year": candidate.claimed_year,
+        "venue": candidate.claimed_venue,
+        "abstract_snippet": abstract or None,
+    }
+
+
+def _claim_to_dict(claim: Any) -> dict[str, Any]:
+    """Serialize a Claim via the store's canonical dict form."""
+    from llmxive.state.claims import _claim_to_dict as store_claim_to_dict
+
+    return store_claim_to_dict(claim)
+
+
+def _error(message: str) -> dict[str, str]:
+    return {"error": message}
+
+
+def create_server() -> FastMCP:
+    """Build the FastMCP server with all llmXive tools registered."""
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ImportError as exc:  # pragma: no cover — exercised via __main__
+        raise ImportError(MISSING_MCP_SDK_MSG) from exc
+
+    server = FastMCP("llmxive")
+
+    @server.tool()
+    def search_semantic_scholar(query: str, limit: int = 10) -> list[dict[str, Any]] | dict[str, str]:
+        """Search Semantic Scholar for papers by keyword query.
+
+        Returns a list of candidate records (backend, id, title, authors,
+        year, venue, abstract_snippet). Requires SEMANTIC_SCHOLAR_API_KEY
+        (free tier) — returns an error payload if the key is missing.
+        """
+        from llmxive.librarian.search import SemanticScholarClient
+
+        client = SemanticScholarClient()
+        if not client.has_key:
+            return _error(
+                "SEMANTIC_SCHOLAR_API_KEY is not configured — request a free "
+                "key at https://www.semanticscholar.org/product/api#api-key-form "
+                "and store it with llmxive.credentials.save_semantic_scholar_key()."
+            )
+        try:
+            return [_candidate_to_dict(c) for c in client.search_papers(query, limit=limit)]
+        except Exception as exc:
+            return _error(f"semantic scholar search failed: {type(exc).__name__}: {exc}")
+
+    @server.tool()
+    def search_arxiv(query: str, max_results: int = 10) -> list[dict[str, Any]] | dict[str, str]:
+        """Search arXiv for papers by keyword query.
+
+        Returns a list of candidate records (backend, id, title, authors,
+        year, venue, abstract_snippet). Rate-limited per arXiv's guidelines;
+        sustained 429s trip a 60s circuit breaker and yield an empty list.
+        """
+        from llmxive.librarian.search import ArxivClient
+
+        try:
+            return [
+                _candidate_to_dict(c)
+                for c in ArxivClient().search(query, max_results=max_results)
+            ]
+        except Exception as exc:
+            return _error(f"arxiv search failed: {type(exc).__name__}: {exc}")
+
+    @server.tool()
+    def get_arxiv_paper(arxiv_id: str) -> dict[str, Any]:
+        """Fetch one arXiv paper by id (e.g. '1706.03762' or '1706.03762v3').
+
+        Returns a candidate record (backend, id, title, authors, year, venue,
+        abstract_snippet), or an error payload if the id does not resolve.
+        """
+        from llmxive.librarian.search import ArxivClient
+
+        try:
+            candidate = ArxivClient().get_by_id(arxiv_id)
+        except Exception as exc:
+            return _error(f"arxiv lookup failed: {type(exc).__name__}: {exc}")
+        if candidate is None:
+            return _error(f"no arXiv paper found for id {arxiv_id!r}")
+        return _candidate_to_dict(candidate)
+
+    @server.tool()
+    def search_theorems(term: str, limit: int = 10) -> list[dict[str, Any]] | dict[str, str]:
+        """Search TheoremSearch for mathematical theorems, resolved to arXiv.
+
+        Returns a list of candidate records for arXiv-sourced theorem hits.
+        An unavailable TheoremSearch backend returns an error payload (the
+        service is optional enrichment, not a hard dependency).
+        """
+        from llmxive.backends.base import TransientBackendError
+        from llmxive.librarian.theoremsearch import TheoremSearchClient
+
+        try:
+            return [
+                _candidate_to_dict(c)
+                for c in TheoremSearchClient().search(term, limit=limit)
+            ]
+        except TransientBackendError as exc:
+            return _error(f"theoremsearch unavailable: {exc}")
+        except Exception as exc:
+            return _error(f"theorem search failed: {type(exc).__name__}: {exc}")
+
+    @server.tool()
+    def resolve_reference(kind: str, value: str) -> dict[str, Any]:
+        """Existence-check one reference: kind is 'url', 'arxiv', or 'doi'.
+
+        Resolves the reference through doi.org / arxiv.org / the URL itself
+        (real HTTP, redirect-following). Returns state ('resolved' |
+        'present_ambiguous' | 'unreachable'), the final resolved_url, the
+        http_status, a reason, and a boolean 'present'. Anti-fabrication
+        existence check only — titles are not compared.
+        """
+        from llmxive.librarian.verify import resolve_reference as _resolve
+
+        if kind not in ("url", "arxiv", "doi"):
+            return _error(f"kind must be one of 'url', 'arxiv', 'doi' (got {kind!r})")
+        try:
+            outcome = _resolve(kind, value)
+        except Exception as exc:
+            return _error(f"reference resolution failed: {type(exc).__name__}: {exc}")
+        return {
+            "state": outcome.state,
+            "resolved_url": outcome.resolved_url,
+            "http_status": outcome.http_status,
+            "reason": outcome.reason,
+            "present": outcome.present,
+        }
+
+    @server.tool()
+    def register_and_resolve_claims(text: str, artifact_path: str = "mcp-adhoc.md") -> dict[str, Any]:
+        """Run the claim layer on a document: extract→register→resolve→render.
+
+        Extracts check-worthy claims from the text with an LLM, registers
+        them in the durable claim register (state/claims/), resolves each
+        against authoritative sources (reusing cached VERIFIED claims), and
+        returns the rendered text plus the claim records and gate report.
+        Requires a Dartmouth Chat API key — returns an error payload if the
+        key is unavailable.
+        """
+        from llmxive.backends.dartmouth import _ensure_api_key_env
+        from llmxive.backends.router import make_backend
+        from llmxive.claims.service import process_document
+        from llmxive.config import repo_root
+
+        _ensure_api_key_env()
+        import os
+
+        if not os.environ.get("DARTMOUTH_CHAT_API_KEY"):
+            return _error(
+                "DARTMOUTH_CHAT_API_KEY is not available (checked the environment "
+                "and ~/.config/llmxive/credentials.toml) — the claim layer needs "
+                "an LLM backend for extraction."
+            )
+        try:
+            backend = make_backend("dartmouth")
+            # model=None → the claim layer's default reasoning model with the
+            # router's standard peer-model fallback chain (qwen → gpt-oss →
+            # gemma), exactly as the pipeline invokes it.
+            rendered, claims, gate_report = process_document(
+                text,
+                artifact_path=artifact_path,
+                project_id=MCP_ADHOC_PROJECT_ID,
+                backend=backend,
+                model=None,
+                repo_root=repo_root(),
+            )
+        except Exception as exc:
+            return _error(f"claim processing failed: {type(exc).__name__}: {exc}")
+        return {
+            "rendered_text": rendered,
+            "claims": [_claim_to_dict(c) for c in claims],
+            "gate_report": {
+                "blocked": gate_report.blocked,
+                "unresolved_markers": list(gate_report.unresolved_markers),
+            },
+            "project_id": MCP_ADHOC_PROJECT_ID,
+        }
+
+    @server.tool()
+    def claim_status(claim_id: str) -> dict[str, Any]:
+        """Look up one claim by id in the durable claim register.
+
+        Scans every per-project register under state/claims/ and returns the
+        claim record (status, kind, raw/canonical text, resolved value,
+        evidence, resolver, timestamps) plus the owning project_id, or an
+        error payload if the claim id is unknown.
+        """
+        from llmxive.config import repo_root
+        from llmxive.state import claims as claim_store
+
+        claims_dir = repo_root() / "state" / "claims"
+        if not claims_dir.is_dir():
+            return _error(f"no claim registers exist yet under {claims_dir}")
+        for register in sorted(claims_dir.glob("*.yaml")):
+            project_id = register.stem
+            try:
+                claim = claim_store.get(project_id, claim_id)
+            except Exception as exc:
+                logger.warning("claim register %s unreadable: %s", register, exc)
+                continue
+            if claim is not None:
+                payload = _claim_to_dict(claim)
+                payload["project_id"] = project_id
+                return payload
+        return _error(f"claim {claim_id!r} not found in any register under {claims_dir}")
+
+    @server.tool()
+    def credit_balance() -> dict[str, Any]:
+        """Fetch the live Dartmouth Chat daily paid-credit balance.
+
+        Returns account, spend, max_budget, budget_duration, budget_reset_at,
+        and the derived remaining credits. Requires a Dartmouth Chat API key
+        — returns an error payload on any failure (network, auth).
+        """
+        from llmxive.backends.credits import fetch_credit_balance
+
+        try:
+            balance = fetch_credit_balance()
+        except Exception as exc:
+            return _error(f"credit balance unavailable: {type(exc).__name__}: {exc}")
+        payload = dataclasses.asdict(balance)
+        payload["remaining"] = balance.remaining
+        return payload
+
+    return server
+
+
+def main() -> None:
+    """Run the llmXive MCP server over stdio (``python -m llmxive.mcp_server``)."""
+    create_server().run()
+
+
+__all__ = ["MCP_ADHOC_PROJECT_ID", "MISSING_MCP_SDK_MSG", "create_server", "main"]

--- a/src/llmxive/state/runlog.py
+++ b/src/llmxive/state/runlog.py
@@ -29,30 +29,38 @@ def _state_root() -> Path:
 
 
 class CostInvariantError(RuntimeError):
-    """Raised when an agent attempts to log a non-zero cost in v1.
+    """Raised when an agent logs a non-zero cost without paid opt-in.
 
-    Per FR-020 + Constitution Principle IV (Free First), every backend
-    in the v1 agent registry has `is_paid: false` and every agent has
-    `paid_opt_in: false`. A run-log entry with cost_estimate_usd > 0
-    therefore indicates either (a) a backend implementation bug or (b)
-    a registry compromise — both warrant a hard failure.
+    Per FR-020 + Constitution Principle IV (Free First), runs default to
+    free models only (``cost_estimate_usd == 0.0``). The ONLY sanctioned
+    non-zero-cost path is the credit-managed Dartmouth daily budget
+    (issue #295), active solely when ``LLMXIVE_PAID_OPT_IN`` is set —
+    see :mod:`llmxive.backends.credits`. A non-zero cost WITHOUT that
+    switch indicates either (a) a backend implementation bug or (b) a
+    registry compromise — both warrant a hard failure.
     """
 
 
 def _check_cost_invariant(entry: RunLogEntry) -> None:
-    """T103: hard-block any non-zero cost in v1.
+    """T103: hard-block any non-zero cost unless paid opt-in is active.
 
-    The agent registry's contract schema asserts paid_opt_in is
-    `const false`; this guard catches the case where the registry has
-    been edited to allow a paid backend without also relaxing the
-    schema.
+    When ``LLMXIVE_PAID_OPT_IN`` is enabled, opted-in paid calls log
+    their real list-price estimate (honest accounting of credit
+    consumption); the backend's credit guard
+    (:func:`llmxive.backends.credits.paid_call_allowed`) enforces the
+    daily-budget cap before any such call is made.
     """
     if entry.cost_estimate_usd > 0:
+        from llmxive.backends.credits import paid_opt_in_enabled
+
+        if paid_opt_in_enabled():
+            return
         raise CostInvariantError(
             f"agent {entry.agent_name!r} attempted to log "
             f"cost_estimate_usd={entry.cost_estimate_usd} on backend "
-            f"{entry.backend.value!r}; the v1 invariant is 0.0 "
-            f"(see contracts/agent-registry.schema.yaml is_paid:const false)"
+            f"{entry.backend.value!r} without LLMXIVE_PAID_OPT_IN; the "
+            f"free-first invariant is 0.0 (the only sanctioned paid path "
+            f"is the credit-managed opt-in — issue #295, backends/credits.py)"
         )
 
 

--- a/src/llmxive/types.py
+++ b/src/llmxive/types.py
@@ -439,7 +439,12 @@ class AgentRegistryEntry(_Strict):
     default_model: str = Field(min_length=1)
     tools: list[SnakeNameField] = Field(default_factory=list)
     wall_clock_budget_seconds: int = Field(ge=30, le=1800)
-    paid_opt_in: Literal[False]  # v1 invariant: Constitution Principle IV
+    # Default False (Constitution Principle IV free-first). True is
+    # sanctioned ONLY via the credit-managed Dartmouth daily-budget path
+    # (issue #295; runtime-gated by LLMXIVE_PAID_OPT_IN + the live credit
+    # cap in backends/credits.py) and requires written justification in
+    # the introducing PR.
+    paid_opt_in: bool = False
 
 
 class AgentRegistry(_Strict):

--- a/tests/integration/test_free_backend_only.py
+++ b/tests/integration/test_free_backend_only.py
@@ -35,25 +35,28 @@ def test_every_backend_is_free() -> None:
 
 
 def test_every_agent_is_paid_opt_in_false() -> None:
+    """Pin: no registry agent currently opts into paid models.
+
+    paid_opt_in=True is now schema-legal (issue #295: the credit-managed
+    Dartmouth daily-budget path), but flipping an agent requires a written
+    justification in the introducing PR — updating this pin is the visible
+    friction that enforces it (Constitution IV).
+    """
     reg = registry_loader.load()
     for agent in reg.agents:
         assert agent.paid_opt_in is False, (
-            f"agent {agent.name!r} has paid_opt_in=True; v1 invariant is False "
-            f"(FR-020)"
+            f"agent {agent.name!r} has paid_opt_in=True; flipping this pin "
+            f"requires a written Constitution-IV justification (issue #295)"
         )
 
 
-def test_runlog_writer_blocks_non_zero_cost(tmp_path: Path) -> None:
-    """A run-log entry with cost_estimate_usd > 0 must raise."""
-    for sub in ("projects", "run-log", "locks", "citations"):
-        (tmp_path / "state" / sub).mkdir(parents=True, exist_ok=True)
-
+def _cost_entry(project_id: str, cost: float) -> RunLogEntry:
     now = datetime.now(UTC)
-    entry = RunLogEntry(
+    return RunLogEntry(
         run_id="11111111-1111-1111-1111-111111111111",
         entry_id="22222222-2222-2222-2222-222222222222",
         agent_name="test_agent",
-        project_id="PROJ-001-cost",
+        project_id=project_id,
         task_id="33333333-3333-3333-3333-333333333333",
         inputs=[],
         outputs=[],
@@ -63,11 +66,41 @@ def test_runlog_writer_blocks_non_zero_cost(tmp_path: Path) -> None:
         started_at=now,
         ended_at=now,
         outcome=Outcome.SUCCESS,
-        cost_estimate_usd=0.000001,  # any non-zero
+        cost_estimate_usd=cost,
     )
+
+
+def test_runlog_writer_blocks_non_zero_cost(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A run-log entry with cost_estimate_usd > 0 must raise without opt-in."""
+    monkeypatch.delenv("LLMXIVE_PAID_OPT_IN", raising=False)
+    for sub in ("projects", "run-log", "locks", "citations"):
+        (tmp_path / "state" / sub).mkdir(parents=True, exist_ok=True)
+
+    entry = _cost_entry("PROJ-001-cost", 0.000001)  # any non-zero
 
     with pytest.raises(CostInvariantError):
         append_entry(entry, repo_root=tmp_path)
+
+
+def test_runlog_writer_allows_cost_with_paid_opt_in(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With LLMXIVE_PAID_OPT_IN set, an opted-in paid call's real cost
+    estimate is logged (honest credit accounting — issue #295)."""
+    monkeypatch.setenv("LLMXIVE_PAID_OPT_IN", "1")
+    for sub in ("projects", "run-log", "locks", "citations"):
+        (tmp_path / "state" / sub).mkdir(parents=True, exist_ok=True)
+
+    entry = _cost_entry("PROJ-003-paid", 0.000032)
+
+    written = append_entry(entry, repo_root=tmp_path)
+    assert written.exists()
+    import json
+
+    logged = json.loads(written.read_text(encoding="utf-8").strip())
+    assert logged["cost_estimate_usd"] == pytest.approx(0.000032)
 
 
 def test_zero_cost_runlog_succeeds(tmp_path: Path) -> None:

--- a/tests/real_call/test_mcp_server_real.py
+++ b/tests/real_call/test_mcp_server_real.py
@@ -1,0 +1,78 @@
+"""Real-call: llmXive MCP server over stdio (issue #295, scope item 2).
+
+Spawns ``python -m llmxive.mcp_server`` as a real subprocess and drives it
+with the official MCP SDK client — real transport, real network calls, no
+mocks. Gated by LLMXIVE_REAL_TESTS=1 (tests/conftest.py); the arXiv search
+is additionally marked ``slow`` (rate-limited external API, ~seconds-to-
+minutes under backoff) so it runs in the nightly suite, not the PR gate.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mcp", reason="optional extra not installed: pip install llmxive[mcp]")
+
+import anyio
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from llmxive.credentials import load_dartmouth_key
+
+_SERVER_PARAMS = StdioServerParameters(
+    command=sys.executable, args=["-m", "llmxive.mcp_server"]
+)
+
+
+def _call_tool(name: str, arguments: dict[str, Any]) -> Any:
+    """Spawn the stdio server, call one tool, return the decoded payload."""
+
+    async def _go() -> Any:
+        async with stdio_client(_SERVER_PARAMS) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                result = await session.call_tool(name, arguments)
+                assert not result.isError, f"tool {name} errored: {result.content}"
+                if result.structuredContent is not None:
+                    structured = result.structuredContent
+                    # FastMCP wraps non-dict returns as {"result": ...}.
+                    if isinstance(structured, dict) and set(structured) == {"result"}:
+                        return structured["result"]
+                    return structured
+                # Fall back to the text content (JSON-encoded by FastMCP).
+                texts = [c.text for c in result.content if hasattr(c, "text")]
+                assert texts, f"tool {name} returned no content"
+                return json.loads(texts[0])
+
+    return anyio.run(_go)
+
+
+@pytest.mark.slow
+def test_search_arxiv_over_stdio_returns_real_results() -> None:
+    payload = _call_tool(
+        "search_arxiv", {"query": "knot theory crossing number", "max_results": 2}
+    )
+    assert isinstance(payload, list), f"expected list of candidates, got {payload!r}"
+    assert len(payload) >= 1
+    first = payload[0]
+    assert first.get("backend") == "arxiv"
+    assert first.get("title"), f"first result has no title: {first!r}"
+    assert first.get("id"), f"first result has no arXiv id: {first!r}"
+
+
+@pytest.mark.skipif(
+    not load_dartmouth_key(),
+    reason="Dartmouth Chat API key unavailable (env + credentials.toml)",
+)
+def test_credit_balance_over_stdio() -> None:
+    payload = _call_tool("credit_balance", {})
+    assert isinstance(payload, dict), f"expected dict, got {payload!r}"
+    assert "error" not in payload, f"credit_balance failed: {payload}"
+    assert payload["max_budget"] > 0
+    assert {"account", "spend", "budget_duration", "budget_reset_at", "remaining"} <= set(
+        payload
+    )

--- a/tests/real_call/test_paid_credits_real.py
+++ b/tests/real_call/test_paid_credits_real.py
@@ -1,0 +1,99 @@
+"""Real-call: Dartmouth daily-credit balance + the paid-model guard (issue #295).
+
+Fast (PR-gate) parts: fetch the real balance endpoint; confirm the backend
+refuses a paid model without opt-in (no spend incurred).
+
+Slow (nightly) part: one deliberately tiny opted-in claude-haiku call
+(~0.03 credits =~ $0.00003 list-price) verifying the full path: guard
+approves -> call succeeds -> real cost estimate logged -> server-side
+spend increases.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+requires_key = pytest.mark.skipif(
+    not (
+        os.environ.get("DARTMOUTH_CHAT_API_KEY")
+        or os.path.exists(
+            os.path.expanduser("~/.config/llmxive/credentials.toml")
+        )
+    ),
+    reason="No Dartmouth credentials configured",
+)
+
+
+@requires_key
+def test_fetch_credit_balance_real() -> None:
+    from llmxive.backends.credits import fetch_credit_balance
+
+    balance = fetch_credit_balance()
+    assert balance.max_budget > 0
+    assert 0 <= balance.spend
+    assert balance.budget_duration  # e.g. "1d"
+    assert balance.budget_reset_at  # ISO timestamp
+    # The measured account shape (2026-06-10): 2000 credits/day. Don't pin
+    # the exact number (policy may change); sanity-bound it instead.
+    assert balance.max_budget >= 1.0
+
+
+@requires_key
+def test_paid_model_refused_without_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The backend must refuse a paid model when LLMXIVE_PAID_OPT_IN is unset
+    — this is the live free-first guard (no credits are spent)."""
+    from llmxive.backends.base import ChatMessage, PermanentBackendError
+    from llmxive.backends.dartmouth import DartmouthBackend
+
+    monkeypatch.delenv("LLMXIVE_PAID_OPT_IN", raising=False)
+    backend = DartmouthBackend()
+    with pytest.raises(PermanentBackendError, match="LLMXIVE_PAID_OPT_IN"):
+        backend.chat(
+            [ChatMessage(role="user", content="Reply with exactly: ok")],
+            model="anthropic.claude-haiku-4-5-20251001",
+            max_tokens=8,
+        )
+
+
+@pytest.mark.slow
+@requires_key
+def test_tiny_paid_call_end_to_end(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Opted-in tiny paid call: guard approves, call succeeds, the real cost
+    estimate is non-zero, and the server-side daily spend advances."""
+    from llmxive.backends import credits
+    from llmxive.backends.base import ChatMessage
+    from llmxive.backends.dartmouth import DartmouthBackend
+
+    monkeypatch.setenv("LLMXIVE_PAID_OPT_IN", "1")
+    credits.reset_balance_cache()
+    before = credits.fetch_credit_balance()
+    if before.spend >= credits.budget_fraction() * before.max_budget:
+        pytest.skip("daily credit cap already reached; not spending past it")
+
+    backend = DartmouthBackend()
+    response = backend.chat(
+        [ChatMessage(role="user", content="Reply with exactly: ok")],
+        model="anthropic.claude-haiku-4-5-20251001",
+        max_tokens=8,
+    )
+    assert response.text.strip()
+    assert response.cost_estimate_usd > 0  # honest paid accounting
+
+    # Server-side metering is asynchronous (observed lag: a few seconds to
+    # tens of seconds) — poll briefly rather than asserting instantly.
+    import time
+
+    after = before
+    for wait in (3, 5, 10, 15, 30):
+        time.sleep(wait)
+        credits.reset_balance_cache()
+        after = credits.fetch_credit_balance()
+        if after.spend > before.spend:
+            break
+    assert after.spend > before.spend  # the server metered the call
+    # 1 credit == $0.001: the spend delta (credits) should be ~1000x the
+    # USD estimate. Allow generous tolerance for token-count variance.
+    delta = after.spend - before.spend
+    assert delta == pytest.approx(response.cost_estimate_usd * 1000.0, rel=0.5)

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,0 +1,52 @@
+"""Unit: llmXive MCP server registers exactly the expected tools (issue #295).
+
+Skips cleanly when the optional ``mcp`` extra is not installed. No mocks —
+this introspects the real FastMCP server object via the SDK's own
+``list_tools()`` API.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+mcp = pytest.importorskip("mcp", reason="optional extra not installed: pip install llmxive[mcp]")
+
+import anyio  # noqa: E402
+
+EXPECTED_TOOLS = {
+    "search_semantic_scholar",
+    "search_arxiv",
+    "get_arxiv_paper",
+    "search_theorems",
+    "resolve_reference",
+    "register_and_resolve_claims",
+    "claim_status",
+    "credit_balance",
+}
+
+
+def test_server_lists_exactly_the_expected_tools() -> None:
+    from llmxive.mcp_server import create_server
+
+    server = create_server()
+    assert server.name == "llmxive"
+
+    async def _list() -> list:
+        return await server.list_tools()
+
+    tools = anyio.run(_list)
+    names = {t.name for t in tools}
+    assert names == EXPECTED_TOOLS
+
+    for tool in tools:
+        assert tool.description and tool.description.strip(), (
+            f"tool {tool.name} has an empty description"
+        )
+
+
+def test_import_llmxive_mcp_server_does_not_require_running_server() -> None:
+    """The package imports light: create_server is the only SDK touchpoint."""
+    import llmxive.mcp_server as pkg
+
+    assert callable(pkg.create_server)
+    assert callable(pkg.main)

--- a/tests/unit/test_model_fallback_outage_classification.py
+++ b/tests/unit/test_model_fallback_outage_classification.py
@@ -1,0 +1,137 @@
+"""Regression: an all-TRANSIENT chain exhaustion must abort cleanly, not escalate.
+
+Observed live (PROJ-552, dispatch 27306941191, 2026-06-10): a Dartmouth-wide
+outage made every model in the fallback chain fail with transient-class
+errors (qwen hung past its 360s deadline; gpt-oss + gemma both returned the
+302→outage.dartmouth.edu maintenance redirect). ``chat_with_model_fallback``
+raised plain ``BackendError`` (the breaker had not tripped yet, so the old
+``saw_unavailable``-only clause did not fire), the stage-panel's generic
+engine-failure handler caught it, and the project was WRONGLY escalated to
+``human_input_needed`` — a transient infrastructure outage is not
+human-actionable (bug-#8 family; see notes/spec-015-review-status.md).
+
+The fix: chain exhaustion where ANY failure was transient-class
+(``ModelDownError`` / ``TransientBackendError``) raises ``BackendUnavailable``
+— the run loop's clean-abort path (state preserved, retried next tick).
+Plain ``BackendError`` is reserved for an all-permanent exhaustion.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llmxive.backends.base import (
+    BackendError,
+    BackendUnavailable,
+    ChatMessage,
+    ChatResponse,
+    ModelDownError,
+    PermanentBackendError,
+    TransientBackendError,
+)
+from llmxive.backends.router import MODEL_FALLBACKS, chat_with_model_fallback
+
+PRIMARY = "qwen.qwen3.5-122b"
+
+_OUTAGE_HTML = (
+    '!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN"> '
+    "<title>302 Moved Temporarily</title> outage.dartmouth.edu"
+)
+
+
+class _AllDownBackend:
+    """Every model raises the given exception class (a full-endpoint outage)."""
+
+    name = "dartmouth"
+
+    def __init__(self, exc_factory) -> None:
+        self._exc_factory = exc_factory
+        self.models_tried: list[str] = []
+
+    def chat(self, messages, *, model, max_tokens=None, temperature=None):
+        self.models_tried.append(model)
+        raise self._exc_factory(model)
+
+
+def _msgs() -> list[ChatMessage]:
+    return [ChatMessage(role="user", content="ping")]
+
+
+def test_all_model_down_exhaustion_raises_backend_unavailable() -> None:
+    """The exact live shape: deadline-hang on the primary, 302→outage on the
+    peers — all ModelDownError. Must surface as BackendUnavailable so the
+    stage panel re-raises it AS-IS (clean abort), never an escalation."""
+    backend = _AllDownBackend(
+        lambda m: ModelDownError(f"Dartmouth model {m!r}: {_OUTAGE_HTML}")
+    )
+    with pytest.raises(BackendUnavailable):
+        chat_with_model_fallback(backend, _msgs(), model=PRIMARY)
+    # The walk really visited the whole chain before giving up.
+    assert set(backend.models_tried) == {PRIMARY, *MODEL_FALLBACKS[PRIMARY]}
+
+
+def test_all_transient_exhaustion_raises_backend_unavailable() -> None:
+    """Plain transient flaps (5xx/conn-reset) on every model: same clean-abort
+    classification."""
+    backend = _AllDownBackend(
+        lambda m: TransientBackendError(f"connection reset talking to {m}")
+    )
+    with pytest.raises(BackendUnavailable):
+        chat_with_model_fallback(backend, _msgs(), model=PRIMARY)
+
+
+def test_permanent_failures_on_peers_keep_backend_error() -> None:
+    """All-permanent exhaustion stays a plain BackendError (engine-actionable,
+    NOT an outage): transient primary, permanent peers — the single transient
+    in the chain still classifies the exhaustion as an outage; but a chain
+    where the only non-primary failures are permanent AND the primary is
+    permanent aborts immediately at the primary (pre-existing contract)."""
+    backend = _AllDownBackend(lambda m: PermanentBackendError(f"refused {m}"))
+    # Primary permanent -> immediate raise (no chain exhaustion at all).
+    with pytest.raises(PermanentBackendError):
+        chat_with_model_fallback(backend, _msgs(), model=PRIMARY)
+    assert backend.models_tried == [PRIMARY]
+
+
+def test_mixed_transient_then_permanent_peers_classify_as_outage() -> None:
+    """Transient primary + permanent peers: the transient signal means the
+    endpoint may heal — clean abort (BackendUnavailable), not BackendError."""
+
+    class _Mixed:
+        name = "dartmouth"
+
+        def chat(self, messages, *, model, max_tokens=None, temperature=None):
+            if model == PRIMARY:
+                raise ModelDownError(f"{model} hung past 360s deadline")
+            raise PermanentBackendError(f"refused {model}")
+
+    with pytest.raises(BackendUnavailable):
+        chat_with_model_fallback(_Mixed(), _msgs(), model=PRIMARY)
+
+
+def test_healthy_peer_still_serves_the_chain() -> None:
+    """Sanity: the new classification changes ONLY the exhausted case — a
+    healthy peer still answers."""
+
+    class _PeerHealthy:
+        name = "dartmouth"
+
+        def chat(self, messages, *, model, max_tokens=None, temperature=None):
+            if model == PRIMARY:
+                raise ModelDownError(f"{model}: {_OUTAGE_HTML}")
+            return ChatResponse(
+                text="ok", model=model, backend=self.name, cost_estimate_usd=0.0
+            )
+
+    response = chat_with_model_fallback(_PeerHealthy(), _msgs(), model=PRIMARY)
+    assert response.text == "ok"
+    assert response.model in MODEL_FALLBACKS[PRIMARY]
+
+
+def test_backend_error_class_still_reachable_for_all_permanent_peers() -> None:
+    """Exhaustion with ONLY permanent peer failures (primary transient is
+    required to reach exhaustion at all — covered above as outage). Document
+    that plain BackendError now requires a chain with zero transient signals,
+    which cannot occur via the primary path; the aggregate error class is kept
+    for forward-compatibility rather than deleted."""
+    assert issubclass(BackendUnavailable, BackendError)

--- a/tests/unit/test_paid_credits.py
+++ b/tests/unit/test_paid_credits.py
@@ -1,0 +1,171 @@
+"""Unit tests for the credit-managed paid-model guard (issue #295).
+
+Offline: every balance read is supplied by an injected fetch callable
+returning a real :class:`CreditBalance` value (no network, no mocks of
+our own code). The live endpoint shape these values mirror was measured
+on 2026-06-10: ``GET /api/v1/credits/balance`` ->
+``{"account": "Personal", "spend": 0.032, "max_budget": 2000.0,
+"budget_duration": "1d", "budget_reset_at": "2026-06-11T03:45:00Z"}``
+(and 1 credit == $0.001 list-price equivalent, measured via a real
+claude-haiku call moving spend by exactly tokens x price x 1000).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llmxive.backends import credits
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(monkeypatch: pytest.MonkeyPatch):
+    """Each test starts with no opt-in, default fraction, empty cache."""
+    monkeypatch.delenv(credits.PAID_OPT_IN_ENV, raising=False)
+    monkeypatch.delenv(credits.BUDGET_FRACTION_ENV, raising=False)
+    monkeypatch.delenv(credits.BALANCE_TTL_ENV, raising=False)
+    credits.reset_balance_cache()
+    yield
+    credits.reset_balance_cache()
+
+
+def _balance(spend: float = 0.0, max_budget: float = 2000.0) -> credits.CreditBalance:
+    return credits.CreditBalance(
+        account="Personal",
+        spend=spend,
+        max_budget=max_budget,
+        budget_duration="1d",
+        budget_reset_at="2026-06-11T03:45:00Z",
+    )
+
+
+class TestOptInSwitch:
+    def test_refused_by_default(self):
+        allowed, reason = credits.paid_call_allowed(
+            "anthropic.claude-haiku-4-5-20251001", fetch=lambda: _balance()
+        )
+        assert not allowed
+        assert credits.PAID_OPT_IN_ENV in reason
+
+    @pytest.mark.parametrize("value", ["1", "true", "YES", "on"])
+    def test_truthy_values_enable(self, monkeypatch, value):
+        monkeypatch.setenv(credits.PAID_OPT_IN_ENV, value)
+        assert credits.paid_opt_in_enabled()
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "banana"])
+    def test_falsy_values_stay_off(self, monkeypatch, value):
+        monkeypatch.setenv(credits.PAID_OPT_IN_ENV, value)
+        assert not credits.paid_opt_in_enabled()
+
+
+class TestBudgetCap:
+    def test_allowed_under_cap(self, monkeypatch):
+        monkeypatch.setenv(credits.PAID_OPT_IN_ENV, "1")
+        allowed, reason = credits.paid_call_allowed(
+            "anthropic.claude-haiku-4-5-20251001",
+            fetch=lambda: _balance(spend=10.0),
+        )
+        assert allowed
+        assert "allowed" in reason
+
+    def test_refused_at_cap(self, monkeypatch):
+        # default fraction 0.75 of 2000.0 -> cap 1500.0
+        monkeypatch.setenv(credits.PAID_OPT_IN_ENV, "1")
+        allowed, reason = credits.paid_call_allowed(
+            "anthropic.claude-opus-4-8", fetch=lambda: _balance(spend=1500.0)
+        )
+        assert not allowed
+        assert "cap" in reason
+
+    def test_custom_fraction(self, monkeypatch):
+        monkeypatch.setenv(credits.PAID_OPT_IN_ENV, "1")
+        monkeypatch.setenv(credits.BUDGET_FRACTION_ENV, "0.10")
+        # cap = 200.0; spend 250 must refuse
+        allowed, _ = credits.paid_call_allowed(
+            "anthropic.claude-opus-4-8", fetch=lambda: _balance(spend=250.0)
+        )
+        assert not allowed
+
+    def test_zero_max_budget_refused(self, monkeypatch):
+        monkeypatch.setenv(credits.PAID_OPT_IN_ENV, "1")
+        allowed, reason = credits.paid_call_allowed(
+            "anthropic.claude-opus-4-8",
+            fetch=lambda: _balance(spend=0.0, max_budget=0.0),
+        )
+        assert not allowed
+        assert "max_budget" in reason
+
+    def test_bad_fraction_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv(credits.BUDGET_FRACTION_ENV, "not-a-number")
+        assert credits.budget_fraction() == credits.DEFAULT_BUDGET_FRACTION
+
+    def test_fraction_clamped(self, monkeypatch):
+        monkeypatch.setenv(credits.BUDGET_FRACTION_ENV, "7.5")
+        assert credits.budget_fraction() == 1.0
+        monkeypatch.setenv(credits.BUDGET_FRACTION_ENV, "-1")
+        assert credits.budget_fraction() == 0.0
+
+
+class TestFailClosed:
+    def test_fetch_failure_refuses(self, monkeypatch):
+        monkeypatch.setenv(credits.PAID_OPT_IN_ENV, "1")
+
+        def boom() -> credits.CreditBalance:
+            raise ConnectionError("endpoint down")
+
+        allowed, reason = credits.paid_call_allowed(
+            "anthropic.claude-opus-4-8", fetch=boom
+        )
+        assert not allowed
+        assert "failing closed" in reason
+
+
+class TestBalanceCache:
+    def test_within_ttl_reuses_fetch(self, monkeypatch):
+        monkeypatch.setenv(credits.PAID_OPT_IN_ENV, "1")
+        calls = []
+
+        def counting_fetch() -> credits.CreditBalance:
+            calls.append(1)
+            return _balance(spend=1.0)
+
+        for _ in range(3):
+            allowed, _ = credits.paid_call_allowed("m", fetch=counting_fetch)
+            assert allowed
+        assert len(calls) == 1  # cached within the 30s default TTL
+
+    def test_reset_forces_refetch(self, monkeypatch):
+        monkeypatch.setenv(credits.PAID_OPT_IN_ENV, "1")
+        calls = []
+
+        def counting_fetch() -> credits.CreditBalance:
+            calls.append(1)
+            return _balance(spend=1.0)
+
+        credits.paid_call_allowed("m", fetch=counting_fetch)
+        credits.reset_balance_cache()
+        credits.paid_call_allowed("m", fetch=counting_fetch)
+        assert len(calls) == 2
+
+    def test_zero_ttl_disables_cache(self, monkeypatch):
+        monkeypatch.setenv(credits.PAID_OPT_IN_ENV, "1")
+        monkeypatch.setenv(credits.BALANCE_TTL_ENV, "0")
+        calls = []
+
+        def counting_fetch() -> credits.CreditBalance:
+            calls.append(1)
+            return _balance(spend=1.0)
+
+        credits.paid_call_allowed("m", fetch=counting_fetch)
+        credits.paid_call_allowed("m", fetch=counting_fetch)
+        assert len(calls) == 2
+
+
+class TestCreditBalanceValue:
+    def test_remaining_and_usd(self):
+        b = _balance(spend=500.0)
+        assert b.remaining == 1500.0
+        assert b.usd_equivalent_spend == pytest.approx(0.5)
+
+    def test_remaining_never_negative(self):
+        b = _balance(spend=9999.0)
+        assert b.remaining == 0.0

--- a/tests/unit/test_reviser_response_contract.py
+++ b/tests/unit/test_reviser_response_contract.py
@@ -215,6 +215,20 @@ def test_build_concern_responses_pads_missing_honestly():
     assert by_id["C1"].artifacts_changed == ["specs/000-x/spec.md"]
     assert by_id["C2"].response == "<missing>"
     assert "no response" in by_id["C2"].what_changed.lower()
+    # Observability: a partial miss names the concerns the reviser DID answer
+    # so the trail distinguishes a skip from a total parse-to-zero.
+    assert "C1" in by_id["C2"].what_changed
+
+
+def test_build_concern_responses_all_missing_records_parse_to_zero_reason():
+    """When the whole reply parses to zero per-concern responses (the
+    PROJ-552 plan-009 R2 shape), every padded entry must say SO in the
+    trail — not the generic skip message (notes/spec-015 observability
+    follow-up)."""
+    out = build_concern_responses([], _concerns())
+    assert all(r.response == "<missing>" for r in out)
+    for r in out:
+        assert "ZERO per-concern responses" in r.what_changed
 
 
 def test_delimited_path_with_crlf_line_endings():


### PR DESCRIPTION
Closes #295 (audit #294 Phase 3 follow-up). All three scope items addressed; spec artifacts in `specs/022-audit-phase3-followup/`.

## 1. Orchestration-harness pilot → DECISION: keep the bespoke pipeline

Per the audit's adoption threshold ("adopt only if a one-lane pilot reduces orchestration LOC and passes the same gates"):
- Ran the implementer micro-lane through a smolagents 1.26 `CodeAgent` with a `RouterModel` adapter that keeps every model call inside `chat_with_fallback` (free-model guard, breakers, peer fallback intact). Real `qwen.qwen3.5-122b` calls.
- Run 1 **failed**: the sandbox blocks the implementer's core execute-what-you-wrote validation; step cap hit. Run 2 **passed** only after authorizing `subprocess` (forfeiting the sandbox — the audit's headline benefit for this lane) and raising the step cap.
- Net orchestration LOC would **increase** (~150–250 new adapter/glue vs ~60–80 replaceable loop LOC; the rest of `implement_cmd.py` is llmXive semantics smolagents doesn't provide).
- Full evidence + reproduce instructions: `specs/022-audit-phase3-followup/pilot/RESULTS.md`. smolagents is NOT added as a dependency. The carry-forward: the router-delegating adapter pattern is proven for any future lane.
- As-you-go: removed `langgraph` from dependencies (declared since the bootstrap commit, zero imports anywhere) + pruned stale mypy ignore sections.

## 2. MCP server for librarian + claim-verifier tools

- `src/llmxive/mcp_server/` (optional extra: `pip install -e ".[mcp]"`), stdio server via `python -m llmxive.mcp_server`.
- 8 tools wrapping the EXISTING functions (no reimplementation): `search_semantic_scholar`, `search_arxiv`, `get_arxiv_paper`, `search_theorems`, `resolve_reference`, `register_and_resolve_claims`, `claim_status`, `credit_balance`.
- Tests: offline tool-inventory introspection + a real stdio client spawning the server (live arXiv search marked `slow`; live credit balance fast).

## 3. Credit-managed `paid_opt_in` backend (maintainer-directed)

Explored the credit system live per the issue comment:
- `GET /api/v1/credits/balance` → `{spend, max_budget: 2000.0, budget_duration: "1d", budget_reset_at}` (resets 03:45Z = 11:45 PM ET).
- **Measured: 1 credit = $0.001 USD list-price equivalent** (a 12-in/4-out-token haiku call at $1/M-in $5/M-out moved spend by exactly 0.032 credits — 1000× ratio). So the daily 2000 credits ≈ **$2.00/day** of list-price usage, at $0 actual cost.
- Implementation (encapsulated per Constitution IV — written justification in `specs/022-audit-phase3-followup/paid-backend-justification.md`):
  - `backends/credits.py`: master switch `LLMXIVE_PAID_OPT_IN` (default **OFF**), budget cap `LLMXIVE_PAID_BUDGET_FRACTION` (default 75% of max_budget — 25% reserve covers async metering lag), 30s-TTL balance cache, **fail-closed** on any doubt.
  - `DartmouthBackend.chat`: the v1 unconditional paid block becomes this guard; opted-in calls log REAL cost estimates (catalog price × token usage).
  - Run-log cost invariant relaxed ONLY under the same switch; registry `paid_opt_in` schema const-false → boolean default false. **No agent is flipped** — each flip is its own reviewed decision (the all-false registry pin test is the visible friction).
  - `llmxive credits` CLI shows live balance/cap/reset.
- Verified with real calls including a tiny opted-in haiku e2e (≈0.03 credits) asserting guard → call → cost → server-side metering.

## Also in this PR (as-you-go, per repo policy)

- Observability (notes/spec-015 follow-up): padded `<missing>` reviser responses now record WHY (parsed-to-zero vs skipped-this-concern) in the convergence trail.

## Verification

- Offline gate: **2349 passed, 16 skipped, 0 failed** (baseline before this PR: 2323/16/0; +26 new tests).
- ruff + mypy (strict, 212 files): clean.
- Real-call: credits suite 3/3 (incl. slow e2e), MCP suite 2/2, fast per-PR gate run locally (result posted below when complete).
- Constitution: I (no lifecycle fork — pilot rejected), III (real-call validation throughout), IV (written justification + encapsulation + default-off), V (fail-fast/fail-closed guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)