### PR TITLE
fix(pipeline): resolve issue #1139 — pipeline liveness anti-patterns

### DIFF
--- a/.github/workflows/advance.yml
+++ b/.github/workflows/advance.yml
@@ -5,8 +5,8 @@ name: Pipeline — Advance (deterministic matrix workers)
 # review/paper-speckit, which all just ran the SAME load-balanced
 # `python -m llmxive run` and thus competed as undifferentiated workers).
 #
-# A 12-job matrix where each worker `i` calls
-#   python -m llmxive run --worker i --workers 12
+# A 6-job matrix where each worker `i` calls
+#   python -m llmxive run --worker i --workers 6
 # which DETERMINISTICALLY picks a DISTINCT project via
 # scheduler.pick_for_worker: the jobs are APPORTIONED across stages in proportion
 # to load (the fullest stage gets the most workers, capped at
@@ -15,21 +15,30 @@ name: Pipeline — Advance (deterministic matrix workers)
 # project's changes; the commit-and-push.sh rebase-retry handles the concurrent
 # pushes.
 #
-# Width 12 (was 6): implementation is the pipeline's bottleneck — 433 projects sat
-# at in_progress and none had ever crossed it. A public repo gets 20 free
-# concurrent jobs, so 12 leaves headroom for the other lanes (compile/pages/
-# intake/signoff). With load-apportionment that puts ~8 workers on in_progress
-# per tick, versus 1 under the old flat round-robin.
+# CADENCE + WIDTH (issue #1139, defect D16 — concurrent persistence loses work):
+# reduced from `*/15` × 12 workers to `*/30` × 6 workers. Twelve 150-min-budget
+# jobs firing every 15 min guaranteed many OVERLAPPING ticks running at DIFFERENT
+# HEADs; two such ticks can pick the SAME project (pick_for_worker is
+# deterministic only at a fixed HEAD) and both write its state, and the
+# commit-and-push rebase race then keeps whichever lands last — silently dropping
+# the other tick's completed work. A wider cadence + narrower matrix shrinks the
+# overlap window (fewer simultaneous ticks) and the stale-checkout window without
+# stopping throughput. RECOMMENDED / easy to tune: keep the cron, the matrix
+# list, and the two workflow_dispatch defaults below IN SYNC — schedule `*/30`
+# (was `*/15`), width 6 (was 12; a public repo gets 20 free concurrent jobs, so 6
+# still leaves ample headroom for compile/pages/intake/signoff). Raise them again
+# only once the per-project lease (src/llmxive/pipeline/project_lease.py) + a
+# CAS-verified push make overlapping ticks safe.
 
 on:
   schedule:
-    - cron: '*/15 * * * *'   # every 15 minutes
+    - cron: '*/30 * * * *'   # every 30 minutes (was */15; issue #1139 lost-work race)
   workflow_dispatch:
     inputs:
       workers:
         description: "Total matrix workers (must match the matrix size below)."
         required: false
-        default: "12"
+        default: "6"
       max_tasks:
         description: "Scheduler ticks per worker (each in_progress tick batches many tasks)."
         required: false
@@ -55,10 +64,12 @@ jobs:
     # multi-tick loop early so the final step + commit always land.
     timeout-minutes: 150
     strategy:
-      fail-fast: false
-      max-parallel: 12
+      fail-fast: false            # preserved (issue #1139): one worker failing
+                                  # must NOT abort the rest of the matrix.
+      max-parallel: 6             # was 12; see cadence/width note (issue #1139).
       matrix:
-        worker: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        worker: [0, 1, 2, 3, 4, 5]   # width 6 (was 0..11) — keep in sync with
+                                     # max-parallel + the workers dispatch default.
     env:
       DARTMOUTH_CHAT_API_KEY: ${{ secrets.DARTMOUTH_CHAT_API_KEY }}
       LLMXIVE_RUN_WALL_BUDGET_S: "2400"
@@ -88,28 +99,46 @@ jobs:
         run: |
           python -m llmxive run \
             --worker "${{ matrix.worker }}" \
-            --workers "${WORKERS:-12}" \
+            --workers "${WORKERS:-6}" \
             --max-tasks "${MAX_TASKS:-10}"
         env:
           WORKERS: ${{ github.event.inputs.workers }}
           MAX_TASKS: ${{ github.event.inputs.max_tasks }}
-      # Only worker 0 regenerates web data + triggers Pages — otherwise all 12
-      # workers commit web/data/ and fire pages.yml, and the rapid Pages builds
-      # cancel each other (the deploy thrash that leaves the live site stale).
-      - name: Regenerate web data (worker 0 only)
-        if: matrix.worker == 0
-        run: python -c "from llmxive.agents.status_reporter import regenerate_web_data; from pathlib import Path; regenerate_web_data(repo_root=Path('.'))"
-      - name: Commit + push
+      # Persist this tick's PROJECT STATE first (issue #1139, defect D16): commit
+      # + push BEFORE the (worker-0-only) web-data regeneration. Previously the
+      # long, wholesale web-gen ran while this checkout was still holding the
+      # tick's uncommitted state, and its regenerated web/data/projects.json was
+      # bundled into the hot commit — making that big file the routine merge
+      # conflict AND widening the window in which the state could be lost to a
+      # racing tick. Committing state first shrinks that window and isolates the
+      # web-data churn into its own commit below.
+      - name: Commit + push (project state)
         id: commit
         run: |
           bash scripts/ci/commit-and-push.sh "advance(worker ${{ matrix.worker }}): tick"
+      # Only worker 0 regenerates web data + triggers Pages — otherwise all 6
+      # workers commit web/data/ and fire pages.yml, and the rapid Pages builds
+      # cancel each other (the deploy thrash that leaves the live site stale).
+      # Runs AFTER the state push and does its OWN commit + push, so the
+      # regenerated projects.json lands in a separate, isolated commit and never
+      # holds the state push hostage to a slow web-gen.
+      - name: Regenerate web data (worker 0 only)
+        if: matrix.worker == 0
+        run: python -c "from llmxive.agents.status_reporter import regenerate_web_data; from pathlib import Path; regenerate_web_data(repo_root=Path('.'))"
+      - name: Commit + push (web data, worker 0 only)
+        id: webpush
+        if: matrix.worker == 0
+        run: |
+          bash scripts/ci/commit-and-push.sh "advance(worker 0): regenerate web data"
 
       - name: Trigger Pages deploy
         # GitHub suppresses workflow triggers from GITHUB_TOKEN pushes (to
         # prevent infinite cron loops); workflow_dispatch invoked from another
         # workflow DOES fire regardless. Without this, pages.yml never
         # redeploys after a cron tick even though we touched web/data/.
-        if: matrix.worker == 0 && steps.commit.outputs.pushed == 'true'
+        # Gated on the WEB-DATA push (issue #1139): the site rebuilds only when
+        # web/data/ actually changed, not on every project-state commit.
+        if: matrix.worker == 0 && steps.webpush.outputs.pushed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh workflow run pages.yml --ref main

--- a/.github/workflows/llmxive-real-call-tests.yml
+++ b/.github/workflows/llmxive-real-call-tests.yml
@@ -94,6 +94,13 @@ jobs:
       - name: Backend reachability check (Dartmouth + HF list_models())
         run: python -m llmxive.checks.backends
 
+      # issue #1139 anti-pattern 1: every fixed-name state artifact a non-test
+      # source module writes under state/ or .specify/memory/ must have a non-test
+      # reader (a persist-and-forget dead-end like the old resolved_datasets.yaml
+      # fails here).
+      - name: State-artifact reader check (no persist-and-forget dead-ends)
+        run: python -m llmxive.checks.state_readers
+
       # The contract suite validates every schema in contracts/.
       - name: Contract tests
         run: pytest tests/contract -v

--- a/agents/tools/citation_fetcher.py
+++ b/agents/tools/citation_fetcher.py
@@ -28,11 +28,16 @@ this.
 
 Resolves a citation to its primary source and returns
 `{fetched_title, fetched_authors, status}`. Distinguishes:
-  - `verified`    — primary source reachable AND title-overlap ≥ threshold
+  - `verified`    — primary source reachable AND a REAL cited title
+                    cross-checks (token-overlap ≥ threshold, or verbatim body
+                    match). Reachability ALONE never earns verified (D14).
   - `mismatch`    — reachable but title doesn't match the cited title
   - `unreachable` — transient 5xx / timeout / DNS / 4xx (other than 404)
                     — caller may retry on the next scheduled run
-  - `pending`     — should never be returned; caller's responsibility
+  - `pending`     — present-but-unverified: reachable but the title can't be
+                    cross-checked (access-gated body, redirect/bot-wall stub, or
+                    no real cited title stored). Bounded retry / substitution
+                    upstream; the reference gate treats it as blocking.
 
 Per Constitution Principle II (Verified Accuracy), this tool MUST hit
 the primary source on every call. No caching, no faking — the
@@ -83,8 +88,10 @@ def _is_real_title(s: str) -> bool:
     field (or leaves it empty); comparing that against the fetched page title then
     yields ~0 overlap and a FALSE ``mismatch`` — even though the reference resolved
     to the REAL paper (``fetched_title`` is the genuine title). When there is no
-    real title to cross-check, existence (a resolved page WITH a title) is the best
-    signal we have, so the caller treats it as verified rather than fabricated."""
+    real title to cross-check, existence is NOT verification: the caller treats a
+    resolved-but-uncrosscheckable reference as PENDING (present-but-unverified,
+    bounded retry/substitution — recover a real title from DOI/arXiv metadata
+    upstream, then title-match), never VERIFIED (issue #1139 D14)."""
     s = (s or "").strip()
     if not s:
         return False
@@ -161,11 +168,13 @@ def _classify_match(cited_title: str, fetched_title: str) -> VerificationStatus:
     title_unreadable = (not ft) or _is_block_title(ft)
     if not _is_real_title(cited_title):
         # No real cited title to cross-check (the citation stored a URL/DOI/id).
-        return (
-            VerificationStatus.PENDING
-            if title_unreadable
-            else VerificationStatus.VERIFIED
-        )
+        # Existence != verification (issue #1139 D14): a reference that RESOLVED
+        # to a live, readable page but whose cited title we cannot cross-check is
+        # PRESENT-BUT-UNVERIFIED, so DEFER to PENDING (bounded retry/substitution:
+        # resolve DOI/arXiv metadata to recover a real title, then title-match).
+        # Only a real cited-title token-overlap match (below) or a verbatim
+        # body match (``_title_in_body`` in the caller) earns VERIFIED.
+        return VerificationStatus.PENDING
     if title_unreadable:
         # We have a real cited title but the page didn't give us a readable one to
         # compare against — present but unverifiable, not fabricated.

--- a/notes/2026-07-15-issue-1139-fix-plan.md
+++ b/notes/2026-07-15-issue-1139-fix-plan.md
@@ -55,3 +55,15 @@ Full recon evidence: `<scratchpad>/recon-{A..G}.md` (also summarized here).
 - Independent clusters (VERIFIER, DATA, SEMVERDICT, PAPER-RESOLVER, STATE-IO, PERSISTENCE, DOCS+FLAGS) = parallel background subagents, strict disjoint file ownership, each runs its targeted tests + reports.
 - CORE = main thread (most interlinked/critical).
 - Full suite green at end. Document every defect on #1139 with before/after evidence. Do NOT push to main (live pipeline); flag merge + live-migration for user.
+
+---
+## COMPLETION STATUS (2026-07-15)
+
+- Branch `fix/issue-1139-pipeline-antipatterns`, commit **3251f7a458**, **PR #1145** (open, against main; "Addresses #1139", not auto-close).
+- Every defect fixed via foundations (state/_io.py atomic write + CAS; execution/failure_class.py FailureClass) + CORE (graph/stage/analysis_runner/lifecycle/execution_status) + 8 file-disjoint clusters.
+- **D3 nuance**: correct discriminator is panel-label match (honor kickback only when its panel runs at current stage), NOT is_valid_transition (that guard was reverted — it broke legit deep-rollback kickbacks). Fixes all 5 recorded invalid transitions; 4 kickback tests + 8 CORE tests green.
+- **Verification**: offline `unit+contract -m "not slow"` = 6165 passed/8 skipped; contract 86 passed; real-call not-slow = 23 passed/5 skipped (real Dartmouth); CORE 8 passed; ruff clean; CI pre-checks (prompts/speckit/backends) pass. Only unrelated failure = test_datacite_resolves_doi (doi.org 503 external outage; module not in changed set; passed in baseline).
+- **Migrations (dry-run; scripts/maintenance/*, run after merge with --apply)**: drain_under_review 7021 [~] -> 3791 [X] + 1141 [ ] + 2089 residue; classify_advance_errors 74 -> permanent 53/transient 8/invariant 5/repair 4/emitter 4; archive_weak_manifests 676 manifests / 9.8MB.
+- **CI on PR #1145**: real-call + audit-{speckit,pdf,personality,feedback-loop} running (monitor active).
+- **Deferred / user's-call (documented on issue)**: run migrations on live corpus (--apply); merge to main; operational intake-pause + cadence (advance.yml cadence already reduced in code); full result-bundle-worker + serialized-merger rearchitecture (Phase 6 residual); canary/SLO suite (Phase 7); a CI check that every state writer has a non-test reader (AP1 follow-up); 3.2 best-effort catches remain fail-open by design (cause now threaded via FailureClass).
+- **Docs**: 6 evidence comments being drafted -> posted to #1139.

--- a/notes/2026-07-15-issue-1139-fix-plan.md
+++ b/notes/2026-07-15-issue-1139-fix-plan.md
@@ -1,0 +1,57 @@
+# Issue #1139 — comprehensive pipeline anti-pattern fix session (2026-07-15)
+
+Branch: `fix/issue-1139-pipeline-antipatterns` (off `main`@bfe019a785; source == origin/main, only state ticks diverged).
+Baseline: full offline suite (`tests/unit tests/contract -m "not slow"`, 6061 tests) **green, exit 0**.
+Full recon evidence: `<scratchpad>/recon-{A..G}.md` (also summarized here).
+
+## Confirmed defects (all reproduced at HEAD)
+
+### CORE cluster (main-thread owns: graph.py, execution/stage.py, agents/lifecycle.py, state/execution_status.py, execution/analysis_runner.py, pipeline/_kickback.py, new execution/failure_class.py)
+- **D1** Paper-complete gate checks `paper/source/main.pdf`; producer writes `paper/pdf/main.pdf`. graph.py:407 vs latex_build.py:123. → consume `build_result["pdf_path"]` + source-freshness. 104 tex / 0 pdf-in-pdf / 2 pdf-in-source.
+- **D3** `_decide_next_stage` returns kickback `to_stage` unvalidated (graph.py:1525/1485/1504); cross-stage/cross-track sentinel → 5 recorded invalid transitions (PROJ-575/601 paper_analyzed→paper_planned; 577/606 in_progress→clarified; 644 in_progress→specified). → validate vs `is_valid_transition`, fall through to legal forward; scope kickback dirs to current track.
+- **D4** Failure class computed (stage.py `_compute_infra_failures`/`_data_unavailable_failures`/`_needs_verified_source`) then discarded; execution_status stores only strings; `_write_execution_replan_feedback` has no class arg → always CPU/dep-light advice. → `FailureClass` enum + evidence threaded runner→status→feedback→replan→terminal.
+- **D20** Execution exhaustion → `VALIDATOR_REJECTED` (graph.py:1716), conflated with idea-quality reject (1369/1636). → split terminal (`EXECUTION_INFEASIBLE`), register edge in lifecycle.
+- **D12** GPU offload accept (stage.py:482-499) advances on non-empty presence, skips fabrication/hollow/durable/declared/schema gates. → extract `_semantic_gate` from analysis_runner.py:322-359, rejoin it; receipts only after gate.
+- **D21** Broad `except Exception … skipped: %s` in stage.py (705/718/727/743). → branch on cause/thread it (keep fail-open but actionable).
+- **D2-stage** `_reopen_failing_tasks` edits first-glob `specs/*/tasks.md` (stage.py:756) not pointer. → `feature_dir_for`.
+- **D6-wiring** graph.py:328 calls `run_verification_pass` without `cap=` → stuck at 6. → pass batch-matched cap.
+
+### VERIFIER cluster (owns: agents/task_verifier.py, config.py, scripts/maintenance drain)
+- **D6** 30/tick implement vs 6/tick verify → 7,021 `[~]` stranded (33% of 21,094 marks); forced-accept 3×INCOMPLETE→`[X]` (task_verifier.py:329-339) fail-open; evidence `_PATH_RE` misses src/tests/config. → capacity>=batch, deterministic-first, verdict bound to task+evidence hash, route 3×-reject to typed kickback (never `[X]`), drain `[~]`. Test change: `test_reject_counts_accumulate_across_reannotation`.
+
+### DATA cluster (owns: librarian/dataset_resolver.py, execution/data_source.py, librarian/data_source_discovery.py, speckit/plan_cmd.py, speckit/_reference_repair.py)
+- **D7** `resolved_datasets.yaml` write-only (676 files, 9.8MB, 0 readers). → stop writing dead manifest / candidate-only.
+- **D8** cache key = file path only; caches `error`/`none` forever (rediscovery_calls=0). → key=sha256(intent+fields+plan/spec hash+verifier ver); never cache transient; TTL/retry negatives.
+- **D9** `_verify_data_url` sniffs format, record_count=0, no field check (data_source_discovery.py:630-650); coverage=1.0 when no required_fields → false verified. → records>0 + field coverage for all kinds or candidate-only.
+- **D10** renderer says `pip install {ref}` for all kinds incl URLs (data_source.py:183-214). → branch on kind.
+- **D11** strong discovery only at execution; plan uses weak resolver. → proactive plan-time `discover_data_source` sharing exec cache.
+
+### SEMVERDICT cluster (owns: agents/proofreader.py, agents/tools/citation_fetcher.py, agents/reference_validator.py)
+- **D13** `proofreader_clean` stores/checks no source hash → stale clean survives edits (probe: still clean after typos). → bind source_hash+version+TTL.
+- **D14** bare URL w/ any readable title → VERIFIED (citation_fetcher.py:160-176). → PENDING + resolve-metadata retry. Test change: `test_url_as_cited_title_does_not_false_mismatch`.
+- **D15** ref gate blocks only UNREACHABLE/MISMATCH → PENDING advances (reference_validator.py:232-243). → positive gate: only current VERIFIED advances; PENDING→bounded retry/substitution. Test change: `test_pending_does_not_block_the_gate`.
+
+### PAPER-RESOLVER cluster (owns: agents/paper_writing.py, agents/paper_figure_generation.py)
+- **D2-paper** first-sorted spec/plan glob (paper_writing.py:41/43, paper_figure_generation.py:52). → `feature_dir_for(track="paper")`.
+
+### STATE-IO cluster (owns: new state/_io.py + project.py, citations.py, claims.py, results.py, reviews.py, paper_status.py, escalations.py, runlog.py, publication.py, revision_history.py — NOT execution_status.py [core])
+- **D19** only 2/13 stores atomic, dup `_atomic_write`; no CAS. → one shared `atomic_write_text` (tmp+os.replace); route all; add mtime/version CAS to RMW stores.
+
+### PERSISTENCE cluster (owns: .github/workflows/advance.yml, scripts/ci/commit-and-push.sh, new pipeline/project_lease.py)
+- **D16** 12 workers/15min direct push to main; 20x rebase race, per-index (not per-project) concurrency; worker0 web-gen extends stale window. → per-project lock/CAS + reduce cadence/width; web-gen post-merge. (partly OPERATIONAL — implement on branch, flag merge.)
+
+### DOCS+FLAGS cluster (owns: latex_build.py docstring only + new tests/ for flags)
+- **D17** grounding/claim/fill flags on in prod, off in tests, isolated by conftest → prod combo under-tested. → offline flag-on test.
+- **D18** latex_build.py:7-8 docstring says compile-fail → human_input_needed (retired). → rewrite to bounded-repair/paper_status.
+
+## Migrations / recovery (after code fixes)
+- Drain 7,021 `[~]` (re-run deterministic checks → [X]/[ ]/kickback).
+- Classify 74 advance_errors (15 ≥3, 4 ≥10, max 365); route permanent classes.
+- Archive/invalidate 676 weak manifests + 16 dead discovery caches.
+- Before/after corpus report.
+
+## Strategy
+- Foundations inline: state/_io.py, execution/failure_class.py.
+- Independent clusters (VERIFIER, DATA, SEMVERDICT, PAPER-RESOLVER, STATE-IO, PERSISTENCE, DOCS+FLAGS) = parallel background subagents, strict disjoint file ownership, each runs its targeted tests + reports.
+- CORE = main thread (most interlinked/critical).
+- Full suite green at end. Document every defect on #1139 with before/after evidence. Do NOT push to main (live pipeline); flag merge + live-migration for user.

--- a/scripts/ci/commit-and-push.sh
+++ b/scripts/ci/commit-and-push.sh
@@ -26,6 +26,11 @@
 #   web/data/* which is rebuilt next tick regardless.
 # * Always `git rebase --abort` before each attempt so we NEVER operate on a
 #   conflicted tree.
+# * VERIFY the push landed (issue #1139): after a "successful" push, re-fetch
+#   origin/main from the server and confirm our commit is contained in it before
+#   claiming success — a masked exit code (the git-push-exitcode-mask class) or a
+#   concurrent force-update would otherwise report pushed=true while the tick's
+#   work was actually lost. A failed verify falls through and re-races.
 # * FAIL LOUD (exit 1) if we still can't push after the retries — the project
 #   state on origin is then simply unchanged (no corruption); it stays
 #   schedulable and a later tick re-does the work. A masked success is worse
@@ -86,10 +91,22 @@ for i in $(seq 1 "$ATTEMPTS"); do
     echo "fetch failed (attempt $i); retrying" >&2; sleep $((2 + RANDOM % 5)); continue
   fi
   if git rebase -X theirs origin/main >/dev/null 2>&1; then
+    head_sha="$(git rev-parse HEAD)"
     if git push origin HEAD:main --quiet; then
-      echo "pushed on attempt $i"
-      emit true
-      exit 0
+      # VERIFY the push actually landed (issue #1139 — concurrent persistence
+      # loses work; guard against the exit-code-mask class of bug where a push
+      # is reported OK but the tick's commit is not on origin/main). Re-fetch
+      # origin/main from the SERVER and confirm our commit is contained in it.
+      # If it is NOT an ancestor of the refreshed tip, the work did not persist
+      # (a concurrent force-update, or a masked failure) — do NOT emit success;
+      # fall through and re-race.
+      if git fetch origin main --quiet \
+         && git merge-base --is-ancestor "$head_sha" FETCH_HEAD; then
+        echo "pushed on attempt $i (verified $head_sha landed on origin/main)"
+        emit true
+        exit 0
+      fi
+      echo "push reported success but $head_sha is NOT on origin/main (attempt $i) — re-racing" >&2
     fi
   else
     git rebase --abort 2>/dev/null || true

--- a/scripts/maintenance/archive_weak_manifests.py
+++ b/scripts/maintenance/archive_weak_manifests.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Archive (or delete) the dead ``resolved_datasets.yaml`` weak-manifest files.
+
+Issue #1139 / D7: the per-project ``projects/**/.specify/memory/resolved_datasets.yaml``
+manifest was WRITE-ONLY — one writer (``dataset_resolver.write_manifest``), zero
+non-test readers. The planner consumes the resolver's in-process return value, not
+the on-disk file. Those manifests are ~84% ``wrong_format`` noise and total ~9.8 MB
+across ~676 files. With ``write_manifest`` removed, this script cleans up the
+already-committed manifests.
+
+DEFAULT is a DRY-RUN: it only reports the count + total bytes and lists a sample.
+Pass ``--apply`` to actually move each manifest under
+``state/_archive/resolved_datasets/<project>/resolved_datasets.yaml`` (preserved
+for audit), or ``--apply --delete`` to remove them outright.
+
+Usage:
+    python scripts/maintenance/archive_weak_manifests.py            # dry-run report
+    python scripts/maintenance/archive_weak_manifests.py --apply    # archive
+    python scripts/maintenance/archive_weak_manifests.py --apply --delete  # delete
+    python scripts/maintenance/archive_weak_manifests.py --repo-root /path/to/repo
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_MANIFEST_NAME = "resolved_datasets.yaml"
+
+
+def _default_repo_root() -> Path:
+    """Repo root via ``llmxive.config.repo_root`` when importable, else this
+    file's location (``scripts/maintenance/`` → repo root)."""
+    try:
+        from llmxive.config import repo_root
+
+        return repo_root()
+    except Exception:
+        return Path(__file__).resolve().parent.parent.parent
+
+
+def find_weak_manifests(repo_root: Path) -> list[Path]:
+    """Every ``projects/**/.specify/memory/resolved_datasets.yaml`` under repo.
+
+    Uses ``os.walk``-style rglob but note: ``Path.glob('**')`` skips dot-dirs, so
+    we anchor on the known ``.specify/memory`` segment explicitly.
+    """
+    projects = repo_root / "projects"
+    if not projects.is_dir():
+        return []
+    return sorted(projects.glob(f"*/.specify/memory/{_MANIFEST_NAME}"))
+
+
+def _archive_target(repo_root: Path, manifest: Path) -> Path:
+    """``state/_archive/resolved_datasets/<project>/resolved_datasets.yaml``."""
+    # projects/<project>/.specify/memory/resolved_datasets.yaml → <project>.
+    try:
+        rel = manifest.relative_to(repo_root / "projects")
+        project = rel.parts[0]
+    except (ValueError, IndexError):
+        project = manifest.parent.parent.parent.name
+    return repo_root / "state" / "_archive" / "resolved_datasets" / project / _MANIFEST_NAME
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root", type=Path, default=None,
+        help="Repository root (default: llmxive.config.repo_root()).",
+    )
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="Actually archive/delete (default: dry-run report only).",
+    )
+    parser.add_argument(
+        "--delete", action="store_true",
+        help="With --apply, DELETE the manifests instead of archiving them.",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = (args.repo_root or _default_repo_root()).resolve()
+    manifests = find_weak_manifests(repo_root)
+    total_bytes = sum((m.stat().st_size for m in manifests if m.is_file()), 0)
+
+    action = "delete" if args.delete else "archive"
+    print(f"repo root: {repo_root}")
+    print(f"found {len(manifests)} '{_MANIFEST_NAME}' manifest(s), "
+          f"{total_bytes:,} bytes total")
+    for m in manifests[:10]:
+        print(f"  - {m.relative_to(repo_root)}")
+    if len(manifests) > 10:
+        print(f"  … and {len(manifests) - 10} more")
+
+    if not manifests:
+        return 0
+
+    if not args.apply:
+        print(f"\nDRY-RUN: no files changed. Re-run with --apply to {action} them "
+              f"(add --delete to remove instead of archive).")
+        return 0
+
+    moved = 0
+    for m in manifests:
+        if not m.is_file():
+            continue
+        if args.delete:
+            m.unlink()
+        else:
+            target = _archive_target(repo_root, m)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            m.replace(target)
+        moved += 1
+    verb = "deleted" if args.delete else f"archived under {repo_root / 'state' / '_archive' / 'resolved_datasets'}"
+    print(f"\n{action.upper()} complete: {moved} manifest(s) {verb}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/maintenance/classify_advance_errors.py
+++ b/scripts/maintenance/classify_advance_errors.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+"""One-time migration: classify the existing untyped advance-error ledger.
+
+Issue #1139 (defect D5) replaced the untyped ``state/advance_errors/<id>.json``
+log (``{project_id, stage, last_error, last_seen, count}``) with a typed control
+record that the scheduler honours (see :mod:`llmxive.pipeline.advance_ledger`).
+This script upgrades the ~74 legacy records IN PLACE: it fingerprints each stored
+``last_error`` into one of the nine real classes, carries the old ``count`` over as
+``consecutive_count``, assigns the control disposition (class + status +
+retry_after), and prints a before/after table (worst offenders first, so the four
+``count >= 10`` records — PROJ-077=365, PROJ-770=91, PROJ-047=84, PROJ-362=76 —
+lead the report).
+
+DEFAULT is a DRY-RUN (nothing written). Pass ``--apply`` to write the upgraded
+records. Run with ``PYTHONPATH=src``::
+
+    ./.venv/bin/python scripts/maintenance/classify_advance_errors.py            # dry-run
+    ./.venv/bin/python scripts/maintenance/classify_advance_errors.py --apply    # write
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+from llmxive.config import repo_root as _repo_root
+from llmxive.pipeline import advance_ledger as al
+from llmxive.state._io import atomic_write_text
+
+
+def _parse_dt(value: str | None) -> datetime:
+    if value:
+        try:
+            dt = datetime.fromisoformat(value)
+            return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+        except ValueError:
+            pass
+    return datetime.now(UTC)
+
+
+def _upgrade(old: dict) -> dict:
+    """Build the typed record from a legacy (or already-typed) record."""
+    message = old.get("last_error", "") or ""
+    # Legacy schema used ``count``; a re-run over an already-typed record uses
+    # ``consecutive_count`` — accept either so the migration is idempotent.
+    count = int(old.get("consecutive_count", old.get("count", 1)) or 1)
+    last_seen = _parse_dt(old.get("last_seen"))
+    first_seen = old.get("first_seen") or (old.get("last_seen") or last_seen.isoformat())
+    return al.make_record(
+        project_id=old.get("project_id", ""),
+        stage=old.get("stage", ""),
+        message=message,
+        consecutive_count=count,
+        first_seen=first_seen,
+        last_seen=last_seen,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="write the upgraded records (default: dry-run, no writes)",
+    )
+    parser.add_argument(
+        "--repo-root", default=None,
+        help="repo root (default: llmxive.config.repo_root())",
+    )
+    args = parser.parse_args(argv)
+
+    repo = Path(args.repo_root) if args.repo_root else _repo_root()
+    ledger_dir = repo.joinpath(*al.LEDGER_SUBDIR)
+    files = sorted(ledger_dir.glob("*.json"))
+    if not files:
+        print(f"[classify] no records under {ledger_dir}")
+        return 0
+
+    rows: list[tuple[int, str, dict, dict]] = []
+    for path in files:
+        try:
+            old = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            print(f"[classify] SKIP {path.name}: unreadable ({exc})", file=sys.stderr)
+            continue
+        new = _upgrade(old)
+        count = int(old.get("consecutive_count", old.get("count", 1)) or 1)
+        rows.append((count, path.name, old, new))
+
+    # Worst offenders (highest count) first.
+    rows.sort(key=lambda r: (-r[0], r[1]))
+
+    hdr = f"{'count':>5}  {'stage':<18} {'fingerprint':<22} {'class':<20} {'status'}"
+    print(f"\n{'DRY-RUN (no writes) — ' if not args.apply else 'APPLYING — '}"
+          f"{len(rows)} record(s) under {ledger_dir}\n")
+    print(hdr)
+    print("-" * len(hdr))
+    class_hist: dict[str, int] = {}
+    written = 0
+    for count, name, _old, new in rows:
+        class_hist[new["class"]] = class_hist.get(new["class"], 0) + 1
+        print(
+            f"{count:>5}  {new['stage']:<18} {new['fingerprint']:<22} "
+            f"{new['class']:<20} {new['status']}"
+        )
+        if args.apply:
+            atomic_write_text(ledger_dir / name, json.dumps(new, indent=2))
+            written += 1
+
+    print("\nby class:")
+    for cls, n in sorted(class_hist.items(), key=lambda kv: (-kv[1], kv[0])):
+        print(f"  {cls:<20} {n}")
+    if args.apply:
+        print(f"\n[classify] wrote {written} upgraded record(s).")
+    else:
+        print("\n[classify] dry-run only; re-run with --apply to write.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/maintenance/drain_under_review.py
+++ b/scripts/maintenance/drain_under_review.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""One-time maintenance: drain the stranded ``[~]`` (under-review) task backlog.
+
+The independent task-verifier historically consumed only ``DEFAULT_VERIFY_CAP``
+LLM calls per tick while the implementer claimed up to ``IMPLEMENT_TASK_BATCH``
+tasks — so everything past the cap was force-marked ``[~]`` and rarely re-visited.
+Across the in_progress corpus that produced a large ``[~]`` backlog (issue #1139).
+
+This script re-runs the NEW deterministic checks (LLM-FREE) over every in_progress
+project's ``[~]`` tasks and reclassifies each:
+
+  * ``[~]`` → ``[X]``  — its declared artifacts now exist and validate;
+  * ``[~]`` → ``[ ]``  — a production task whose declared artifacts are missing
+                          (recorded UNVERIFIABLE if it already hit REJECT_CAP);
+  * ``[~]`` stays ``[~]`` — genuinely ambiguous (no detectable artifact path); it
+                          still needs the semantic verifier on a later tick.
+
+Default is DRY-RUN: it prints a per-project + total before/after count table and
+writes nothing. Pass ``--apply`` to persist the reclassification.
+
+Usage::
+
+    PYTHONPATH=src python scripts/maintenance/drain_under_review.py           # dry-run
+    PYTHONPATH=src python scripts/maintenance/drain_under_review.py --apply
+    PYTHONPATH=src python scripts/maintenance/drain_under_review.py --project PROJ-552-foo
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def _fmt_counts(c: dict[str, int]) -> str:
+    return f"X={c['X']:<4} open={c[' ']:<4} ~={c['~']:<4}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="write the reclassification to tasks.md (default: dry-run only)",
+    )
+    parser.add_argument(
+        "--repo-root", type=Path, default=None,
+        help="repository root (default: resolved via llmxive.config.repo_root)",
+    )
+    parser.add_argument(
+        "--project", action="append", default=None, metavar="PROJ-ID",
+        help="limit to specific project id(s); repeatable",
+    )
+    args = parser.parse_args(argv)
+
+    from llmxive.agents.task_verifier import drain_under_review
+    from llmxive.config import repo_root as _repo_root
+    from llmxive.state import project as project_store
+    from llmxive.state.project import feature_dir_for
+    from llmxive.types import Stage
+
+    root = args.repo_root.resolve() if args.repo_root else _repo_root()
+    want = set(args.project) if args.project else None
+
+    targets = [
+        p for p in project_store.list_all(repo_root=root)
+        if p.current_stage == Stage.IN_PROGRESS and (want is None or p.id in want)
+    ]
+
+    mode = "APPLY (writing)" if args.apply else "DRY-RUN (no writes)"
+    print(f"drain_under_review — {mode}")
+    print(f"repo root: {root}")
+    print(f"in_progress projects considered: {len(targets)}\n")
+
+    header = f"{'PROJECT':<34} {'BEFORE':<26} -> {'AFTER':<26} acc  reopen unv  amb"
+    print(header)
+    print("-" * len(header))
+
+    tot_before = {"X": 0, " ": 0, "~": 0}
+    tot_after = {"X": 0, " ": 0, "~": 0}
+    tot_acc = tot_reopen = tot_unv = tot_amb = 0
+    touched = 0
+
+    for p in targets:
+        project_dir = root / "projects" / p.id
+        fdir = feature_dir_for(project_dir, track="research")
+        if fdir is None:
+            continue
+        tasks_path = fdir / "tasks.md"
+        if not tasks_path.is_file():
+            continue
+        try:
+            if "- [~]" not in tasks_path.read_text(encoding="utf-8"):
+                continue  # nothing under review — skip the deterministic sweep
+        except OSError:
+            continue
+        try:
+            res = drain_under_review(
+                project_dir, tasks_path,
+                project_id=p.id, repo_root=root, apply=args.apply,
+            )
+        except Exception as exc:  # one bad project must not abort the sweep
+            print(f"{p.id:<34} ERROR: {type(exc).__name__}: {exc}")
+            continue
+
+        touched += 1
+        for k in tot_before:
+            tot_before[k] += res["before"][k]
+            tot_after[k] += res["after"][k]
+        tot_acc += res["accepted"]
+        tot_reopen += res["reopened"]
+        tot_unv += len(res["unverifiable"])
+        tot_amb += res["ambiguous"]
+        print(
+            f"{p.id:<34} {_fmt_counts(res['before']):<26} -> "
+            f"{_fmt_counts(res['after']):<26} "
+            f"{res['accepted']:<4} {res['reopened']:<6} "
+            f"{len(res['unverifiable']):<4} {res['ambiguous']}"
+        )
+
+    print("-" * len(header))
+    print(
+        f"{'TOTAL (' + str(touched) + ' projects w/ [~])':<34} "
+        f"{_fmt_counts(tot_before):<26} -> {_fmt_counts(tot_after):<26} "
+        f"{tot_acc:<4} {tot_reopen:<6} {tot_unv:<4} {tot_amb}"
+    )
+    if not args.apply:
+        print("\n(dry-run — re-run with --apply to persist these changes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/llmxive/agents/latex_build.py
+++ b/src/llmxive/agents/latex_build.py
@@ -4,8 +4,11 @@ The Build agent is mostly a wrapper around `pdflatex`; the LLM is
 consulted only to summarize errors. The Fix agent is LLM-driven —
 it edits .tex files to repair compile failures. The runtime alternates
 build/fix until the build succeeds OR a consecutive-failure cap is
-reached, at which point the project transitions to
-`human_input_needed`.
+reached. A persistent failure is NOT escalated to a human (spec 023 /
+issue #303 removed the retired `human_input_needed` transition — the
+sole human gate is publication DOI sign-off): the failure feeds the
+bounded repair loop via the shared revision machinery and is recorded
+as a defect in `state/paper_status/<id>.json`, never a human park.
 """
 
 from __future__ import annotations

--- a/src/llmxive/agents/lifecycle.py
+++ b/src/llmxive/agents/lifecycle.py
@@ -115,6 +115,13 @@ ALLOWED_TRANSITIONS: dict[Stage, set[Stage]] = {
         Stage.RESEARCH_COMPLETE, Stage.IN_PROGRESS,
         Stage.PLANNED, Stage.HUMAN_INPUT_NEEDED,
         Stage.VALIDATOR_REJECTED,
+        # issue #1139 P1-2 / sec 3.7: execution exhaustion (all model tiers AND
+        # all re-plans spent — the analysis simply cannot run in this
+        # environment) now routes to AGENT_BLOCKED, a distinct, operator-clearable,
+        # re-openable sink, instead of VALIDATOR_REJECTED. This keeps an
+        # infra/data-blocked GOOD idea (COMPUTE_ENV / DATA_UNREACHABLE
+        # FailureClass) from being counted as an idea-quality rejection.
+        Stage.AGENT_BLOCKED,
     },
     # research_complete is now a brief checkpoint where the
     # specialist reviewers run before research_review, so we allow

--- a/src/llmxive/agents/paper_figure_generation.py
+++ b/src/llmxive/agents/paper_figure_generation.py
@@ -16,6 +16,7 @@ from llmxive.agents.base import Agent, AgentContext
 from llmxive.agents.prompts import render_prompt
 from llmxive.backends.base import ChatMessage, ChatResponse
 from llmxive.config import repo_root as _repo_root
+from llmxive.state.project import feature_dir_for
 
 
 def _read_optional(path: Path) -> str:
@@ -49,8 +50,14 @@ class PaperFigureGenerationAgent(Agent):
 
         constitution = paper_dir / ".specify" / "memory" / "constitution.md"
         paper_constitution = _read_optional(constitution)
-        paper_plans = sorted((paper_dir / "specs").glob("*/plan.md"))
-        paper_plan_text = paper_plans[0].read_text(encoding="utf-8") if paper_plans else ""
+        # Resolve the CURRENT paper feature dir via the canonical pointer-first
+        # selector (state.project.feature_dir_for) rather than the first/oldest
+        # ``specs/*/`` glob, which resolves a STALE prior kickback cycle
+        # (spec 023 defect #17).
+        paper_feature_dir = feature_dir_for(project_dir, track="paper")
+        paper_plan_text = (
+            _read_optional(paper_feature_dir / "plan.md") if paper_feature_dir else ""
+        )
 
         data_summary = (
             _summarize_data_file(data_source_path) if data_source_path else "(no data path)"

--- a/src/llmxive/agents/paper_writing.py
+++ b/src/llmxive/agents/paper_writing.py
@@ -55,6 +55,13 @@ class PaperWritingAgent(Agent):
         paper_constitution = _read_optional(constitution)
         results_summary = _read_optional(project_dir / "results.md")
         existing = _read_optional(target_path) if target_path else ""
+        # Residual WRITING-level reviewer action items carried forward when the
+        # project advanced to research_accepted on the two-tier writing-only
+        # exhaustion path (advancement._carry_forward_writing_residue). These were
+        # judged minor (not science-blocking) but the paper-writing stage MUST
+        # still address them — thread the note forward so it is not a dead-end
+        # (issue #1139 anti-pattern 1: persist-and-forget -> persist-and-consume).
+        writing_residue = _read_optional(project_dir / "paper_writing_residue.md")
 
         system = render_prompt(
             "agents/prompts/paper_writing.md",
@@ -72,7 +79,11 @@ class PaperWritingAgent(Agent):
             f"# Paper plan.md\n\n{paper_plan_text}\n\n"
             f"# Paper constitution\n\n{paper_constitution}\n\n"
             f"# Research-stage results summary\n\n{results_summary}\n\n"
-            f"# Existing section text\n\n{existing}\n\n"
+            + (
+                f"# Residual reviewer notes to address (carried forward)\n\n"
+                f"{writing_residue}\n\n" if writing_residue.strip() else ""
+            )
+            + f"# Existing section text\n\n{existing}\n\n"
             "# Task\n\nReturn the YAML document per the contract."
         )
         return [

--- a/src/llmxive/agents/paper_writing.py
+++ b/src/llmxive/agents/paper_writing.py
@@ -19,6 +19,7 @@ from llmxive.agents.prompts import render_prompt
 from llmxive.backends.base import ChatMessage, ChatResponse
 from llmxive.config import repo_root as _repo_root
 from llmxive.speckit.yaml_extract import parse_yaml_lenient
+from llmxive.state.project import feature_dir_for
 
 
 def _read_optional(path: Path) -> str:
@@ -37,11 +38,19 @@ class PaperWritingAgent(Agent):
         target_path_rel = ctx.metadata.get("target_path", "")
         target_path = repo / target_path_rel if target_path_rel else None
 
-        # Pull paper-stage spec + plan + research-stage results.
-        paper_specs = sorted((paper_dir / "specs").glob("*/spec.md"))
-        paper_spec_text = paper_specs[0].read_text(encoding="utf-8") if paper_specs else ""
-        paper_plans = sorted((paper_dir / "specs").glob("*/plan.md"))
-        paper_plan_text = paper_plans[0].read_text(encoding="utf-8") if paper_plans else ""
+        # Pull paper-stage spec + plan + research-stage results. Resolve the
+        # CURRENT paper feature dir via the canonical pointer-first selector
+        # (state.project.feature_dir_for) rather than the first/oldest
+        # ``specs/*/`` glob: on a project that cycled through kickbacks the
+        # first-sorted dir is the STALE prior cycle, so the writer would compose
+        # against a superseded spec/plan (spec 023 defect #17).
+        paper_feature_dir = feature_dir_for(project_dir, track="paper")
+        paper_spec_text = (
+            _read_optional(paper_feature_dir / "spec.md") if paper_feature_dir else ""
+        )
+        paper_plan_text = (
+            _read_optional(paper_feature_dir / "plan.md") if paper_feature_dir else ""
+        )
         constitution = paper_dir / ".specify" / "memory" / "constitution.md"
         paper_constitution = _read_optional(constitution)
         results_summary = _read_optional(project_dir / "results.md")

--- a/src/llmxive/agents/proofreader.py
+++ b/src/llmxive/agents/proofreader.py
@@ -3,10 +3,22 @@
 Reads the assembled paper LaTeX source and emits a flag list. An
 empty flag list is a precondition for `paper_complete` (per FR-007's
 proofreader-flag-list-empty rule).
+
+A "clean" verdict is BOUND to the exact paper source it was computed
+against (a SHA-256 of the concatenated ``paper/source/**/*.tex``), the
+verifier version that produced it, and a freshness TTL. ``proofreader_clean``
+re-derives the CURRENT source hash and only reports clean when the stored
+verdict still matches — existence of a stored "clean" is NOT proof the
+current source is clean. Any drift (source edited, verifier bumped, verdict
+expired) is treated as stale and forces a bounded re-proofread rather than a
+silent pass (issue #1139 D13 — presence must never be mistaken for a fresh
+verified verdict).
 """
 
 from __future__ import annotations
 
+import hashlib
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import yaml
@@ -16,6 +28,15 @@ from llmxive.agents.prompts import render_prompt
 from llmxive.backends.base import ChatMessage, ChatResponse
 from llmxive.config import repo_root as _repo_root
 from llmxive.speckit.yaml_extract import parse_yaml_lenient
+
+#: Bump when the proofreader's flagging logic changes materially — a stored
+#: verdict produced by an older verifier is treated as stale (re-proofread).
+PROOFREADER_VERIFIER_VERSION = "proofreader/1"
+
+#: A stored "clean" verdict older than this is treated as stale even when the
+#: source is byte-identical, bounding how long a cached PASS is trusted.
+#: Generous by design (proofreading is re-run cheaply each paper round).
+PROOFREADER_VERDICT_TTL = timedelta(days=30)
 
 
 def _read_optional(path: Path) -> str:
@@ -31,6 +52,16 @@ def _concat_paper_source(paper_source_dir: Path) -> str:
         body = tex.read_text(encoding="utf-8", errors="ignore")
         out.append(f"=== {rel} ===\n{body}\n")
     return "\n".join(out)
+
+
+def _source_hash(paper_source_dir: Path) -> str:
+    """SHA-256 of the concatenated paper source — the input a proofreader verdict
+    is bound to. Identical between store (``handle_response``) and check
+    (``proofreader_clean``) so a source edit provably invalidates a stored verdict.
+    """
+    return hashlib.sha256(
+        _concat_paper_source(paper_source_dir).encode("utf-8")
+    ).hexdigest()
 
 
 class ProofreaderAgent(Agent):
@@ -70,6 +101,15 @@ class ProofreaderAgent(Agent):
         if not isinstance(doc, dict):
             raise RuntimeError("Proofreader YAML must be a mapping")
 
+        # BIND the verdict to the exact source it was computed against, the
+        # verifier version, and a wall-clock timestamp. proofreader_clean
+        # re-derives the source hash and refuses to report clean when any of
+        # these drift — so a "clean" verdict cannot survive a later source edit.
+        source_dir = repo / "projects" / ctx.project_id / "paper" / "source"
+        doc["source_hash"] = _source_hash(source_dir)
+        doc["verifier_version"] = PROOFREADER_VERIFIER_VERSION
+        doc["verified_at"] = datetime.now(UTC).isoformat()
+
         # Persist the flag list under the project's paper memory so the
         # paper_complete gate can read it.
         flags_path = (
@@ -86,8 +126,28 @@ class ProofreaderAgent(Agent):
         return [str(flags_path.relative_to(repo))]
 
 
-def proofreader_clean(project_id: str, *, repo_root: Path | None = None) -> bool:
-    """Return True iff the most recent proofreader run had an empty flag list."""
+def proofreader_clean(
+    project_id: str,
+    *,
+    repo_root: Path | None = None,
+    now: datetime | None = None,
+) -> bool:
+    """Return True iff a FRESH proofreader verdict certifies the CURRENT source.
+
+    "Fresh" is a positive gate — all of the following must hold:
+
+    * the stored verdict is ``clean`` with an empty flag list;
+    * the stored ``source_hash`` equals the hash of the CURRENT
+      ``paper/source/**/*.tex`` (a source edit after proofreading invalidates
+      the verdict — the D13 staleness fix);
+    * the stored ``verifier_version`` matches the current verifier; and
+    * the verdict has not aged past :data:`PROOFREADER_VERDICT_TTL`.
+
+    Any drift (or a legacy record written before verdicts were bound to a
+    source hash) is treated as STALE and reported NOT clean, so the
+    paper_complete gate re-runs a bounded proofread rather than trusting a
+    cached PASS on existence alone.
+    """
     repo = repo_root or _repo_root()
     flags_path = (
         repo
@@ -107,7 +167,30 @@ def proofreader_clean(project_id: str, *, repo_root: Path | None = None) -> bool
     if not isinstance(doc, dict):
         return False
     flags = doc.get("flags") or []
-    return doc.get("verdict") == "clean" and not flags
+    if doc.get("verdict") != "clean" or flags:
+        return False
+
+    # The verdict must still describe the source in front of us, must have been
+    # produced by the current verifier, and must not have expired. Otherwise it
+    # is stale — re-proofread rather than silently pass.
+    source_dir = repo / "projects" / project_id / "paper" / "source"
+    if doc.get("source_hash") != _source_hash(source_dir):
+        return False
+    if doc.get("verifier_version") != PROOFREADER_VERIFIER_VERSION:
+        return False
+    verified_at_raw = doc.get("verified_at")
+    if not verified_at_raw:
+        return False
+    try:
+        verified_at = datetime.fromisoformat(str(verified_at_raw))
+    except ValueError:
+        return False
+    if verified_at.tzinfo is None:
+        verified_at = verified_at.replace(tzinfo=UTC)
+    current = now or datetime.now(UTC)
+    if current - verified_at > PROOFREADER_VERDICT_TTL:
+        return False
+    return True
 
 
 __all__ = ["ProofreaderAgent", "proofreader_clean"]

--- a/src/llmxive/agents/reference_validator.py
+++ b/src/llmxive/agents/reference_validator.py
@@ -230,24 +230,30 @@ def validate_artifact(
 
 
 def has_blocking_citations(project_id: str, *, repo_root: Path | None = None) -> bool:
-    """Return True iff the project has any unreachable or mismatch citations.
+    """Return True iff the project has ANY citation that is not currently VERIFIED.
 
-    This is the gate the Advancement-Evaluator consults at the
-    research_review → research_accepted and paper_review → paper_accepted
-    transitions.
+    POSITIVE gate (issue #1139 D15): a project may advance ONLY when EVERY
+    citation carries a fresh ``VERIFIED`` verdict. Anything else — ``PENDING``
+    (present-but-unverified: access-gated, redirect stub, or a bare URL/DOI/id
+    with no cross-checkable title), ``UNREACHABLE``, ``MISMATCH``, or any future
+    non-verified status — is BLOCKING. Existence is no longer mistaken for
+    verification: an unverified reference triggers bounded retry / substitution
+    upstream instead of silently passing the gate.
+
+    A project with no citations is not blocked (there is nothing to verify).
+    This gate is consulted at the research_review → research_accepted /
+    paper_review → paper_accepted transitions and at the paper_complete
+    publish-readiness check.
     """
     cits = citations_store.load(project_id, repo_root=repo_root)
-    return any(
-        c.verification_status in {VerificationStatus.UNREACHABLE, VerificationStatus.MISMATCH}
-        for c in cits
-    )
+    return any(c.verification_status != VerificationStatus.VERIFIED for c in cits)
 
 
 def project_has_unverified_for_review(project: Project, *, repo_root: Path | None = None) -> bool:
-    """FIX C2: applied by Advancement-Evaluator before awarding any review point.
+    """FIX C2: applied by Advancement-Evaluator before advancing a review stage.
 
-    Returns True if the project's reviewed artifacts contain any
-    citation that did not pass verification. Identical semantics to
+    Returns True if the project's reviewed artifacts contain any citation that
+    is not currently VERIFIED. Identical (positive-gate) semantics to
     has_blocking_citations() but accepts a Project for ergonomics.
     """
     return has_blocking_citations(project.id, repo_root=repo_root)

--- a/src/llmxive/agents/task_verifier.py
+++ b/src/llmxive/agents/task_verifier.py
@@ -3,25 +3,42 @@
 The speckit implementer checks off a task as soon as it BELIEVES it did the work.
 That self-report is exactly how a project's implementation can drift from its spec
 (PROJ-604: tasks claimed a benchmark was produced; the artifacts were random
-numbers). This module adds an INDEPENDENT check — a SEPARATE LLM call, outside the
-implementer's prompt/session — that looks at the task's REQUIREMENTS and the ACTUAL
+numbers). This module adds an INDEPENDENT check — outside the implementer's
+prompt/session — that looks at the task's REQUIREMENTS and the ACTUAL
 artifacts/evidence and decides whether the work is genuinely done.
 
-Flow (wired in ``pipeline.graph`` run_one_step, after the implement batch):
-  - implementer marks a task ``- [X]`` (claims done),
-  - the verifier judges it: COMPLETE → keep ``- [X]``; INCOMPLETE → mark
-    ``- [~]`` (under review) and append the reason to a notes file the NEXT
-    implementer session reads as context,
-  - a transient backend failure DEFERS (``- [~]``) — never silently accepts —
-    so a task is checked off complete ONLY on a real COMPLETE verdict.
+Two-tier verification (issue #1139, defect D6 — throughput + fail-open fix):
 
-Modeled on ``librarian.relevance_judge`` (a deterministic, temp-0 LLM judge), but
-fails CLOSED (defer), not open: an unverifiable task must not count as done.
+  1. DETERMINISTIC-FIRST (free, no LLM). Before spending any model call, each
+     claimed/under-review task is settled from FILESYSTEM STATE: a task whose
+     declared artifacts all exist and validate (data outputs parse + have rows)
+     is ACCEPTED ``[X]``; a production task whose declared artifacts are all
+     missing/empty is REOPENED ``[ ]``. This is what drains the huge ``[~]``
+     backlog cheaply — the throughput lever is deterministic draining, NOT a
+     bigger LLM cap. The artifact-path detector is broadened well beyond the old
+     code/data/figures/results/outputs roots (now also src/, tests/, scripts/,
+     config/, and bare build/config files) so setup/config/test tasks are judged
+     from STATE, not prose.
+  2. SEMANTIC RESIDUE (bounded LLM). Only genuinely ambiguous tasks (no
+     detectable artifact path, or a mixed/partial state) reach the single
+     temp-0 LLM call in :func:`verify_task`, bounded to ``cap`` calls per tick.
+     Each semantic verdict is bound to a ``(task_key, evidence_hash)`` cache so
+     re-verifying an unchanged task is free and a verdict invalidates the moment
+     the evidence bytes change.
+
+Verdict → mark: COMPLETE → ``[X]``; INCOMPLETE → ``[ ]`` (implementer REDOES it)
++ a note the next session reads; DEFER (backend outage / over-cap) → ``[~]``
+(under review; re-verified later, NOT redone). A task that receives ``REJECT_CAP``
+consecutive INCOMPLETE verdicts is NEVER force-accepted — it is reopened ``[ ]``
+AND recorded in :mod:`llmxive.state.unverifiable`, which stops the redo loop
+(the recorded task is not re-judged until cleared) and signals CORE to route the
+project to ``research_full_revision``. Fails CLOSED (defer), never open.
 """
 
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import logging
 import re
 from pathlib import Path
@@ -60,11 +77,47 @@ Then 1-3 sentences naming the evidence you checked. If INCOMPLETE, state CONCRET
 what is missing or wrong, so the next implementer can fix it.
 """
 
-# File paths a task line references (the evidence to inspect): code/data/figures/
-# results/outputs rooted, with a real extension.
-_PATH_RE = re.compile(r"\b((?:code|data|figures|results|outputs)/[\w./-]+\.\w+)")
+# --- Artifact-path detection (the deterministic evidence a task line references) ---
+#
+# Broadened well beyond the original code/data/figures/results/outputs roots so
+# scaffolding / config / test tasks are judged from real files, not prose.
+#: Directory-rooted artifact paths with a real dotted extension.
+_ROOTED_PATH_RE = re.compile(
+    r"\b((?:code|data|figures|results|outputs|src|tests?|scripts|config|configs|"
+    r"notebooks|docs|assets|models|reports)/[\w./-]+\.\w+)"
+)
+#: Bare (optionally path-prefixed) build/config filenames a task may reference.
+_CONFIG_FILE_RE = re.compile(
+    r"\b((?:[\w./-]+/)?(?:pyproject\.toml|setup\.cfg|setup\.py|"
+    r"requirements(?:-[\w.]+)?\.txt|environment\.ya?ml|tox\.ini|noxfile\.py|"
+    r"conftest\.py|pytest\.ini|mkdocs\.ya?ml|Makefile|Dockerfile))\b"
+)
+#: Generic config-extension files (…toml/…cfg/…yaml/…ini) referenced under the project.
+_CONFIG_EXT_RE = re.compile(r"\b((?:[\w./-]+/)?[\w-]+\.(?:toml|cfg|ya?ml|ini))\b")
+#: Back-compat alias — some callers/tests reference the historical single regex; it
+#: now points at the primary rooted-path pattern (the deterministic detector uses
+#: the full :func:`_declared_paths` union).
+_PATH_RE = _ROOTED_PATH_RE
+
 _MAX_EVIDENCE_FILES = 6
 _MAX_BYTES_PER_FILE = 3000
+#: Cap bytes read when VALIDATING a data/JSON artifact (parse cheaply, not fully).
+_VALIDATE_MAX_BYTES = 200_000
+_DATA_EXTS = {".csv", ".tsv"}
+_JSON_EXTS = {".json"}
+
+#: A task line whose text shows the implementer was meant to PRODUCE an artifact.
+#: Gate for deterministic-REJECT (a "remove/delete" task legitimately ends with the
+#: artifact absent, so those are routed to the semantic verifier instead).
+_PRODUCE_RE = re.compile(
+    r"\b(creat\w*|writ\w*|produc\w*|generat\w*|implement\w*|add\w*|build\w*|"
+    r"sav\w*|export\w*|output\w*|comput\w*|plot\w*|train\w*|populat\w*|render\w*|"
+    r"serializ\w*|dump\w*|emit\w*|scaffold\w*|configur\w*|initializ\w*|set up|setup)\b",
+    re.IGNORECASE,
+)
+_REMOVE_RE = re.compile(
+    r"\b(remov\w*|delet\w*|drop\w*|deprecat\w*|clean up)\b", re.IGNORECASE
+)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -80,18 +133,87 @@ class TaskVerdict:
         return self.complete is None
 
 
-def gather_evidence(project_dir: Path, task_text: str) -> str:
-    """Collect the artifacts a task references (head of each) as evidence text."""
-    paths = []
+def _declared_paths(task_text: str) -> list[str]:
+    """Every artifact path a task line references (rooted paths + build/config
+    files), de-duplicated in first-seen order."""
+    out: list[str] = []
     seen: set[str] = set()
-    for m in _PATH_RE.finditer(task_text):
-        rel = m.group(1)
-        if rel in seen:
-            continue
-        seen.add(rel)
-        paths.append(rel)
-        if len(paths) >= _MAX_EVIDENCE_FILES:
-            break
+    for rx in (_ROOTED_PATH_RE, _CONFIG_FILE_RE, _CONFIG_EXT_RE):
+        for m in rx.finditer(task_text):
+            rel = m.group(1)
+            if rel and rel not in seen:
+                seen.add(rel)
+                out.append(rel)
+    return out
+
+
+def _artifact_valid(project_dir: Path, rel: str) -> bool:
+    """True iff ``rel`` exists, is non-empty, AND (for declared data outputs) parses
+    with at least one data row. Pure filesystem + stdlib parse — never an LLM."""
+    import json
+
+    f = project_dir / rel
+    if not f.is_file():
+        return False
+    try:
+        size = f.stat().st_size
+    except OSError:
+        return False
+    if size == 0:
+        return False
+    ext = f.suffix.lower()
+    try:
+        if ext in _DATA_EXTS:
+            text = f.read_text(encoding="utf-8", errors="ignore")[:_VALIDATE_MAX_BYTES]
+            rows = [ln for ln in text.splitlines() if ln.strip()]
+            return len(rows) >= 2  # header + >=1 data row
+        if ext in _JSON_EXTS:
+            if size > _VALIDATE_MAX_BYTES:
+                return True  # too large to parse cheaply; non-empty is the check
+            data = json.loads(f.read_text(encoding="utf-8", errors="ignore") or "null")
+            if isinstance(data, (list, dict)):
+                return len(data) > 0
+            return data is not None
+        # code / config / text / binary artifact: non-empty with real content.
+        return bool(f.read_bytes()[:_VALIDATE_MAX_BYTES].strip())
+    except (OSError, ValueError):
+        return False  # a malformed data/JSON file is NOT valid evidence
+
+
+def _has_production_intent(task_text: str) -> bool:
+    return bool(_PRODUCE_RE.search(task_text)) and not _REMOVE_RE.search(task_text)
+
+
+def _deterministic_verdict(project_dir: Path, task_text: str) -> tuple[str | None, str]:
+    """Settle a claimed task from FILESYSTEM STATE alone — no LLM.
+
+    Returns ``("accept", reason)`` when every declared artifact exists and
+    validates, ``("reject", reason)`` when a production task's declared artifacts
+    are all missing/empty/invalid, or ``(None, "")`` when the task is genuinely
+    ambiguous (no detectable artifact path, or a mixed/partial state) and must go
+    to the semantic verifier."""
+    paths = _declared_paths(task_text)
+    if not paths:
+        return None, ""
+    statuses = [(p, _artifact_valid(project_dir, p)) for p in paths]
+    if all(valid for _, valid in statuses):
+        present = ", ".join(p for p, _ in statuses)
+        return "accept", f"all declared artifacts exist and validate: {present}"
+    missing = [p for p, valid in statuses if not valid]
+    if len(missing) == len(statuses) and _has_production_intent(task_text):
+        return "reject", (
+            f"declared artifact(s) missing/empty/invalid: {', '.join(missing)}"
+        )
+    return None, ""
+
+
+def gather_evidence(project_dir: Path, task_text: str) -> str:
+    """Collect the artifacts a task references (head of each) as evidence text.
+
+    Uses the broadened :func:`_declared_paths` detector, so a setup/config/test
+    task (``pyproject.toml``, ``tests/…``, ``src/…``) yields REAL file evidence
+    instead of the "no artifact path" prose fallback."""
+    paths = _declared_paths(task_text)[:_MAX_EVIDENCE_FILES]
     chunks: list[str] = []
     for rel in paths:
         f = project_dir / rel
@@ -182,12 +304,17 @@ def _parse(text: str) -> TaskVerdict:
 # A task line in tasks.md: ``- [ ] T001 [P?] [US1?] desc with path``. group(1) is
 # the bullet+space prefix, group(2) the mark, group(3) the rest (id + desc).
 _TASK_LINE_RE = re.compile(r"^(\s*-\s*)\[([ xX~])\](\s.*)$")
-#: A task the implementer keeps failing verification is, after this many
-#: consecutive rejections, ACCEPTED with a logged warning — the downstream LLM
-#: review panel is the final backstop, and an unbreakable redo loop would
-#: otherwise wedge the project forever at in_progress.
+#: A task that receives this many consecutive INCOMPLETE verdicts is NOT
+#: force-accepted (that was the fail-open removed in issue #1139). It is reopened
+#: ``[ ]`` AND recorded in :mod:`llmxive.state.unverifiable`, which BOTH breaks the
+#: redo loop (the recorded task is not re-judged until cleared) and signals CORE to
+#: route the whole project to ``research_full_revision``. Incomplete work must
+#: never count as done.
 REJECT_CAP = 3
-#: Max verifier LLM calls per tick (bounds cost; the rest verify on later ticks).
+#: Max verifier LLM calls per tick (bounds cost). Deterministic accepts/rejects and
+#: evidence-hash cache hits are FREE and do NOT count against this — so the huge
+#: ``[~]`` backlog drains without a bigger cap; only genuinely ambiguous residue
+#: consumes the budget, and anything past it defers to a later tick.
 DEFAULT_VERIFY_CAP = 6
 
 
@@ -255,6 +382,49 @@ def claimed_done_keys(tasks_text: str) -> set[str]:
     return out
 
 
+def _resolve_ids(
+    project_dir: Path, project_id: str | None, repo_root: Path | None
+) -> tuple[str, Path]:
+    """Derive ``(project_id, repo_root)`` from ``project_dir`` when not supplied.
+
+    graph.py calls the verifier with only ``project_dir`` (``…/projects/<id>``), so
+    the project id is the dir name and the repo root is two levels up. Tests may
+    pass either explicitly (e.g. a ``tmp_path`` project dir that is itself the root)."""
+    pid = project_id if project_id is not None else project_dir.name
+    if repo_root is not None:
+        return pid, repo_root
+    if project_dir.parent.name == "projects":
+        return pid, project_dir.parent.parent
+    return pid, project_dir
+
+
+def _evidence_hash(evidence: str) -> str:
+    return hashlib.sha256(evidence.encode("utf-8")).hexdigest()
+
+
+def _cache_path(state_path: Path) -> Path:
+    """Sibling of the reject-count state file holding the (key -> evidence-hash +
+    verdict) cache. Kept separate so the reject-count file's schema is unchanged."""
+    return state_path.parent / "task_verify_cache.yaml"
+
+
+def _mark_counts(lines: list[str]) -> dict[str, int]:
+    """Count real checkbox marks by kind (``X`` done / `` `` open / ``~`` under-review)."""
+    out = {"X": 0, " ": 0, "~": 0}
+    for line in lines:
+        m = _TASK_LINE_RE.match(line)
+        if not m:
+            continue
+        mk = m.group(2)
+        if mk in ("x", "X"):
+            out["X"] += 1
+        elif mk == "~":
+            out["~"] += 1
+        else:
+            out[" "] += 1
+    return out
+
+
 def run_verification_pass(
     project_dir: Path,
     tasks_path: Path,
@@ -267,19 +437,37 @@ def run_verification_pass(
     notes_path: Path,
     state_path: Path,
     cap: int = DEFAULT_VERIFY_CAP,
+    project_id: str | None = None,
+    repo_root: Path | None = None,
 ) -> dict[str, Any]:
     """Independently verify each newly-claimed (``[X]`` not in ``already_verified``)
-    or previously-deferred (``[~]``) task in ``tasks_path``, rewriting its mark:
+    or previously-deferred (``[~]``) task in ``tasks_path``, rewriting its mark.
+
+    Two tiers (issue #1139): every task is first settled DETERMINISTICALLY from
+    filesystem state (free) — declared artifacts all valid → ``[X]``; a production
+    task's declared artifacts all missing → ``[ ]``. Only genuinely ambiguous tasks
+    reach the bounded (``cap``) semantic LLM, whose verdicts are cached by
+    ``(task_key, evidence_hash)`` so unchanged tasks re-verify for free and a verdict
+    invalidates the instant the evidence bytes change.
 
       - COMPLETE   → ``[X]`` (truly done),
       - INCOMPLETE → ``[ ]`` (implementer REDOES it) + a note in ``notes_path``;
-        after ``REJECT_CAP`` rejections the task is accepted (``[X]``) with a log,
-      - DEFER      → ``[~]`` (under review; re-verified next tick, NOT redone).
+        after ``REJECT_CAP`` consecutive INCOMPLETE verdicts the task is NEVER
+        force-accepted — it is reopened ``[ ]`` AND recorded in
+        :mod:`llmxive.state.unverifiable` (loop broken by escalation, not by lying),
+      - DEFER      → ``[~]`` (under review; re-verified later, NOT redone).
 
-    Returns a summary dict ``{accepted, rejected:[(key,reason)], deferred:[key]}``.
-    Bounded to ``cap`` LLM calls per tick. Pure file IO + the injected
-    :func:`verify_task`; safe to call once per implement-batch."""
+    Returns ``{accepted, rejected:[(key,reason)], deferred:[key],
+    unverifiable:[key]}``. ``unverifiable`` is non-empty iff this pass recorded (or
+    re-encountered) a repeatedly-unverifiable task — CORE routes such a project to
+    ``research_full_revision`` (see :mod:`llmxive.state.unverifiable`). Pure file IO
+    + the injected :func:`verify_task`; safe to call once per implement-batch."""
     import yaml
+
+    from llmxive.state import unverifiable as _unv
+    from llmxive.state._io import atomic_write_text
+
+    project_id, repo_root = _resolve_ids(project_dir, project_id, repo_root)
 
     text = tasks_path.read_text(encoding="utf-8")
     lines = text.splitlines()
@@ -289,12 +477,47 @@ def run_verification_pass(
         reject_counts = {}
     if not isinstance(reject_counts, dict):
         reject_counts = {}
+    cache_path = _cache_path(state_path)
+    try:
+        cache = yaml.safe_load(cache_path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        cache = {}
+    if not isinstance(cache, dict):
+        cache = {}
+    unv_keys = _unv.recorded_keys(project_id, repo_root=repo_root)
 
     accepted = 0
     rejected: list[tuple[str, str]] = []
     deferred: list[str] = []
+    unverifiable_flagged: list[str] = []
     budget = cap
     keys = task_keys(lines)  # unique + churn-stable; see task_keys()
+
+    def _accept(i: int, m: re.Match[str], rest: str, key: str) -> None:
+        nonlocal accepted
+        lines[i] = f"{m.group(1)}[X]{rest}"
+        accepted += 1
+        reject_counts.pop(key, None)
+
+    def _reject(i: int, m: re.Match[str], rest: str, key: str, reason: str) -> None:
+        count = int(reject_counts.get(key, 0)) + 1
+        reject_counts[key] = count
+        lines[i] = f"{m.group(1)}[ ]{rest}"
+        rejected.append((key, reason))
+        if count >= REJECT_CAP:
+            _unv.record_unverifiable(project_id, key, reason, repo_root=repo_root)
+            reject_counts.pop(key, None)
+            cache.pop(key, None)
+            unv_keys.add(key)
+            if key not in unverifiable_flagged:
+                unverifiable_flagged.append(key)
+            LOGGER.warning(
+                "[task-verifier] %r rejected %dx — recording UNVERIFIABLE and "
+                "reopening [ ] (project routes to research_full_revision; never "
+                "force-accepted)",
+                key, count,
+            )
+
     for i, line in enumerate(lines):
         m = _TASK_LINE_RE.match(line)
         if not m:
@@ -305,64 +528,183 @@ def run_verification_pass(
         under_review = mark == "~"
         if not (newly_claimed or under_review):
             continue
-        if budget <= 0:
-            # Over the per-tick LLM cap → DEFER to a later tick. Mark ``[~]`` so an
-            # unverified ``[X]`` does not silently escape verification (next tick's
-            # snapshot would otherwise treat it as already-accepted).
+        task_text = rest.strip()
+
+        # (A) Already recorded UNVERIFIABLE → do NOT re-judge (this is what breaks
+        # the loop REJECT_CAP used to paper over). Keep it OUT of the done set
+        # (reopen ``[ ]``) and re-signal so CORE still routes to re-plan.
+        if key in unv_keys:
+            if mark != " ":
+                lines[i] = f"{m.group(1)}[ ]{rest}"
+            if key not in unverifiable_flagged:
+                unverifiable_flagged.append(key)
+            continue
+
+        # (B) DETERMINISTIC-FIRST settle (no LLM) — drains the ``[~]`` backlog cheaply.
+        det, det_reason = _deterministic_verdict(project_dir, task_text)
+        if det == "accept":
+            _accept(i, m, rest, key)
+            continue
+        if det == "reject":
+            _reject(i, m, rest, key, det_reason)
+            continue
+
+        # (C) Ambiguous residue → evidence-hash cache, else bounded semantic LLM.
+        evidence = gather_evidence(project_dir, rest)
+        ev_hash = _evidence_hash(evidence)
+        cached = cache.get(key)
+        if (
+            isinstance(cached, dict)
+            and cached.get("h") == ev_hash
+            and isinstance(cached.get("c"), bool)
+        ):
+            complete: bool | None = cached["c"]
+            reason = str(cached.get("r") or "(cached verdict; evidence unchanged)")
+        elif budget <= 0:
+            # Over the per-tick LLM cap with no cache hit → DEFER to a later tick.
             if mark != "~":
                 lines[i] = f"{m.group(1)}[~]{rest}"
             deferred.append(key)
             continue
-        budget -= 1
-        verdict = verify_task(
-            task_text=rest.strip(),
-            evidence=gather_evidence(project_dir, rest),
-            spec_context=spec_context,
-            model=model,
-            default_backend=default_backend,
-            fallback_backends=fallback_backends,
-        )
-        if verdict.complete is True:
-            lines[i] = f"{m.group(1)}[X]{rest}"
-            accepted += 1
-            reject_counts.pop(key, None)
-        elif verdict.complete is False:
-            count = int(reject_counts.get(key, 0)) + 1
-            reject_counts[key] = count
-            if count >= REJECT_CAP:
-                lines[i] = f"{m.group(1)}[X]{rest}"
-                reject_counts.pop(key, None)
-                LOGGER.warning(
-                    "[task-verifier] %r rejected %dx — accepting to avoid an "
-                    "unbreakable redo loop (review panel is the final backstop)",
-                    key, count,
-                )
-            else:
-                lines[i] = f"{m.group(1)}[ ]{rest}"
-                rejected.append((key, verdict.reason))
+        else:
+            budget -= 1
+            verdict = verify_task(
+                task_text=task_text,
+                evidence=evidence,
+                spec_context=spec_context,
+                model=model,
+                default_backend=default_backend,
+                fallback_backends=fallback_backends,
+            )
+            complete = verdict.complete
+            reason = verdict.reason
+            if complete is not None:
+                cache[key] = {"h": ev_hash, "c": complete, "r": reason[:600]}
+
+        if complete is True:
+            _accept(i, m, rest, key)
+        elif complete is False:
+            _reject(i, m, rest, key, reason)
         else:  # deferred (backend outage / unparseable)
             lines[i] = f"{m.group(1)}[~]{rest}"
             deferred.append(key)
 
     new_text = "\n".join(lines) + ("\n" if text.endswith("\n") else "")
     if new_text != text:
-        tasks_path.write_text(new_text, encoding="utf-8")
+        atomic_write_text(tasks_path, new_text)
 
-    # Drop reject counts for tasks that no longer exist in tasks.md. This also
-    # self-heals the legacy text-keyed entries stranded by the identity fix above
-    # (projects had accumulated ~205 dead keys for ~132 real tasks), so a task's
-    # count reflects ONLY its own consecutive rejections and REJECT_CAP can fire.
+    # Drop reject counts / cache entries for tasks that no longer exist in tasks.md.
+    # This also self-heals legacy text-keyed entries stranded by the identity fix, so
+    # a task's count reflects ONLY its own consecutive rejections and REJECT_CAP fires.
     live_keys = set(task_keys(lines).values())
     reject_counts = {k: v for k, v in reject_counts.items() if k in live_keys}
+    cache = {k: v for k, v in cache.items() if k in live_keys}
 
     state_path.parent.mkdir(parents=True, exist_ok=True)
     if reject_counts:
-        state_path.write_text(yaml.safe_dump(reject_counts, sort_keys=True), encoding="utf-8")
+        atomic_write_text(state_path, yaml.safe_dump(reject_counts, sort_keys=True))
     else:
         state_path.unlink(missing_ok=True)
+    if cache:
+        atomic_write_text(cache_path, yaml.safe_dump(cache, sort_keys=True))
+    else:
+        cache_path.unlink(missing_ok=True)
 
     _write_notes(notes_path, rejected)
-    return {"accepted": accepted, "rejected": rejected, "deferred": deferred}
+    return {
+        "accepted": accepted,
+        "rejected": rejected,
+        "deferred": deferred,
+        "unverifiable": unverifiable_flagged,
+    }
+
+
+def drain_under_review(
+    project_dir: Path,
+    tasks_path: Path,
+    *,
+    project_id: str | None = None,
+    repo_root: Path | None = None,
+    state_path: Path | None = None,
+    apply: bool = True,
+) -> dict[str, Any]:
+    """LLM-FREE maintenance sweep over a project's ``[~]`` (under-review) tasks.
+
+    Re-runs the DETERMINISTIC checks (no model call) and reclassifies each ``[~]``:
+    ``[~]``→``[X]`` when its declared artifacts now exist+validate; ``[~]``→``[ ]``
+    when a production task's declared artifacts are missing (recording it
+    UNVERIFIABLE when its stored reject_count already reached ``REJECT_CAP``); and
+    a task already flagged unverifiable is reopened ``[ ]``. Genuinely-ambiguous
+    ``[~]`` tasks (no detectable path) are LEFT ``[~]`` — they still need the
+    semantic verifier. With ``apply=False`` (dry-run) the reclassification is
+    computed WITHOUT writing tasks.md or recording anything.
+
+    Returns ``{project_id, before:{X,' ',~}, after:{…}, accepted, reopened,
+    unverifiable:[key], ambiguous}`` (``before``/``after`` are mark counts)."""
+    import yaml
+
+    from llmxive.state import unverifiable as _unv
+    from llmxive.state._io import atomic_write_text
+
+    project_id, repo_root = _resolve_ids(project_dir, project_id, repo_root)
+    if state_path is None:
+        state_path = project_dir / ".specify" / "memory" / "task_verify.yaml"
+
+    text = tasks_path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    try:
+        reject_counts = yaml.safe_load(state_path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        reject_counts = {}
+    if not isinstance(reject_counts, dict):
+        reject_counts = {}
+    unv_keys = _unv.recorded_keys(project_id, repo_root=repo_root)
+    keys = task_keys(lines)
+    before = _mark_counts(lines)
+
+    accepted = reopened = ambiguous = 0
+    newly_unverifiable: list[str] = []
+    for i, line in enumerate(lines):
+        m = _TASK_LINE_RE.match(line)
+        if not m or m.group(2) != "~":
+            continue
+        rest = m.group(3)
+        key = keys[i]
+        task_text = rest.strip()
+        if key in unv_keys:
+            lines[i] = f"{m.group(1)}[ ]{rest}"
+            reopened += 1
+            continue
+        det, reason = _deterministic_verdict(project_dir, task_text)
+        if det == "accept":
+            lines[i] = f"{m.group(1)}[X]{rest}"
+            accepted += 1
+        elif det == "reject":
+            lines[i] = f"{m.group(1)}[ ]{rest}"
+            reopened += 1
+            if int(reject_counts.get(key, 0)) >= REJECT_CAP:
+                if apply:
+                    _unv.record_unverifiable(
+                        project_id, key, reason, repo_root=repo_root
+                    )
+                newly_unverifiable.append(key)
+        else:
+            ambiguous += 1  # leave [~] — needs the semantic verifier
+
+    after = _mark_counts(lines)
+    if apply:
+        new_text = "\n".join(lines) + ("\n" if text.endswith("\n") else "")
+        if new_text != text:
+            atomic_write_text(tasks_path, new_text)
+    return {
+        "project_id": project_id,
+        "before": before,
+        "after": after,
+        "accepted": accepted,
+        "reopened": reopened,
+        "unverifiable": newly_unverifiable,
+        "ambiguous": ambiguous,
+    }
 
 
 def _write_notes(notes_path: Path, rejected: list[tuple[str, str]]) -> None:
@@ -392,6 +734,7 @@ __all__ = [
     "VERIFIER_TEMPERATURE",
     "TaskVerdict",
     "claimed_done_keys",
+    "drain_under_review",
     "gather_evidence",
     "run_verification_pass",
     "task_keys",

--- a/src/llmxive/checks/state_readers.py
+++ b/src/llmxive/checks/state_readers.py
@@ -1,0 +1,348 @@
+"""State-artifact reader pre-check (issue #1139, anti-pattern 1).
+
+Anti-pattern 1 ("dead-end verified artifact") is a stage that COMPUTES/persists a
+durable state artifact that NOTHING downstream reads — so the work is thrown away
+(the ``resolved_datasets.yaml`` case: written 676 times, read by nobody). This guard
+makes that class of defect a CI failure instead of a latent dead-end.
+
+Rule: **every fixed-name artifact a non-test source module WRITES under
+``state/`` or ``.specify/memory/`` must also be READ by non-test source** — a
+writer with no reader (its own store's ``load`` counts; only-test readers do not)
+is a dead-end and fails the check.
+
+The analysis is AST dataflow, associating each write/read verb with the SPECIFIC
+artifact basename it touches (so a module that writes ``a.yaml`` and separately
+reads ``b.yaml`` does not falsely count as reading ``a.yaml``):
+
+* Module-level ``NAME = "foo.yaml"`` constants and same-module path helpers
+  (functions that ``return <path built from a basename>``) are resolved, so
+  ``(dir / _CACHE_NAME).write_text(...)`` and ``_cache_path(...).read_text()``
+  both resolve to the basename.
+* Local variables are tracked within each function: ``p = dir / "x.yaml"`` then
+  ``p.write_text(...)`` associates the write with ``x.yaml``.
+* Per-project files with DYNAMIC names (``f"{project_id}.json"``) carry no fixed
+  basename, so they are naturally out of scope — always read by their own
+  store's ``load``.
+* A basename is IN SCOPE only if it is written on a path that references a
+  ``state`` / ``.specify`` / ``memory`` segment (machine state, not content
+  artifacts like ``spec.md`` or prompt files).
+
+Artifacts intentionally consumed OUTSIDE non-test Python (the web dashboard, git,
+humans) are listed in :data:`ALLOWLIST` with a justification. Exits 1 with one
+line per dead-end.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+from llmxive.config import repo_root as _repo_root
+
+_SOURCE_ROOTS = ("src/llmxive", "agents")
+_ARTIFACT_SUFFIXES = (".yaml", ".yml", ".json", ".md")
+_STATE_TOKENS = {"state", ".specify", "memory", ".specify/memory"}
+
+#: Method names that READ a path (receiver is the path expression).
+_READ_METHODS = {"read_text", "read_bytes", "exists", "is_file", "glob", "rglob",
+                 "iterdir", "open"}
+#: Method names that WRITE a path (receiver is the path expression).
+_WRITE_METHODS = {"write_text", "write_bytes"}
+#: Free functions that WRITE, path = first positional arg.
+_WRITE_FUNCS = {"atomic_write_text", "atomic_write_text_cas"}
+#: Free functions that READ, path = first positional arg (``open(path)``).
+_READ_FUNCS = {"open"}
+
+ALLOWLIST: dict[str, str] = {
+    # A human-readable consolidated peer-review artifact committed to git (222
+    # files under projects/**/paper/) and read by maintainers/authors. It is a
+    # RENDERED VIEW, not a pipeline input: the underlying action-item DATA is
+    # threaded forward from the review records (paper/reviews/*) in-memory to the
+    # review PDF (paper_reprocess.preprint_pdf.build_peer_review_tex) and to the
+    # dashboard via web/data/projects.json's `action_items` field. So the writer
+    # is NOT a dead-end — its consumer is human/git, not non-test src.
+    "action_items.md": (
+        "human-readable committed peer-review artifact; action-item data is "
+        "threaded forward via review records -> review PDF + dashboard JSON"
+    ),
+    # The dashboard data file: consumed by the web dashboard (web/js/app.js,
+    # web/js/dialog.js) and committed to docs/data/. No Python consumer by design
+    # (web_data + status_reporter GENERATE it).
+    "projects.json": "dashboard data file consumed by web/js + committed docs/",
+    # The Kaggle kernel spec that offload.dispatch writes and PUSHES; the Kaggle
+    # API/CLI is the consumer (issue #367 GPU offload), not non-test src.
+    "kernel-metadata.json": "Kaggle kernel spec consumed by the Kaggle API on push",
+    # Read by the implementer via `round_dir.glob('*.md')` (spec-012 auto-revisions
+    # round contract, agents/implementer.py ~L2208) — consumed by a directory glob,
+    # so it is never named literally for a by-name static reader to see.
+    "analyze-report.md": "read by implementer via round_dir.glob('*.md') (spec-012)",
+    # Human reproduction guide for a reprocessed code paper; surfaced as a project
+    # artifact link in web/data/projects.json (dashboard), read by humans.
+    "reproduction.md": "human reproduction guide; surfaced as a dashboard artifact",
+    # Documented human-facing deliverable of the arXiv/reprocess intake bundle
+    # (paper_reprocess/__init__ lists it); the actionable code-resource data is
+    # threaded via metadata.json (consumed by paper_reprocess/classify.py).
+    "external_resources.md": (
+        "documented human-facing intake deliverable; code-resource data threaded "
+        "via metadata.json (consumed by classify.py)"
+    ),
+    # Intentional provenance/historical marker, EXPLICITLY documented at
+    # pipeline/graph.py ~L1696 ("left in place as a historical artifact; it does
+    # not override the default stage transition"). Authoritative state is the
+    # stage transition; the sentinel is a committed git provenance record.
+    "research_question_validated.yaml": (
+        "intentional historical provenance marker (documented graph.py ~L1696)"
+    ),
+    # Sibling provenance marker to research_question_validated.yaml: a committed
+    # git record of the idea selection + timestamp. Selection is authoritative via
+    # the stage transition; no code consumer by design.
+    "idea_selected.yaml": (
+        "provenance/selection marker committed to git; selection authoritative via "
+        "the stage transition (sibling of research_question_validated.yaml)"
+    ),
+}
+
+
+def _is_test_path(p: Path) -> bool:
+    parts = set(p.parts)
+    return "tests" in parts or p.name.startswith("test_") or "__pycache__" in parts
+
+
+def _basename_if_artifact(value: str) -> str | None:
+    if value.lower().endswith(_ARTIFACT_SUFFIXES):
+        name = Path(value).name
+        # must have a real stem before the extension (excludes bare ".json"/"*.json")
+        if name and not name.startswith("*") and "." in name and name.split(".")[0]:
+            return name
+    return None
+
+
+class _ModuleScan:
+    """Resolves artifact basenames touched by write/read verbs in one module."""
+
+    def __init__(self, tree: ast.Module):
+        self.tree = tree
+        self.consts: dict[str, str] = {}       # NAME -> basename
+        self.helpers: dict[str, set[str]] = {}  # func name -> basenames it returns
+        self.mentions: set[str] = set()         # every artifact basename referenced
+        self.state_tokens_present = False
+        self.writes: set[str] = set()
+        self.reads: set[str] = set()
+        self.write_is_state: dict[str, bool] = {}
+        self.read_wrappers: set[str] = set()   # fns that read their first arg
+        self._collect_consts_and_helpers()
+        self._detect_read_wrappers()
+        self._walk_functions()
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                b = _basename_if_artifact(node.value)
+                if b:
+                    self.mentions.add(b)
+        self.mentions |= set(self.consts.values())
+
+    # ---- pass 1: module constants + path-helper return basenames ---------- #
+    def _collect_consts_and_helpers(self) -> None:
+        for node in self.tree.body:
+            if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant) \
+                    and isinstance(node.value.value, str):
+                b = _basename_if_artifact(node.value.value)
+                if b:
+                    for t in node.targets:
+                        if isinstance(t, ast.Name):
+                            self.consts[t.id] = b
+        for node in ast.walk(self.tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                returned: set[str] = set()
+                for sub in ast.walk(node):
+                    if isinstance(sub, ast.Return) and sub.value is not None:
+                        returned |= self._expr_basenames(sub.value, {})
+                if returned:
+                    self.helpers[node.name] = returned
+
+    # ---- detect custom read-wrapper functions (``_read_optional(path)``) --- #
+    def _detect_read_wrappers(self) -> None:
+        """A function that applies a READ verb to its FIRST parameter is a read
+        wrapper (e.g. ``_read_optional(path)`` → ``path.read_text()``); a call to
+        it consumes the artifact passed in. Same-module detection only."""
+        for node in ast.walk(self.tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not node.args.args:
+                continue
+            first = node.args.args[0].arg
+            for sub in ast.walk(node):
+                if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute) \
+                        and sub.func.attr in _READ_METHODS:
+                    if any(isinstance(n, ast.Name) and n.id == first
+                           for n in ast.walk(sub.func.value)):
+                        self.read_wrappers.add(node.name)
+                        break
+                if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name) \
+                        and sub.func.id in _READ_FUNCS and sub.args \
+                        and any(isinstance(n, ast.Name) and n.id == first
+                                for n in ast.walk(sub.args[0])):
+                    self.read_wrappers.add(node.name)
+                    break
+
+    # ---- resolve the artifact basenames a path expression refers to ------- #
+    def _expr_basenames(self, expr: ast.AST, locals_: dict[str, set[str]]) -> set[str]:
+        out: set[str] = set()
+        for node in ast.walk(expr):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                b = _basename_if_artifact(node.value)
+                if b:
+                    out.add(b)
+            elif isinstance(node, ast.Name):
+                if node.id in self.consts:
+                    out.add(self.consts[node.id])
+                if node.id in locals_:
+                    out |= locals_[node.id]
+            elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name) \
+                    and node.func.id in self.helpers:
+                out |= self.helpers[node.func.id]
+        return out
+
+    @staticmethod
+    def _expr_has_state(expr: ast.AST) -> bool:
+        for node in ast.walk(expr):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str) \
+                    and node.value in _STATE_TOKENS:
+                return True
+        return False
+
+    # ---- pass 2: flow-insensitive dataflow over the WHOLE module --------- #
+    def _walk_functions(self) -> None:
+        # Local-var -> basenames bindings, collected module-wide and regardless of
+        # nesting (writes/reads inside if/for/with/try blocks must be seen). Two
+        # passes so a binding that depends on a later-collected one still resolves.
+        # A var reused across functions unions its basenames — a safe
+        # over-approximation (it can only ADD read/write associations, never hide
+        # a real dead-end).
+        locals_: dict[str, set[str]] = {}
+        for _ in range(2):
+            for node in ast.walk(self.tree):
+                if isinstance(node, ast.Assign):
+                    bn = self._expr_basenames(node.value, locals_)
+                    if bn:
+                        for t in node.targets:
+                            if isinstance(t, ast.Name):
+                                locals_.setdefault(t.id, set()).update(bn)
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.Call):
+                self._classify_call(node, locals_)
+
+    def _classify_call(self, call: ast.Call, locals_: dict[str, set[str]]) -> None:
+        func = call.func
+        if isinstance(func, ast.Attribute):
+            recv = func.value
+            if func.attr in _WRITE_METHODS:
+                for b in self._expr_basenames(recv, locals_):
+                    self.writes.add(b)
+                    self.write_is_state[b] = self.write_is_state.get(b, False) or \
+                        self._path_is_state(recv, locals_)
+            elif func.attr in _READ_METHODS:
+                self.reads |= self._expr_basenames(recv, locals_)
+        elif isinstance(func, ast.Name):
+            if func.id in _WRITE_FUNCS and call.args:
+                bns = self._expr_basenames(call.args[0], locals_)
+                for b in bns:
+                    self.writes.add(b)
+                    self.write_is_state[b] = self.write_is_state.get(b, False) or \
+                        self._path_is_state(call.args[0], locals_)
+            elif func.id in _READ_FUNCS and call.args:
+                self.reads |= self._expr_basenames(call.args[0], locals_)
+            elif func.id in self.read_wrappers and call.args:
+                self.reads |= self._expr_basenames(call.args[0], locals_)
+
+    def _path_is_state(self, expr: ast.AST, locals_: dict[str, set[str]]) -> bool:
+        """True if the write path references a state/.specify/memory segment.
+
+        Checks the expression itself and, when it is a bare Name bound earlier,
+        the whole module text as a fallback (a store module that writes under
+        ``state/`` almost always references the token somewhere)."""
+        if self._expr_has_state(expr):
+            return True
+        # bare local var whose binding expr referenced state
+        return self.state_tokens_present
+
+
+def main() -> int:
+    repo = _repo_root()
+    writers: dict[str, set[str]] = {}
+    precise_readers: dict[str, set[str]] = {}
+    state_scoped: set[str] = set()
+    # (rel, basenames-mentioned, has-any-read-verb) per file, for the lenient pass.
+    file_info: list[tuple[str, set[str], bool]] = []
+
+    _READ_MARKERS = (
+        ".read_text(", ".read_bytes(", "safe_load", "json.load", ".exists(",
+        ".is_file(", ".glob(", ".rglob(", ".iterdir(", "open(",
+    )
+
+    files: list[Path] = []
+    for root in _SOURCE_ROOTS:
+        base = repo / root
+        if base.is_dir():
+            files.extend(p for p in base.rglob("*.py") if not _is_test_path(p))
+
+    for f in files:
+        if f.name == "state_readers.py":
+            continue
+        try:
+            text = f.read_text(encoding="utf-8")
+            tree = ast.parse(text)
+        except (OSError, SyntaxError):
+            continue
+        scan = _ModuleScan(tree)
+        scan.state_tokens_present = any(tok in text for tok in _STATE_TOKENS)
+        rel = str(f.relative_to(repo))
+        for b in scan.writes:
+            writers.setdefault(b, set()).add(rel)
+            if scan.write_is_state.get(b) or scan.state_tokens_present:
+                state_scoped.add(b)
+        for b in scan.reads:
+            precise_readers.setdefault(b, set()).add(rel)
+        file_info.append((rel, set(scan.mentions), any(m in text for m in _READ_MARKERS)))
+
+    def _has_reader(b: str) -> bool:
+        # Precise dataflow read anywhere → definitely consumed.
+        if precise_readers.get(b):
+            return True
+        # Lenient cross-module fallback: a NON-writer module that names this
+        # artifact AND has a read verb is almost certainly a reader whose exact
+        # path the dataflow could not trace (e.g. a cross-module loader). Only a
+        # self-only artifact — named by no module other than its writer(s) — has
+        # to prove a precise read; that is the true dead-end case.
+        w = writers.get(b, set())
+        return any(b in mentions and has_read and rel not in w
+                   for rel, mentions, has_read in file_info)
+
+    dead_ends: list[tuple[str, list[str]]] = []
+    for b in sorted(state_scoped):
+        if b in ALLOWLIST:
+            continue
+        if writers.get(b) and not _has_reader(b):
+            dead_ends.append((b, sorted(writers[b])))
+
+    print(f"state-readers-check: {len(state_scoped)} state artifact(s) written by "
+          f"non-test src; {len(ALLOWLIST)} allow-listed; {len(dead_ends)} dead-end(s).")
+    if dead_ends:
+        for b, wf in dead_ends:
+            print(
+                f"state-readers-check: DEAD-END artifact {b!r} — written by "
+                f"{', '.join(wf)} but read by no non-test source module.",
+                file=sys.stderr,
+            )
+        print(
+            "Fix each: thread the value forward through an existing reader (SSoT), "
+            "add the missing consumer, delete the unused write, or (if a real "
+            "external reader exists) add it to ALLOWLIST with a justification.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/llmxive/cli.py
+++ b/src/llmxive/cli.py
@@ -22,32 +22,36 @@ from llmxive.backends import router as backend_router
 
 
 def _record_advance_error(project, exc: Exception) -> None:
-    """Persist a per-project advancement failure so it is reviewable (NOT
-    dismissed) without crashing the run/worker. One file per project -> no
-    cross-worker write conflict; a ``count`` makes a recurring failure (a
-    permanently dead reference, a project the agents cannot converge) visible."""
-    import json
-    from datetime import datetime
-    from llmxive.config import repo_root as _repo_root
+    """Persist a TYPED per-project advancement-failure control record so it is
+    reviewable (NOT dismissed) AND actionable, without crashing the run/worker.
+
+    Delegates to the single :mod:`llmxive.pipeline.advance_ledger` module (shared
+    with the scheduler, Constitution I): it fingerprints the exception into one of
+    the nine real failure classes, increments the CONSECUTIVE-failure count, and
+    assigns a control disposition (transient -> exponential backoff; invariant ->
+    terminal; permanent/emitter -> rerouted). The scheduler then honours that
+    disposition instead of re-picking a permanently-failing project every tick.
+    One file per project -> no cross-worker write conflict."""
     try:
-        d = _repo_root() / "state" / "advance_errors"
-        d.mkdir(parents=True, exist_ok=True)
-        p = d / f"{project.id}.json"
-        prior: dict = {}
-        if p.exists():
-            try:
-                prior = json.loads(p.read_text(encoding="utf-8"))
-            except (OSError, ValueError):
-                prior = {}
-        p.write_text(json.dumps({
-            "project_id": project.id,
-            "stage": project.current_stage.value,
-            "last_error": str(exc)[:1000],
-            "last_seen": datetime.now(UTC).isoformat(),
-            "count": int(prior.get("count", 0)) + 1,
-        }, indent=2), encoding="utf-8")
+        from llmxive.pipeline import advance_ledger
+        advance_ledger.record_failure(project, exc)
     except Exception:
         pass  # error-recording must never break the run
+
+
+def _clear_advance_error(project) -> None:
+    """Neutralize a project's advance-error record after a SUCCESSFUL step.
+
+    Called whenever ``graph.run_one_step`` returns WITHOUT raising — i.e. the
+    project made progress this tick (a stage advance, or an in_progress task
+    ticked off). That breaks the failure streak, so the ledger's
+    ``consecutive_count`` is reset (status -> cleared); the next failure starts a
+    fresh streak at 1. Never raises through to the run loop."""
+    try:
+        from llmxive.pipeline import advance_ledger
+        advance_ledger.clear(project)
+    except Exception:
+        pass  # clearing must never break the run
 
 
 def _cmd_preflight(_args: argparse.Namespace) -> int:
@@ -200,6 +204,10 @@ def _cmd_run(args: argparse.Namespace) -> int:
             _record_advance_error(project, exc)
             break
         print(f"[run]   -> stage={updated.current_stage.value}")
+        # run_one_step returned without raising => the project made progress this
+        # tick (a stage advance, or an in_progress task ticked off). Clear its
+        # advance-error record so consecutive_count reflects CONSECUTIVE failures.
+        _clear_advance_error(project)
         completed += 1
         if updated.current_stage == project.current_stage:
             # In_progress / paper_in_progress legitimately stay in the

--- a/src/llmxive/execution/analysis_runner.py
+++ b/src/llmxive/execution/analysis_runner.py
@@ -172,6 +172,101 @@ def declared_deliverables(tasks_md: str) -> set[str]:
     }
 
 
+@dataclass
+class SemanticGate:
+    """Result of the backend-independent semantic verification of a produced
+    artifact bundle (issue #1139 P1-3)."""
+
+    declared_missing: list[str]
+    fabrication: list[str]
+    hollow: list[str]
+    undurable: list[str]
+
+    @property
+    def ok(self) -> bool:
+        return not (
+            self.declared_missing
+            or self.fabrication
+            or self.hollow
+            or self.undurable
+        )
+
+    def reason(self) -> str:
+        parts: list[str] = []
+        if self.fabrication:
+            parts.append(
+                f"{len(self.fabrication)} fabricated/simulated-result signal(s) — "
+                "results are not real measurements: "
+                + "; ".join(self.fabrication[:3])
+            )
+        if self.hollow:
+            parts.append(
+                f"{len(self.hollow)} hollow-result signal(s) — the analysis ran "
+                "but computed nothing: " + "; ".join(self.hollow[:3])
+            )
+        if self.undurable:
+            parts.append(self.undurable[0])
+        if self.declared_missing:
+            parts.append(
+                f"{len(self.declared_missing)} declared deliverable(s) absent: "
+                + "; ".join(self.declared_missing[:3])
+            )
+        return "; ".join(parts)
+
+
+def verify_artifact_bundle(project_dir: Path, produced: list[str]) -> SemanticGate:
+    """Backend-independent SEMANTIC gate over a produced artifact bundle
+    (issue #1139 P1-3). Checks the artifacts are REAL, not merely present:
+
+    * declared deliverables the code actually references exist + are non-empty,
+    * no fabricated/"simulated metrics"/``random.*`` numbers (fabrication_guard),
+    * no hollow null/NaN/empty computed results (hollow_guard),
+    * at least one durable (non-gitignored) artifact a reviewer can open.
+
+    Shared by the local :func:`run_analysis` path AND the Kaggle GPU-offload
+    retrieval path (:func:`llmxive.execution.stage._poll_offload`), so a bundle
+    computed on ANY compute backend rejoins the SAME gate — an offload run can no
+    longer advance to research_complete on non-empty-file presence alone.
+    """
+    tasks_md = _read_tasks(project_dir)
+    declared = declared_deliverables(tasks_md) if tasks_md else set()
+    # Phantom-deliverable guard: gate only on deliverables the code actually
+    # writes (referenced in code/), not planner/tasker phantom filenames.
+    if declared:
+        code_dir = project_dir / "code"
+        code_blob = (
+            "\n".join(
+                p.read_text(encoding="utf-8", errors="ignore")
+                for p in sorted(code_dir.rglob("*.py"))
+            )
+            if code_dir.is_dir()
+            else ""
+        )
+        if code_blob:
+            declared = {d for d in declared if d in code_blob}
+    declared_missing = sorted(
+        d for d in declared if not (project_dir / d).is_file()
+        or (project_dir / d).stat().st_size == 0
+    )
+    from llmxive.execution.fabrication_guard import find_fabrication
+    from llmxive.execution.hollow_guard import (
+        find_hollow_results,
+        find_no_durable_evidence,
+    )
+
+    fabrication = find_fabrication(project_dir)
+    hollow = find_hollow_results(project_dir, produced)
+    undurable = find_no_durable_evidence(
+        project_dir, produced, repo_root=project_dir.parents[1]
+    )
+    return SemanticGate(
+        declared_missing=declared_missing,
+        fabrication=fabrication,
+        hollow=hollow,
+        undurable=undurable,
+    )
+
+
 def run_analysis(
     project_dir: Path,
     *,
@@ -288,74 +383,24 @@ def run_analysis(
         if _is_research_artifact(rel) and (rel not in before or before[rel] != mt)
     )
 
-    # Verify declared deliverables (best-effort: only those the run-book
-    # SHOULD have produced; missing ones are gate failures).
-    tasks_md = _read_tasks(project_dir)
-    declared = declared_deliverables(tasks_md) if tasks_md else set()
-    # Phantom-deliverable guard: a declared deliverable the project's code never
-    # references is a PLANNER/TASKER phantom, not an output the code intends to
-    # write — endemic to reprocessed code papers, where the back-filled tasks.md
-    # invents deliverable filenames independently of the adapted code's real
-    # outputs (the code RUNS and writes real artifacts, e.g. data/results.json,
-    # yet the gate fails on a never-written data/results_subset.csv). Gate only on
-    # deliverables the code actually writes — verified by the code referencing the
-    # path. `bool(produced)` below still requires real artifacts, so this can
-    # never pass a project that produced nothing.
-    if declared:
-        code_dir = project_dir / "code"
-        code_blob = (
-            "\n".join(
-                p.read_text(encoding="utf-8", errors="ignore")
-                for p in sorted(code_dir.rglob("*.py"))
-            )
-            if code_dir.is_dir()
-            else ""
-        )
-        if code_blob:
-            declared = {d for d in declared if d in code_blob}
-    declared_missing = sorted(
-        d for d in declared if not (project_dir / d).is_file()
-        or (project_dir / d).stat().st_size == 0
-    )
+    # Backend-independent SEMANTIC gate (issue #1139 P1-3): declared deliverables
+    # present + non-empty, no fabricated/simulated numbers, no hollow (null/NaN/
+    # empty) results, at least one durable artifact. Extracted into
+    # ``verify_artifact_bundle`` so the Kaggle GPU-offload retrieval path rejoins
+    # the EXACT same gate (an offload run can no longer advance on presence alone).
+    gate = verify_artifact_bundle(project_dir, produced)
+    declared_missing = gate.declared_missing
+    fabrication = gate.fabrication
+    hollow = gate.hollow
+    undurable = gate.undurable
 
     # Advisory (`python -c` smoke-test) failures are reported but do not gate.
     cmd_failures = [r for r in results if not r.ok and not r.advisory]
-    # DETERMINISTIC anti-fabrication gate (PROJ-604): the code can RUN and write
-    # real files while its reported numbers are fabricated — drawn from random.*,
-    # forced by a tautological constant, or openly labelled "simulated metrics"
-    # because the real (GPU) computation could not run. "code ran + a file
-    # appeared" is satisfied by fabrication, so without this a faked benchmark
-    # reaches research_complete and only the LLM panel catches it. A non-empty
-    # finding hard-fails the gate → kickback to implementation for a REAL run.
-    from llmxive.execution.fabrication_guard import find_fabrication
-    from llmxive.execution.hollow_guard import (
-        find_hollow_results,
-        find_no_durable_evidence,
-    )
-
-    fabrication = find_fabrication(project_dir)
-    # DETERMINISTIC hollow-results gate: `bool(produced)` only asks "did a file
-    # appear?" — it never looks INSIDE. fabrication_guard catches numbers that were
-    # FAKED; this catches numbers that were never COMPUTED. PROJ-179 (metacognitive
-    # awareness, run on the IRIS FLOWER dataset) reached research_complete having
-    # written correlation=null, p=null, d_prime=NaN, robustness=[] and its own
-    # {"status": "PASS"}. Every headline number was missing and the gate said ok.
-    hollow = find_hollow_results(project_dir, produced)
-    # ...and a run whose every artifact is gitignored leaves nothing a reviewer can
-    # open or a paper can cite (PROJ-256 advanced on ONE data/processed/*.json).
-    # project_dir is <repo>/projects/<id>, so parents[1] is the repo whose .gitignore
-    # decides durability (the .gitignore is the SSoT — never re-encode its patterns).
-    undurable = find_no_durable_evidence(
-        project_dir, produced, repo_root=project_dir.parents[1]
-    )
     ok = (
         not deadline_exceeded
         and not cmd_failures
         and bool(produced)
-        and not declared_missing
-        and not fabrication
-        and not hollow
-        and not undurable
+        and gate.ok
     )
     reason_parts: list[str] = []
     if fabrication:
@@ -426,6 +471,23 @@ def _find_quickstart(project_dir: Path) -> Path | None:
 
 
 def _read_tasks(project_dir: Path) -> str:
+    # Pointer-first (issue #1139 P0 D2): honour the project's canonical
+    # ``speckit_research_dir`` pointer so a multi-cycle project reads the CURRENT
+    # feature's tasks.md, not the newest-lexicographic one (which may be a stale
+    # kickback cycle). Falls back to newest specs/*/tasks.md only when no pointer
+    # is set (mirrors _find_quickstart).
+    try:
+        from llmxive.state import project as project_store
+
+        repo = project_dir.parent.parent
+        proj = project_store.load(project_dir.name, repo_root=repo)
+        ptr = proj.speckit_research_dir
+        if ptr:
+            t = repo / ptr / "tasks.md"
+            if t.is_file():
+                return t.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
     for tasks in sorted((project_dir / "specs").glob("*/tasks.md"), reverse=True):
         try:
             return tasks.read_text(encoding="utf-8", errors="replace")

--- a/src/llmxive/execution/data_source.py
+++ b/src/llmxive/execution/data_source.py
@@ -16,8 +16,10 @@ that fetches REAL data instead of guessing.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import re
+from datetime import UTC, datetime
 from pathlib import Path
 
 import yaml
@@ -26,6 +28,19 @@ logger = logging.getLogger(__name__)
 
 _CACHE_NAME = "discovered_data_source.yaml"
 _MAX_INTENT_CHARS = 1500
+
+#: Bump to invalidate EVERY cached discovery record when the verification logic
+#: changes (a stale "verified"/"none" computed by an older, weaker verifier must
+#: not be trusted). Folded into the cache key so a version bump is a global miss.
+VERIFIER_VERSION = "2"
+
+#: A ``status == "none"`` (nothing discoverable) is re-searched only after this
+#: many days AND only up to ``_NONE_MAX_RETRIES`` total attempts — so a genuinely
+#: undiscoverable source isn't re-searched every tick, but a source that appears
+#: LATER (a package published, a dataset uploaded) is eventually re-found instead
+#: of being poisoned forever. A ``verified`` record is durable (never re-searched).
+_NONE_TTL_DAYS = 7.0
+_NONE_MAX_RETRIES = 3
 
 
 def _read(path: Path) -> str:
@@ -133,73 +148,224 @@ def load_cached_source(project_dir: Path) -> dict | None:
         return None
 
 
-def ensure_discovered_source(project_dir: Path) -> dict | None:
-    """Discover + cache a VERIFIED real data source for the project (once).
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
 
-    Returns the cached record. ``status == "verified"`` records carry ``ref``,
-    ``access_python``, ``record_count``. A ``status == "none"`` record is cached
-    too, so a genuinely-undiscoverable source isn't re-searched every tick (the
-    cache can be deleted to force a retry). Never raises — discovery is
-    best-effort; a failure just means no block is injected this round.
+
+def _age_days(searched_at: object) -> float | None:
+    """Age in days of an ISO-8601 ``searched_at`` timestamp, or None if absent/bad."""
+    if not searched_at:
+        return None
+    try:
+        dt = datetime.fromisoformat(str(searched_at))
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return (datetime.now(UTC) - dt).total_seconds() / 86400.0
+
+
+def _plan_hash(raw_sections: str) -> str:
+    """Stable hash of the project's data-relevant planning prose.
+
+    Included in the cache key so that a CHANGED plan/spec invalidates a stale
+    discovery record (a source verified for an old data need must not be reused
+    after the need changed). Deterministic (regex over the artifacts), unlike the
+    LLM-distilled intent — so the deterministic part of the key is stable across
+    ticks even when the LLM query wording drifts slightly.
     """
-    cached = load_cached_source(project_dir)
-    if cached is not None:
-        return cached
+    return hashlib.sha256(raw_sections.encode("utf-8")).hexdigest()[:16]
 
-    intent, required_fields = _distill_data_need(_raw_data_sections(project_dir))
-    record: dict
-    if not intent:
-        record = {"status": "none", "reason": "no data intent found in planning artifacts"}
-    else:
-        try:
-            from llmxive.librarian.data_source_discovery import discover_data_source
 
-            src = discover_data_source(intent, required_fields=required_fields or None)
-            if src is None:
-                record = {"status": "none", "intent": intent[:300],
-                          "required_fields": required_fields}
-            else:
-                record = {
-                    "status": "verified",
-                    "kind": src.kind,
-                    "ref": src.ref,
-                    "access_python": src.access_python,
-                    "record_count": src.record_count,
-                    "sample_fields": list(src.sample_fields),
-                    "field_coverage": round(src.field_coverage, 3),
-                    "required_fields": required_fields,
-                    "intent": intent[:300],
-                }
-        except Exception as exc:  # discovery is best-effort
-            logger.warning("data-source discovery failed for %s: %s", project_dir.name, exc)
-            record = {"status": "error", "reason": str(exc)[:300]}
+def _cache_key(intent: str, required_fields: list[str], plan_hash: str) -> str:
+    """A REAL cache key = sha256(intent + sorted(required_fields) + plan-hash +
+    VERIFIER_VERSION) — NOT the file path. A record is a valid cache HIT only
+    when its stored ``cache_key`` matches; any mismatch (intent / required-field /
+    plan / verifier change) is treated as a MISS so the source is re-discovered
+    rather than a stale/poisoned record being returned forever."""
+    payload = "\x00".join((
+        intent.strip(),
+        "\x00".join(sorted(f.strip() for f in required_fields)),
+        plan_hash,
+        VERIFIER_VERSION,
+    ))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
+
+_TRANSIENT_TYPES = frozenset({
+    "Timeout", "ConnectTimeout", "ReadTimeout", "ConnectionError",
+    "ConnectionResetError", "ConnectionAbortedError", "TimeoutError",
+    "ProtocolError", "ReadTimeoutError", "MaxRetryError", "NewConnectionError",
+    "ChunkedEncodingError", "SSLError",
+})
+_TRANSIENT_MSG_RE = re.compile(
+    r"\b(timed out|timeout|connection (?:reset|aborted|refused)|temporarily "
+    r"unavailable|try again|too many requests|429|50[0-4]|502|503|504|"
+    r"bad gateway|service unavailable|gateway timeout)\b",
+    re.IGNORECASE,
+)
+
+
+def _is_transient_error(exc: BaseException) -> bool:
+    """True if ``exc`` looks like a TRANSIENT failure (timeout / connection reset
+    / HTTP 5xx / 429) rather than a terminal one — used only to LABEL the returned
+    (un-persisted) error record so logs/feedback are actionable. A transient error
+    is NEVER cached regardless (see :func:`ensure_discovered_source`)."""
+    if type(exc).__name__ in _TRANSIENT_TYPES:
+        return True
+    if isinstance(exc, (TimeoutError, ConnectionError)):
+        return True
+    return bool(_TRANSIENT_MSG_RE.search(str(exc)))
+
+
+def _cache_fresh(cached: dict, key: str) -> bool:
+    """Whether a cached record is a valid HIT for ``key`` (else re-discover).
+
+    - key mismatch (or a legacy record with no ``cache_key``) → MISS.
+    - ``verified`` → durable HIT.
+    - ``none`` → HIT while fresh (age < TTL) OR its bounded retry budget is spent;
+      a stale none with retries left → MISS (re-search: the source may exist now).
+    - ``error`` (or anything else) → NEVER a HIT: a cached error is poison; always
+      re-discover (this also invalidates the legacy write-only error caches).
+    """
+    if cached.get("cache_key") != key:
+        return False
+    status = cached.get("status")
+    if status == "verified":
+        return True
+    if status == "none":
+        if int(cached.get("retry_count", 0) or 0) >= _NONE_MAX_RETRIES:
+            return True  # retry budget exhausted → durable none
+        age = _age_days(cached.get("searched_at"))
+        if age is None:
+            return True  # unknown age → trust it (don't thrash)
+        return age < _NONE_TTL_DAYS  # fresh → reuse; stale → re-search
+    return False
+
+
+def _write_cache(project_dir: Path, record: dict) -> None:
     cache = _cache_path(project_dir)
     cache.parent.mkdir(parents=True, exist_ok=True)
     cache.write_text(yaml.safe_dump(record, sort_keys=False), encoding="utf-8")
+
+
+def ensure_discovered_source(project_dir: Path) -> dict | None:
+    """Discover + cache a VERIFIED real data source for the project.
+
+    Shared by plan time (proactive) and the execution backstop, keyed on a REAL
+    cache key (:func:`_cache_key`) stored inside the record — so a stale record
+    from a changed plan / different required fields / bumped verifier is a MISS
+    and is re-discovered, never returned forever.
+
+    Caching policy:
+      - ``status == "verified"`` (``ref`` / ``access_python`` / ``record_count``)
+        is durable.
+      - ``status == "none"`` carries ``searched_at`` + ``retry_count`` and is
+        re-searched after :data:`_NONE_TTL_DAYS` up to :data:`_NONE_MAX_RETRIES`
+        times (a source may be published later), then becomes durable.
+      - a TRANSIENT error (timeout / connection / HTTP 5xx / 429) — or ANY
+        discovery exception — is NOT persisted: the ephemeral error record is
+        returned WITHOUT touching the cache, so the NEXT tick retries (a cached
+        error used to poison the project permanently).
+
+    Never raises — discovery is best-effort; a failure just injects no block.
+    """
+    raw = _raw_data_sections(project_dir)
+    intent, required_fields = _distill_data_need(raw)
+    key = _cache_key(intent, required_fields, _plan_hash(raw))
+
+    cached = load_cached_source(project_dir)
+    if cached is not None and _cache_fresh(cached, key):
+        return cached
+
+    if not intent:
+        # No data need in the artifacts → durable none (nothing to retry for).
+        record = {"status": "none", "reason": "no data intent found in planning artifacts",
+                  "cache_key": key, "searched_at": _now_iso(),
+                  "retry_count": _NONE_MAX_RETRIES}
+        _write_cache(project_dir, record)
+        return record
+
+    try:
+        from llmxive.librarian.data_source_discovery import discover_data_source
+
+        src = discover_data_source(intent, required_fields=required_fields or None)
+    except Exception as exc:  # discovery is best-effort — DO NOT cache the error.
+        transient = _is_transient_error(exc)
+        logger.warning(
+            "data-source discovery failed for %s (%s, not cached — will retry): %s",
+            project_dir.name, "transient" if transient else "error", exc,
+        )
+        # Return WITHOUT persisting so the next tick re-discovers; leave any
+        # existing (verified/none) cache in place rather than clobbering it.
+        return {"status": "error", "reason": str(exc)[:300],
+                "transient": transient, "cached": False}
+
+    if src is None:
+        prev_retries = 0
+        if (cached and cached.get("status") == "none"
+                and cached.get("cache_key") == key):
+            prev_retries = int(cached.get("retry_count", 0) or 0)
+        record = {"status": "none", "intent": intent[:300],
+                  "required_fields": required_fields, "cache_key": key,
+                  "searched_at": _now_iso(), "retry_count": prev_retries + 1}
+    else:
+        record = {
+            "status": "verified",
+            "kind": src.kind,
+            "ref": src.ref,
+            "access_python": src.access_python,
+            "record_count": src.record_count,
+            "sample_fields": list(src.sample_fields),
+            "field_coverage": round(src.field_coverage, 3),
+            "required_fields": required_fields,
+            "intent": intent[:300],
+            "cache_key": key,
+        }
+    _write_cache(project_dir, record)
     return record
 
 
 def render_feedback_block(record: dict | None) -> str:
-    """Render the verified-source section for execution_feedback.md (or '')."""
+    """Render the verified-source section for execution_feedback.md (or '').
+
+    Branches on ``record["kind"]`` so the access instruction is CORRECT for the
+    source type: a ``pypi_package`` gets a ``pip install`` line; a ``data_url``
+    gets a download/stream recipe and is NEVER told to ``pip install <url>``.
+    Only ``verified`` records (``record_count > 0`` by construction) render, so it
+    never claims "loads 0 real records".
+    """
     if not record or record.get("status") != "verified":
         return ""
+    kind = str(record.get("kind") or "pypi_package")
     ref = record.get("ref", "")
     recipe = (record.get("access_python") or "").strip()
     count = record.get("record_count")
     fields = ", ".join(record.get("sample_fields") or [])
-    lines = [
+    field_suffix = f" with fields: {fields}." if fields else "."
+    header = [
         "",
         "## ✅ VERIFIED REAL DATA SOURCE — use THIS in the data loader",
         "",
         "Do NOT invent or guess a download URL/API (a hallucinated endpoint "
-        "will 404). A real, installable source was discovered AND verified by "
-        "actually loading data from it:",
+        "will 404). A real source was discovered AND verified by actually "
+        "loading real data from it:",
         "",
-        f"- **Install**: add `{ref}` to the project's `requirements.txt` and "
-        f"`pip install {ref}`.",
-        f"- **Verified**: this loads **{count}** real records"
-        + (f" with fields: {fields}." if fields else "."),
+    ]
+    if kind == "data_url":
+        access = [
+            f"- **Download / stream** this exact data URL directly (do NOT "
+            f"`pip install` it — it is a data file, not a package): `{ref}`",
+            f"- **Verified**: streaming a sample yielded **{count}** real "
+            f"records{field_suffix}",
+        ]
+    else:  # pypi_package (default)
+        access = [
+            f"- **Install**: add `{ref}` to the project's `requirements.txt` and "
+            f"`pip install {ref}`.",
+            f"- **Verified**: this loads **{count}** real records{field_suffix}",
+        ]
+    tail = [
         "- **Working access recipe** (this EXACT code was executed and returned "
         "real data — base the loader on it):",
         "",
@@ -207,11 +373,11 @@ def render_feedback_block(record: dict | None) -> str:
         recipe,
         "```",
         "",
-        "Write the loader to use this package/recipe, persist the records to the "
+        "Write the loader to use this source/recipe, persist the records to the "
         "declared raw/processed data files, and DELETE any old code that fetches "
-        "from a website endpoint.",
+        "from a guessed website endpoint.",
     ]
-    return "\n".join(lines)
+    return "\n".join(header + access + tail)
 
 
 def ensure_source_in_requirements(project_dir: Path) -> bool:

--- a/src/llmxive/execution/failure_class.py
+++ b/src/llmxive/execution/failure_class.py
@@ -1,0 +1,104 @@
+"""Durable execution-failure classification (issue #1139, P1-2 / anti-pattern 4).
+
+The execution stage already recognizes *compute-environment* (GPU/CUDA/OOM),
+*data-unreachable* (renamed/gated HF dataset, no network) and *fabrication*
+failures — but it threw that classification away: ``execution_status`` persisted
+only free-text ``reason``/``failures`` strings, and ``_write_execution_replan_feedback``
+took no class argument and always emitted the same "make it CPU-tractable" advice.
+Downstream (re-plan feedback, terminal routing, dashboards) could only re-parse
+strings, and a GPU-only method, an unreachable dataset, and a genuine code bug all
+collapsed into one generic message and one ``VALIDATOR_REJECTED`` terminal.
+
+This module is the SINGLE home for the failure taxonomy. The stage classifies
+once (reusing its signature matchers) into a :class:`FailureClass`, persists the
+enum value, and every downstream consumer branches on the durable class instead
+of re-deriving it from strings.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class FailureClass(StrEnum):
+    """Why an execution attempt failed. ``str``-valued so it round-trips through
+    the JSON state files verbatim."""
+
+    #: GPU/CUDA/8-bit/OOM — the free CPU CI cannot satisfy it. Re-scope to CPU
+    #: (smaller model, sampled data) or offload to GPU; NOT an in-place code fix.
+    COMPUTE_ENV = "compute_env"
+    #: External data source unreachable (renamed/removed/gated HF dataset, no
+    #: network). Fix = a verified real source, never synthetic substitution.
+    DATA_UNREACHABLE = "data_unreachable"
+    #: The run fabricated inputs/results (random/hardcoded/"simulated metrics").
+    #: Fix = obtain a real source + compute real results.
+    FABRICATION = "fabrication"
+    #: A genuine, implementer-fixable code bug (import error, traceback, wrong
+    #: path) — the normal fix-loop can repair it in place.
+    EXECUTION_BUG = "execution_bug"
+    #: The run produced no runnable failure signature we recognize (empty/other).
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def from_signals(
+        cls,
+        *,
+        compute_infra: bool,
+        data_unavailable: bool,
+        fabrication: bool,
+        hollow: bool,
+        has_command_failures: bool,
+    ) -> FailureClass:
+        """Map already-computed failure signals to a single class.
+
+        Priority order reflects what the re-plan must address first: a
+        compute-environment wall dominates (nothing else can run until it is
+        re-scoped); then a missing real data source (fabrication/hollow/no-source
+        all mean "needs a verified source"); then an ordinary code bug.
+        """
+        if compute_infra:
+            return cls.COMPUTE_ENV
+        if data_unavailable:
+            return cls.DATA_UNREACHABLE
+        if fabrication or hollow:
+            return cls.FABRICATION
+        if has_command_failures:
+            return cls.EXECUTION_BUG
+        return cls.UNKNOWN
+
+
+#: Class-specific guidance the re-plan report threads to the planner. Keyed by
+#: the durable :class:`FailureClass` value so the message matches the real cause
+#: instead of a one-size-fits-all "make it CPU-tractable" line.
+REPLAN_GUIDANCE: dict[FailureClass, str] = {
+    FailureClass.COMPUTE_ENV: (
+        "The method requires GPU/accelerated compute the free CI runner lacks. "
+        "Re-scope it to run on CPU — a smaller model, fewer parameters, a sampled "
+        "subset, or a classical baseline that answers the same question — OR keep "
+        "the GPU step behind the Kaggle offload path. Do NOT keep the CUDA/8-bit "
+        "requirement in the CPU code path."
+    ),
+    FailureClass.DATA_UNREACHABLE: (
+        "The external data source could not be reached/loaded (renamed, removed, "
+        "gated, or offline). Switch to a VERIFIED, programmatically reachable real "
+        "source (current canonical id, a public mirror, or a different genuinely "
+        "public dataset that supports the same analysis). NEVER fabricate or "
+        "substitute synthetic data — a verified source is discovered and injected "
+        "for you; build the analysis around it."
+    ),
+    FailureClass.FABRICATION: (
+        "The run fabricated its inputs or results (random/hardcoded values or "
+        "'simulated metrics'). Replace them with a real, verified data source and "
+        "compute measured results from it. Fabricated numbers are rejected at the "
+        "execution gate."
+    ),
+    FailureClass.EXECUTION_BUG: (
+        "The analysis failed with a code error. Fix the failing command(s) shown "
+        "above in place — correct the import/path/logic — keeping the same method "
+        "and real data."
+    ),
+    FailureClass.UNKNOWN: (
+        "The implementation approach needs adjustment given the errors above — "
+        "re-plan with a design that avoids them, keeping what worked."
+    ),
+}

--- a/src/llmxive/execution/stage.py
+++ b/src/llmxive/execution/stage.py
@@ -385,9 +385,27 @@ def execute_and_gate(project_dir: Path, *, repo_root: Path | None = None) -> boo
         except Exception as exc:  # never let offload break the local fallback
             logger.warning("GPU offload dispatch skipped for %s: %s", project_id, exc)
 
+    # Classify the failure ONCE (issue #1139 P1-2) and persist the durable class
+    # so re-plan feedback + terminal routing branch on the real cause instead of
+    # re-parsing strings. Reuses the same signature matchers the offload/verified-
+    # source guards use — no forked classifier.
+    from llmxive.execution.failure_class import FailureClass
+
+    _infra = _compute_infra_failures(failures)
+    _dataunavail = _data_unavailable_failures(failures)
+    _fclass = FailureClass.from_signals(
+        compute_infra=bool(_infra),
+        data_unavailable=bool(_dataunavail),
+        fabrication=bool(getattr(res, "fabrication", None)),
+        hollow=bool(getattr(res, "hollow", None)),
+        has_command_failures=bool(failures),
+    )
     execution_status.record(
         project_id, ok=res.ok, reason=res.reason,
-        artifacts=res.artifacts_produced, failures=failures, repo_root=repo,
+        artifacts=res.artifacts_produced, failures=failures,
+        failure_class=None if res.ok else _fclass.value,
+        evidence=None if res.ok else (_infra + _dataunavail)[:20],
+        repo_root=repo,
     )
 
     mem = project_dir / ".specify" / "memory"
@@ -485,7 +503,17 @@ def _poll_offload(project_dir: Path, repo: Path) -> bool:
             rel for rel in pulled
             if (project_dir / rel).is_file() and (project_dir / rel).stat().st_size > 0
         ]
-        if real:
+        # issue #1139 P1-3: a GPU-offload bundle must clear the SAME backend-
+        # independent semantic gate as a local run — non-empty presence is NOT
+        # verification. Without this, a Kaggle run that fabricated its metrics,
+        # produced hollow (null/NaN) numbers, wrote no declared deliverable, or
+        # left only gitignored output advanced straight to research_complete and
+        # minted receipts. Rejoin verify_artifact_bundle so only a genuinely
+        # verified bundle advances; anything else falls to the normal failure path.
+        from llmxive.execution.analysis_runner import verify_artifact_bundle
+
+        gate = verify_artifact_bundle(project_dir, real) if real else None
+        if real and gate is not None and gate.ok:
             execution_status.record(
                 project_id, ok=True,
                 reason=f"GPU offload complete via Kaggle kernel {kernel_ref}",
@@ -495,11 +523,22 @@ def _poll_offload(project_dir: Path, repo: Path) -> bool:
             _mint_artifact_receipts(project_dir, res, repo)
             execution_status.clear_offload(project_id, repo_root=repo)
             (project_dir / ".specify" / "memory" / _FEEDBACK_FILENAME).unlink(missing_ok=True)
-            logger.info("offload %s retrieved %d artifact(s) from Kaggle", project_id, len(real))
+            logger.info(
+                "offload %s retrieved %d VERIFIED artifact(s) from Kaggle",
+                project_id, len(real),
+            )
             return True
-        logger.warning(
-            "offload %s completed but retrieved no real artifacts; falling back", project_id
-        )
+        if real and gate is not None:
+            logger.warning(
+                "offload %s completed but the retrieved bundle FAILED the semantic "
+                "gate — NOT advancing (%s); falling back to a local pass",
+                project_id, gate.reason(),
+            )
+        else:
+            logger.warning(
+                "offload %s completed but retrieved no real artifacts; falling back",
+                project_id,
+            )
         execution_status.record_offload(
             project_id, status="failed", kernel_ref=kernel_ref, repo_root=repo,
         )
@@ -753,10 +792,28 @@ def _reopen_failing_tasks(
     """Un-check tasks.md lines that reference a failed/missing script path or
     its stem, so the implementer re-implements them. Returns count re-opened.
     """
-    tasks_files = sorted(project_dir.glob("specs/*/tasks.md"))
-    if not tasks_files:
-        return 0
-    tasks_path = tasks_files[0]
+    # Pointer-first (issue #1139 P0 D2): reopen tasks in the CANONICAL current
+    # feature dir (the project's speckit_research_dir pointer), NOT the first
+    # lexicographic specs/*/tasks.md. On a multi-cycle project the first-glob dir
+    # is a STALE prior kickback cycle whose tasks the implementer never re-reads
+    # (it reads the pointer dir), so the whole auto-fix loop was inert.
+    tasks_path: Path | None = None
+    try:
+        from llmxive.state import project as project_store
+
+        _repo = project_dir.parent.parent
+        _proj = project_store.load(project_dir.name, repo_root=_repo)
+        if _proj.speckit_research_dir:
+            _cand = _repo / _proj.speckit_research_dir / "tasks.md"
+            if _cand.is_file():
+                tasks_path = _cand
+    except Exception:
+        tasks_path = None
+    if tasks_path is None:
+        tasks_files = sorted(project_dir.glob("specs/*/tasks.md"))
+        if not tasks_files:
+            return 0
+        tasks_path = tasks_files[0]
     text = tasks_path.read_text(encoding="utf-8", errors="replace")
 
     # Collect failing/missing script paths + stems from the run.

--- a/src/llmxive/librarian/data_source_discovery.py
+++ b/src/llmxive/librarian/data_source_discovery.py
@@ -17,8 +17,11 @@ hallucinations are filtered out:
          introspects the installed package's real exports and asks the LLM to
          FIX the snippet — this is what converges first-guess-wrong APIs (e.g.
          ``knotinfo`` → ``link_list``) to a working recipe.
-       - ``data_url``: reuse :func:`llmxive.librarian.dataset_resolver.sniff_format`
-         and require ``parsed is True`` (no venv needed).
+       - ``data_url``: stream + PARSE a real sample via
+         :func:`llmxive.librarian.dataset_resolver.sample_records` and require
+         ``record_count > 0`` real records with real field coverage (no venv
+         needed) — symmetric with the pypi records gate; a format sniff alone is
+         a proxy, not a verification, and does NOT qualify the source.
 
 The verification GATE (``parse_records_gate``) is a PURE function so it can be
 unit-tested without network or an LLM: a recipe printing ``RECORDS=0`` or
@@ -41,7 +44,7 @@ from pathlib import Path
 
 from llmxive.backends.base import ChatMessage
 from llmxive.backends.router import chat_with_fallback
-from llmxive.librarian.dataset_resolver import sniff_format
+from llmxive.librarian.dataset_resolver import sample_records
 
 # Free reasoning model on the Dartmouth catalog (router falls back to local).
 logger = logging.getLogger(__name__)
@@ -630,23 +633,29 @@ def _verify_pypi_package(
 def _verify_data_url(
     proposal: dict[str, str], *, required_fields: list[str] | None = None
 ) -> VerifiedSource | None:
-    """Verify a data URL by sniffing a real sample (no venv). Returns a
-    VerifiedSource with record_count=0 (sniff is format-level, not a count).
+    """Verify a data URL by STREAMING + PARSING a real sample (no venv).
 
-    Field coverage can't be confirmed from a format sniff, so when the caller
-    requires specific fields a URL source is marked 0.0 coverage — it loses to a
-    pip package whose recipe actually proved the fields are present.
+    Symmetric with :func:`_verify_pypi_package`'s records gate: a URL qualifies
+    only if a downloaded sample both sniffs as a known dataset format AND parses
+    into ``record_count > 0`` real records (via
+    :func:`llmxive.librarian.dataset_resolver.sample_records`). A URL that merely
+    "sniffs parseable" but yields zero countable records is REJECTED — a format
+    sniff is a PROXY, not a verification. ``field_coverage`` is computed from the
+    sample's REAL parsed field names against the caller's ``required_fields`` (so
+    a URL with the wrong schema loses to a richer source and, if it's the best
+    candidate, is rejected by the caller's coverage gate) — never the old
+    ``1.0`` free pass when no fields were requested.
     """
     ref = proposal["ref"]
     if not ref.lower().startswith(("http://", "https://")):
         return None
-    report = sniff_format(ref)
-    if not report.parsed:
+    sr = sample_records(ref)
+    if not sr.parsed or sr.record_count <= 0:
         return None
     return VerifiedSource(
         kind="data_url", ref=ref, access_python=proposal["access_python"],
-        record_count=0, sample_fields=[],
-        field_coverage=0.0 if required_fields else 1.0,
+        record_count=sr.record_count, sample_fields=list(sr.fields),
+        field_coverage=field_coverage(sr.fields, required_fields or []),
     )
 
 

--- a/src/llmxive/librarian/dataset_resolver.py
+++ b/src/llmxive/librarian/dataset_resolver.py
@@ -12,12 +12,10 @@ import json
 import re
 import zipfile
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
 from pathlib import Path
 
 import requests  # type: ignore[import-untyped]  # no stub package available
 import urllib3  # bundled with requests; ``r.raw.read`` raises RAW urllib3 errors
-import yaml
 
 from llmxive.librarian import dataset_sources as _sources
 from llmxive.librarian import verify as _verify
@@ -125,22 +123,133 @@ def _is_json(line: str) -> bool:
         return False
 
 
-def sniff_format(url: str) -> FormatReport:
+def _download_sample(url: str) -> tuple[bytes, str | None]:
+    """Stream up to ``_SAMPLE_BYTES`` of ``url``; return ``(sample, error)``.
+
+    ``error`` is a human-readable string on an HTTP >=400 or a transient network
+    failure (best-effort: verifying a URL must NEVER crash the caller), else
+    ``None``. Shared by :func:`sniff_format` (format only) and
+    :func:`sample_records` (records + fields) so the streaming/timeout handling
+    lives in ONE place (Constitution I).
+
+    ``r.raw.read`` reads the RAW urllib3 stream, so a read-timeout there raises a
+    urllib3 error (ReadTimeoutError / ProtocolError) that is NOT a
+    requests.RequestException NOR an OSError — the live PROJ-492 run-22 crash
+    (``us.aws.cdn.hf.co Read timed out`` while verifying a cited HF dataset) took
+    down the whole pipeline run; catching urllib3.exceptions.HTTPError too keeps
+    a transient failure to a "couldn't verify", never a crash.
+    """
     try:
         with requests.get(url, stream=True, headers={"User-Agent": USER_AGENT}, timeout=_SNIFF_TIMEOUT) as r:
             if r.status_code >= 400:
-                return FormatReport(False, None, 0, f"HTTP {r.status_code}")
+                return b"", f"HTTP {r.status_code}"
             sample = r.raw.read(_SAMPLE_BYTES, decode_content=True) or b""
-    # ``r.raw.read`` reads the RAW urllib3 stream, so a read-timeout there raises
-    # a urllib3 error (ReadTimeoutError / ProtocolError) that is NOT a
-    # requests.RequestException NOR an OSError — the live PROJ-492 run-22 crash
-    # (`us.aws.cdn.hf.co Read timed out` while verifying a cited HF dataset took
-    # down the whole pipeline run). Verifying a dataset URL is best-effort: a
-    # transient network failure must yield "couldn't verify", never crash the run.
     except (requests.RequestException, OSError, urllib3.exceptions.HTTPError) as exc:
-        return FormatReport(False, None, 0, str(exc))
+        return b"", str(exc)
+    return sample, None
+
+
+def sniff_format(url: str) -> FormatReport:
+    sample, error = _download_sample(url)
+    if error is not None:
+        return FormatReport(False, None, 0, error)
     ok, fmt = _detect_and_parse(sample, url)
     return FormatReport(ok, fmt, len(sample), None if ok else "unrecognized/non-dataset content")
+
+
+@dataclass(frozen=True)
+class SampleRecords:
+    """Result of streaming a sample of a data URL and PARSING it into records.
+
+    Unlike :class:`FormatReport` (format only), this proves the URL actually
+    yields ``record_count > 0`` real records and surfaces the ``fields``
+    (column/key names) of a sample record — so a directly-streamable data URL can
+    be verified SYMMETRICALLY with a pip package (records + field coverage), not
+    merely "the bytes parsed as some format". ``record_count`` is the count in the
+    downloaded sample (a lower bound on the full file), not the whole dataset.
+    """
+
+    parsed: bool
+    format: str | None
+    record_count: int
+    fields: list[str]
+    downloaded_bytes: int
+    error: str | None = None
+
+
+def _count_records(sample: bytes, fmt: str) -> tuple[int, list[str]]:
+    """Count records + extract field names from a text-format ``sample``.
+
+    Handles the text tabular/record formats (csv/tsv/json/jsonl). A trailing
+    partial row/line from sample truncation is dropped so a half-read record is
+    never counted. Binary container formats (zip/gzip/parquet/hdf5/tar) cannot be
+    record-counted from a head sample (e.g. a parquet footer lives at the end), so
+    they return ``(0, [])`` — a data URL that cannot prove records loses to a pip
+    package, exactly as intended (a sniff-only "parsed" is not a verification).
+    """
+    if fmt not in ("csv", "tsv", "json", "jsonl"):
+        return 0, []
+    text = sample.decode("utf-8", errors="replace")
+    truncated = not text.endswith(("\n", "\r"))
+    if fmt in ("csv", "tsv"):
+        delim = "\t" if fmt == "tsv" else ","
+        rows = [r for r in _csv.reader(io.StringIO(text), delimiter=delim) if r]
+        if truncated and rows:
+            rows = rows[:-1]  # drop a truncated final data row
+        if len(rows) < 2:
+            return 0, []
+        header = [c.strip() for c in rows[0]]
+        return len(rows) - 1, header
+    if fmt == "json":
+        try:
+            obj = json.loads(text)
+        except ValueError:
+            return 0, []
+        if isinstance(obj, list):
+            fields = list(obj[0].keys()) if obj and isinstance(obj[0], dict) else []
+            return len(obj), [str(f) for f in fields]
+        if isinstance(obj, dict):
+            return 1, [str(k) for k in obj]
+        return 0, []
+    # jsonl
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    if truncated and lines:
+        lines = lines[:-1]  # drop a truncated final record line
+    parsed_objs: list[object] = []
+    for ln in lines:
+        try:
+            parsed_objs.append(json.loads(ln))
+        except ValueError:
+            continue
+    if not parsed_objs:
+        return 0, []
+    first = parsed_objs[0]
+    fields = [str(k) for k in first] if isinstance(first, dict) else []
+    return len(parsed_objs), fields
+
+
+def sample_records(url: str) -> SampleRecords:
+    """Stream a real sample of ``url`` and parse it into ``(record_count, fields)``.
+
+    A URL is verified as a real data source only if the sample both sniffs as a
+    known dataset format AND parses into ``record_count > 0`` records — a format
+    sniff alone (``parsed is True`` with zero records) is a PROXY, not a
+    verification, and must not qualify a source. Best-effort: a transient network
+    failure yields ``parsed=False`` with the error, never a crash.
+    """
+    sample, error = _download_sample(url)
+    if error is not None:
+        return SampleRecords(False, None, 0, [], 0, error)
+    ok, fmt = _detect_and_parse(sample, url)
+    if not ok or fmt is None:
+        return SampleRecords(False, fmt, 0, [], len(sample),
+                             "unrecognized/non-dataset content")
+    count, fields = _count_records(sample, fmt)
+    if count <= 0:
+        return SampleRecords(False, fmt, 0, fields, len(sample),
+                             "sample parsed as a format but yielded 0 records "
+                             "(cannot record-verify from this sample)")
+    return SampleRecords(True, fmt, count, fields, len(sample), None)
 
 
 @dataclass(frozen=True)
@@ -383,21 +492,6 @@ def resolve_datasets(spec_text: str, *, project_dir: Path, repo_root: Path,
             candidates_tried=tried,
         ))
     return ResolvedDatasets(datasets=resolved)
-
-
-def write_manifest(rd: ResolvedDatasets, *, project_dir: Path) -> Path:
-    out = Path(project_dir) / ".specify" / "memory" / "resolved_datasets.yaml"
-    out.parent.mkdir(parents=True, exist_ok=True)
-    doc = {
-        "resolved_at": datetime.now(UTC).isoformat(),
-        "datasets": [
-            {"intent": d.intent, "status": d.status,
-             "candidates": d.candidates, "candidates_tried": d.candidates_tried}
-            for d in rd.datasets
-        ],
-    }
-    out.write_text(yaml.safe_dump(doc, sort_keys=False), encoding="utf-8")
-    return out
 
 
 def unresolved_intents(rd: ResolvedDatasets) -> list[str]:

--- a/src/llmxive/pipeline/advance_ledger.py
+++ b/src/llmxive/pipeline/advance_ledger.py
@@ -1,0 +1,457 @@
+"""Typed advancement-failure ledger (issue #1139, defect D5).
+
+Before this module the pipeline wrote ``state/advance_errors/<id>.json`` on every
+per-project advancement exception, incremented a bare ``count``, and then never
+read it: no backoff gated reselection and no success path cleared it. The
+scheduler re-picked a permanently-failing project every tick, so one dead
+reference or template-rejecting emitter burned unlimited scheduler slots
+(PROJ-077 alone looped 365x; 733 wasted attempts across 74 records).
+
+This is the ONE shared read/write/classify module for that ledger — both
+``cli.py`` (writer + success-path clear) and ``pipeline/scheduler.py``
+(``_eligible_candidates`` backoff/hold gate) route through it (Constitution I).
+
+Record schema (``state/advance_errors/<id>.json``, atomic via ``state/_io``)::
+
+    {
+      "project_id":        str,
+      "stage":             str,            # project.current_stage.value at failure
+      "class":             ErrorClass,     # taxonomy that drives control behavior
+      "fingerprint":       str,            # one of the 9 real fingerprints (+ unknown)
+      "consecutive_count": int,            # CONSECUTIVE failures (reset by clear())
+      "first_seen":        ISO-8601 str,
+      "last_seen":         ISO-8601 str,
+      "retry_after":       ISO-8601 str | None,  # None => never retried via backoff
+      "last_error":        str,            # truncated raw exception text
+      "evidence":          str,            # concise, whitespace-collapsed excerpt
+      "remediation":       str,            # class-level "what to do about it"
+      "status":            LedgerStatus,
+    }
+
+Control behavior (assigned by :func:`disposition` off the :class:`ErrorClass`):
+
+* ``transient`` (backend/model chain flap, unrecognized error) — retry with
+  EXPONENTIAL BACKOFF ``retry_after = last_seen + BASE * 2**min(count, cap)``;
+  ``status=retry_scheduled``. The scheduler skips it until ``retry_after``.
+* ``deterministic_repair`` (``[Errno 17]`` file-exists collision) — same bounded
+  backoff so it does NOT loop every tick; the real fix is idempotent artifact
+  creation in the execution stage, and the remediation says so.
+* ``invariant`` (invalid state-machine transition) — ``status=terminal``,
+  ``retry_after=None``: a code bug retrying can never fix. Never consumes retry
+  budget; routed to AGENT_BLOCKED / operator.
+* ``permanent`` (unreachable reference w/o replacement, unfilled-template emit)
+  and ``emitter_context`` (unresolved markers / no seed draft / zero tasks) —
+  ``status=rerouted``, ``retry_after=None``: do NOT re-dispatch unchanged; return
+  the evidence to a source-aware re-plan or the emitter.
+
+The scheduler honours the disposition via :func:`is_on_hold`: a project is
+SKIPPED while its record (for the project's *current* stage) is either in a
+pending backoff window or in a ``rerouted``/``terminal`` hold. A record for a
+DIFFERENT stage than the project now sits at is stale (the project advanced past
+the failing step) and is ignored. A successful advancement step calls
+:func:`clear`, resetting ``consecutive_count`` so it always reflects
+*consecutive* failures.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from pathlib import Path
+
+from llmxive.state._io import atomic_write_text
+
+# --------------------------------------------------------------------------
+# Constants (kept HERE, not in config.py, per issue #1139 scoping)
+# --------------------------------------------------------------------------
+
+#: Ledger directory, relative to the repo root.
+LEDGER_SUBDIR: tuple[str, ...] = ("state", "advance_errors")
+
+#: Exponential-backoff base (seconds) for a transient/deterministic-repair retry.
+#: 5 minutes — long enough that a flapping backend is not re-hammered every tick,
+#: short enough that a genuinely transient failure recovers within a cron cycle.
+BASE_BACKOFF_SECONDS: float = 300.0
+
+#: Cap on the backoff exponent. 2**8 == 256, so the retry window saturates at
+#: ``256 * 5 min`` ≈ 21.3 h — roughly one retry per day once a failure has
+#: recurred ~8 times, instead of the unbounded every-tick re-pick it replaces.
+BACKOFF_CAP: int = 8
+
+#: Max characters of raw exception text persisted in ``last_error``.
+_MAX_ERROR_CHARS: int = 1000
+#: Max characters of the whitespace-collapsed ``evidence`` excerpt.
+_MAX_EVIDENCE_CHARS: int = 400
+
+
+class ErrorClass(StrEnum):
+    """Why an advancement attempt failed — drives the control disposition.
+
+    ``str``-valued so it round-trips through the JSON record verbatim.
+    """
+
+    #: Flaky/recoverable (backend or model chain flap, network, unrecognized) —
+    #: retry with exponential backoff.
+    TRANSIENT = "transient"
+    #: The source or emitted artifact cannot be advanced as-is (dead reference
+    #: without a replacement, unfilled-template emit) — reroute, do not re-emit.
+    PERMANENT = "permanent"
+    #: An invalid state-machine transition — a code bug; retrying can never fix
+    #: it. Terminal / route to AGENT_BLOCKED.
+    INVARIANT = "invariant"
+    #: A deterministic filesystem collision (dir/file already exists) — the step
+    #: must be made idempotent; backoff prevents the every-tick loop meanwhile.
+    DETERMINISTIC_REPAIR = "deterministic_repair"
+    #: The emitter produced insufficient output (unresolved markers, no seed
+    #: draft, zero tasks) — supply the missing context, do not blindly re-emit.
+    EMITTER_CONTEXT = "emitter_context"
+
+
+class LedgerStatus(StrEnum):
+    """Current disposition of a ledger record."""
+
+    #: Transient/deterministic-repair — eligible again once ``retry_after`` passes.
+    RETRY_SCHEDULED = "retry_scheduled"
+    #: Permanent/emitter-context — held out of scheduling pending a re-plan /
+    #: emitter re-input (do NOT re-dispatch unchanged).
+    REROUTED = "rerouted"
+    #: Invariant — held out of scheduling; a code bug for AGENT_BLOCKED/operator.
+    TERMINAL = "terminal"
+    #: A subsequent step succeeded — record neutralized; ``consecutive_count`` 0.
+    CLEARED = "cleared"
+
+
+#: Statuses whose projects the scheduler holds out of reselection until a
+#: re-plan / operator / stage-change releases them (see :func:`is_schedulable`).
+_HOLD_STATUSES: frozenset[str] = frozenset(
+    {LedgerStatus.REROUTED.value, LedgerStatus.TERMINAL.value}
+)
+
+# --------------------------------------------------------------------------
+# The nine real fingerprints (recon C) + an unknown catch-all.
+# --------------------------------------------------------------------------
+
+FP_UNREACHABLE_REFERENCE = "unreachable_reference"
+FP_TEMPLATE_REJECTION = "template_rejection"
+FP_BACKEND_CHAIN_FAILED = "backend_chain_failed"
+FP_INVALID_TRANSITION = "invalid_transition"
+FP_FILESYSTEM_FILE_EXISTS = "filesystem_file_exists"
+FP_MODEL_CHAIN_FAILED = "model_chain_failed"
+FP_UNRESOLVED_MARKERS = "unresolved_markers"
+FP_NO_SEED_DRAFT = "no_seed_draft"
+FP_TASKER_ZERO_TASKS = "tasker_zero_tasks"
+FP_UNKNOWN = "unknown"
+
+#: Fingerprint -> class. An unrecognized error defaults to ``transient`` (retry
+#: with backoff) — the safe default: it neither loops every tick nor permanently
+#: abandons a project on a signature we simply do not recognize yet.
+_FINGERPRINT_CLASS: dict[str, ErrorClass] = {
+    FP_UNREACHABLE_REFERENCE: ErrorClass.PERMANENT,
+    FP_TEMPLATE_REJECTION: ErrorClass.PERMANENT,
+    FP_BACKEND_CHAIN_FAILED: ErrorClass.TRANSIENT,
+    FP_INVALID_TRANSITION: ErrorClass.INVARIANT,
+    FP_FILESYSTEM_FILE_EXISTS: ErrorClass.DETERMINISTIC_REPAIR,
+    FP_MODEL_CHAIN_FAILED: ErrorClass.TRANSIENT,
+    FP_UNRESOLVED_MARKERS: ErrorClass.EMITTER_CONTEXT,
+    FP_NO_SEED_DRAFT: ErrorClass.EMITTER_CONTEXT,
+    FP_TASKER_ZERO_TASKS: ErrorClass.EMITTER_CONTEXT,
+    FP_UNKNOWN: ErrorClass.TRANSIENT,
+}
+
+#: Class-level remediation threaded into the record for review / re-plan.
+REMEDIATION: dict[ErrorClass, str] = {
+    ErrorClass.TRANSIENT: (
+        "Backend/model chain or network flaked (or the signature is unrecognized). "
+        "Retry with exponential backoff. If it persists past the cap the chain/model "
+        "config or the remote is genuinely down — check backend health."
+    ),
+    ErrorClass.PERMANENT: (
+        "The reference/source is unreachable, or the emitted artifact is an unfilled "
+        "template with no valid content. Do NOT re-dispatch unchanged: route the "
+        "evidence to a source-aware re-plan (inject a verified replacement source) or "
+        "back to the emitter, or mark terminal if genuinely unrecoverable."
+    ),
+    ErrorClass.INVARIANT: (
+        "An invalid state-machine transition was attempted — a code bug, not a flake; "
+        "retrying can never fix it. Route to AGENT_BLOCKED and fix the transition logic."
+    ),
+    ErrorClass.DETERMINISTIC_REPAIR: (
+        "A deterministic filesystem collision (a dir/file already exists). Make the "
+        "step idempotent (exist_ok=True / reconcile the existing artifact) then retry; "
+        "backoff spaces the retries so it does not loop every tick meanwhile."
+    ),
+    ErrorClass.EMITTER_CONTEXT: (
+        "The emitter produced insufficient output (unresolved markers / no seed draft / "
+        "zero tasks). Supply the missing inputs/context and re-run; do not blindly "
+        "re-emit the same empty artifact."
+    ),
+}
+
+
+def classify_message(message: str) -> tuple[str, ErrorClass]:
+    """Fingerprint a failure from its exception text, returning ``(fingerprint, class)``.
+
+    Ordering is load-bearing: a ``backend_chain_failed`` message wraps a nested
+    ``every model in chain ...`` error, so "every backend in chain" MUST be tested
+    before "every model in chain" or the outer failure would misclassify.
+    """
+    low = (message or "").lower()
+    if "invalid transition" in low:
+        fp = FP_INVALID_TRANSITION
+    elif "refused to emit a 'template'" in low or "unfilled_bracket" in low:
+        fp = FP_TEMPLATE_REJECTION
+    elif "[errno 17]" in low:  # "[Errno 17] File exists: '.../code'"
+        fp = FP_FILESYSTEM_FILE_EXISTS
+    elif "reference is unreachable" in low:
+        fp = FP_UNREACHABLE_REFERENCE
+    elif "every backend in chain" in low:  # BEFORE "every model in chain" (nested)
+        fp = FP_BACKEND_CHAIN_FAILED
+    elif "every model in chain" in low:
+        fp = FP_MODEL_CHAIN_FAILED
+    elif "markers unresolved" in low:  # "Clarifier left 3 of 3 markers unresolved"
+        fp = FP_UNRESOLVED_MARKERS
+    elif "draft to seed" in low or "to seed from" in low:
+        fp = FP_NO_SEED_DRAFT
+    elif "tasker produced only" in low or ("task id" in low and "produced" in low):
+        fp = FP_TASKER_ZERO_TASKS
+    else:
+        fp = FP_UNKNOWN
+    return fp, _FINGERPRINT_CLASS[fp]
+
+
+def classify(exc: Exception) -> tuple[str, ErrorClass]:
+    """Fingerprint + class for an exception (message- and type-keyed)."""
+    return classify_message(str(exc))
+
+
+def compute_retry_after(last_seen: datetime, consecutive_count: int) -> datetime:
+    """Exponential-backoff next-eligible time: ``last_seen + BASE * 2**min(n, cap)``.
+
+    Monotonically non-decreasing in ``consecutive_count`` and capped at
+    :data:`BACKOFF_CAP` so the retry window saturates instead of growing forever.
+    """
+    exp = min(max(int(consecutive_count), 0), BACKOFF_CAP)
+    return last_seen + timedelta(seconds=BASE_BACKOFF_SECONDS * (2**exp))
+
+
+def disposition(
+    error_class: ErrorClass, *, last_seen: datetime, consecutive_count: int
+) -> tuple[LedgerStatus, datetime | None]:
+    """Map a class to ``(status, retry_after)``.
+
+    Transient / deterministic-repair get a backoff ``retry_after``; invariant is
+    terminal; permanent / emitter-context are rerouted. The latter three carry NO
+    ``retry_after`` — they never consume the backoff budget (retrying cannot fix a
+    code bug, a dead source, or an empty template).
+    """
+    if error_class in (ErrorClass.TRANSIENT, ErrorClass.DETERMINISTIC_REPAIR):
+        return LedgerStatus.RETRY_SCHEDULED, compute_retry_after(
+            last_seen, consecutive_count
+        )
+    if error_class == ErrorClass.INVARIANT:
+        return LedgerStatus.TERMINAL, None
+    # PERMANENT and EMITTER_CONTEXT
+    return LedgerStatus.REROUTED, None
+
+
+def _evidence(message: str) -> str:
+    """A concise, single-line excerpt of the failure for review / re-plan."""
+    return " ".join((message or "").split())[:_MAX_EVIDENCE_CHARS]
+
+
+def make_record(
+    *,
+    project_id: str,
+    stage: str,
+    message: str,
+    consecutive_count: int,
+    first_seen: str,
+    last_seen: datetime,
+) -> dict:
+    """Build a fully-typed record dict from its parts (shared by the live writer
+    and the one-time migration). ``last_seen`` is a datetime (used for backoff)."""
+    fingerprint, error_class = classify_message(message)
+    status, retry_after = disposition(
+        error_class, last_seen=last_seen, consecutive_count=consecutive_count
+    )
+    return {
+        "project_id": project_id,
+        "stage": stage,
+        "class": error_class.value,
+        "fingerprint": fingerprint,
+        "consecutive_count": int(consecutive_count),
+        "first_seen": first_seen,
+        "last_seen": last_seen.isoformat(),
+        "retry_after": retry_after.isoformat() if retry_after is not None else None,
+        "last_error": (message or "")[:_MAX_ERROR_CHARS],
+        "evidence": _evidence(message),
+        "remediation": REMEDIATION[error_class],
+        "status": status.value,
+    }
+
+
+# --------------------------------------------------------------------------
+# Path + IO
+# --------------------------------------------------------------------------
+
+
+def _repo_base(repo_root: Path | None) -> Path:
+    if repo_root is not None:
+        return Path(repo_root)
+    from llmxive.config import repo_root as _rr
+
+    return _rr()
+
+
+def record_path(project_id: str, repo_root: Path | None = None) -> Path:
+    """Absolute path to a project's ledger file."""
+    return _repo_base(repo_root).joinpath(*LEDGER_SUBDIR, f"{project_id}.json")
+
+
+def load_record(project_id: str, *, repo_root: Path | None = None) -> dict | None:
+    """Read a project's ledger record, or ``None`` if absent/unreadable."""
+    path = record_path(project_id, repo_root)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _write(path: Path, record: dict) -> None:
+    atomic_write_text(path, json.dumps(record, indent=2))
+
+
+def record_failure(
+    project,
+    exc: Exception,
+    *,
+    repo_root: Path | None = None,
+    now: datetime | None = None,
+) -> dict:
+    """Persist a typed advancement-failure record, incrementing the CONSECUTIVE
+    failure count (a prior ``cleared``/absent record restarts the count at 1).
+
+    Returns the written record. Never raises through to the caller's control flow
+    beyond normal IO exceptions — the CLI wraps this so recording can never crash
+    the run.
+    """
+    now = now or datetime.now(UTC)
+    path = record_path(project.id, repo_root)
+    prior = load_record(project.id, repo_root=repo_root)
+    prior_count = 0
+    first_seen = now.isoformat()
+    if prior is not None and prior.get("status") != LedgerStatus.CLEARED.value:
+        prior_count = int(prior.get("consecutive_count", 0) or 0)
+        first_seen = prior.get("first_seen") or first_seen
+    record = make_record(
+        project_id=project.id,
+        stage=project.current_stage.value,
+        message=str(exc),
+        consecutive_count=prior_count + 1,
+        first_seen=first_seen,
+        last_seen=now,
+    )
+    _write(path, record)
+    return record
+
+
+def clear(
+    project, *, repo_root: Path | None = None, now: datetime | None = None
+) -> bool:
+    """Neutralize a project's record after a SUCCESSFUL advancement step.
+
+    Sets ``status=cleared`` and ``consecutive_count=0`` (preserving ``first_seen``
+    for audit) so the next failure starts a fresh consecutive streak at 1. Returns
+    ``True`` when a record existed. A no-op (returns ``False``) when there is none.
+    """
+    record = load_record(project.id, repo_root=repo_root)
+    if record is None:
+        return False
+    if record.get("status") == LedgerStatus.CLEARED.value:
+        return True
+    now = now or datetime.now(UTC)
+    record["status"] = LedgerStatus.CLEARED.value
+    record["consecutive_count"] = 0
+    record["retry_after"] = None
+    record["last_seen"] = now.isoformat()
+    _write(record_path(project.id, repo_root), record)
+    return True
+
+
+# --------------------------------------------------------------------------
+# Scheduler gate
+# --------------------------------------------------------------------------
+
+
+def _parse(ts: str) -> datetime:
+    dt = datetime.fromisoformat(ts)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+def is_schedulable(record: dict | None, *, now: datetime | None = None) -> bool:
+    """Whether a project carrying ``record`` may be scheduled right now.
+
+    * no record / ``cleared`` -> schedulable.
+    * ``retry_scheduled`` -> schedulable ONLY once ``retry_after`` has passed
+      (this is the backoff gate that stops the every-tick re-pick).
+    * ``rerouted`` / ``terminal`` -> NOT schedulable — held for re-plan / routing,
+      never resurrected by backoff (they carry no ``retry_after``).
+    """
+    if record is None:
+        return True
+    status = record.get("status")
+    if status in (None, LedgerStatus.CLEARED.value):
+        return True
+    if status in _HOLD_STATUSES:
+        return False
+    if status == LedgerStatus.RETRY_SCHEDULED.value:
+        retry_after = record.get("retry_after")
+        if not retry_after:
+            return True
+        now = now or datetime.now(UTC)
+        try:
+            return now >= _parse(retry_after)
+        except (TypeError, ValueError):
+            return True
+    return True  # unknown status -> do not strand the project
+
+
+def is_on_hold(project, *, repo_root: Path | None = None, now: datetime | None = None) -> bool:
+    """True when the scheduler should SKIP ``project`` because of its ledger record.
+
+    The record only applies while the project still sits at the stage it failed
+    at: a record whose ``stage`` differs from ``project.current_stage`` is stale
+    (the project advanced past the failing step, e.g. via an operator re-route)
+    and is ignored, so a stale hold can never permanently strand a project.
+    """
+    record = load_record(project.id, repo_root=repo_root)
+    if record is None:
+        return False
+    if record.get("stage") != project.current_stage.value:
+        return False
+    return not is_schedulable(record, now=now)
+
+
+__all__ = [
+    "BACKOFF_CAP",
+    "BASE_BACKOFF_SECONDS",
+    "REMEDIATION",
+    "ErrorClass",
+    "LedgerStatus",
+    "classify",
+    "classify_message",
+    "clear",
+    "compute_retry_after",
+    "disposition",
+    "is_on_hold",
+    "is_schedulable",
+    "load_record",
+    "make_record",
+    "record_failure",
+    "record_path",
+]

--- a/src/llmxive/pipeline/graph.py
+++ b/src/llmxive/pipeline/graph.py
@@ -402,10 +402,18 @@ def _paper_complete_preconditions_met(
     build_result = build_paper(project_id, repo_root=repo_root)
     if not build_result.get("ok"):
         return False
-    # And the produced PDF MUST exist on disk (latex_build sometimes
-    # reports ok without producing the artifact).
-    paper_pdf = project_dir / "paper" / "source" / "main.pdf"
-    if not paper_pdf.exists():
+    # And the produced PDF MUST exist on disk. Consume the producer's OWN
+    # returned ``pdf_path`` — ``build_paper`` renders to ``paper/pdf/main.pdf``
+    # (pdflatex ``-output-directory``), NEVER to ``paper/source/main.pdf``. The
+    # old hard-coded ``source/main.pdf`` check was a path the producer never
+    # writes, so this gate was effectively unsatisfiable for real builder output
+    # (issue #1139 P0: 104 compilable main.tex, 0 pdf at the checked path). Also
+    # require the PDF to be at least as fresh as the source it was built from so
+    # a stale carry-over PDF cannot satisfy the gate.
+    pdf_path_str = build_result.get("pdf_path")
+    if not pdf_path_str or not Path(pdf_path_str).is_file():
+        return False
+    if Path(pdf_path_str).stat().st_mtime < paper_source.stat().st_mtime:
         return False
     # Citation gate.
     from llmxive.agents.reference_validator import has_blocking_citations
@@ -1114,6 +1122,50 @@ def _write_convergence_replan_feedback(
     return text
 
 
+def _write_unverifiable_replan_feedback(
+    project_dir: Path, entries: list[dict[str, Any]]
+) -> str:
+    """DETERMINISTIC re-plan note (NO LLM) for tasks the implementer repeatedly
+    could not make pass verification (issue #1139 D6). Written to the SAME
+    kickback-ingestion file the planner already reads (SSoT — no new channel)."""
+    lines: list[str] = [
+        "# Re-plan: task(s) could not be made to pass verification — "
+        "adjust the approach",
+        "",
+        "The implementer repeatedly failed the verification checks for the task(s) "
+        "below. They were NOT force-accepted (that fail-open was removed in "
+        "issue #1139); instead the project re-plans so a DIFFERENT approach "
+        "(simpler method, different tooling, or a decomposition into individually "
+        "verifiable steps) can produce checkable artifacts.",
+        "",
+        "## Repeatedly-unverifiable tasks",
+        "",
+    ]
+    for e in entries:
+        key = str(e.get("task_key", "?"))
+        reason = str(e.get("last_reason", "")).strip()
+        cnt = e.get("reject_count", "?")
+        lines.append(
+            f"- `{key}` (rejected {cnt}x): {reason}"
+            if reason else f"- `{key}` (rejected {cnt}x)"
+        )
+    lines += [
+        "",
+        "## Required change",
+        "",
+        "Re-plan so each promised deliverable is produced by a step whose output "
+        "can be deterministically verified (a real file with the expected "
+        "schema/content). Avoid the approach that produced the unverifiable work "
+        "above.",
+        "",
+    ]
+    text = "\n".join(lines) + "\n"
+    memory_dir = project_dir / ".specify" / "memory"
+    memory_dir.mkdir(parents=True, exist_ok=True)
+    (memory_dir / KICKBACK_FEEDBACK_FILENAME).write_text(text, encoding="utf-8")
+    return text
+
+
 def _write_execution_replan_feedback(
     project_dir: Path, rec: dict[str, Any]
 ) -> str:
@@ -1157,14 +1209,24 @@ def _write_execution_replan_feedback(
     else:
         lines.append("- (no per-command failures recorded; the run produced no "
                      "real data/figure artifacts)")
+    # Class-SPECIFIC guidance (issue #1139 anti-pattern 4 / P1-2): the durable
+    # failure_class the runner recorded decides the advice, instead of one generic
+    # "make it CPU-tractable" line that mis-steers a data-unreachable or code-bug
+    # failure. GPU→re-scope/offload, data→verified source, fabrication→real data,
+    # bug→fix in place.
+    from llmxive.execution.failure_class import REPLAN_GUIDANCE, FailureClass
+
+    _fc_val = rec.get("failure_class")
+    try:
+        _fc = FailureClass(_fc_val) if _fc_val else FailureClass.UNKNOWN
+    except ValueError:
+        _fc = FailureClass.UNKNOWN
     lines += [
         "",
         "## Required change",
+        f"(diagnosed failure class: **{_fc.value}**)",
         "",
-        "The implementation approach needs adjustment given the errors above — "
-        "re-plan with a design that avoids them. Keep what worked; replace the "
-        "parts of the method that produced the failures above with a "
-        "CPU-tractable, dependency-light alternative that the free CI can run.",
+        REPLAN_GUIDANCE[_fc],
         "",
     ]
     lines += _data_availability_replan_note(project_dir, rec)
@@ -1427,6 +1489,26 @@ def _decide_next_stage(
         decision = consume_convergence_kickback(mem_dir)
         if decision is None:
             continue
+        # issue #1139 D3: only HONOR a convergence kickback whose panel is the one
+        # that runs at the project's CURRENT stage. A sentinel whose stage_label
+        # does NOT match the current stage's panel is STALE / cross-stage — it was
+        # written by an earlier stage's panel (or the other track) and is only
+        # being consumed now, after the project moved to a stage that has NO panel
+        # (in_progress, paper_analyzed, analyzed …) or a DIFFERENT panel. Returning
+        # its to_stage is exactly what produced the recorded `invalid transition
+        # paper_analyzed->paper_planned` / `in_progress->clarified` / `in_progress->
+        # specified` crashes (PROJ-575/601/577/606/644). consume_convergence_kickback
+        # already unlinked the sentinel, so skip it and fall through to normal
+        # forward routing — never drive routing from a stale cross-stage sentinel.
+        if _STAGE_PANEL_LABEL.get(project.current_stage) != decision.stage_label:
+            logger.warning(
+                "ignoring stale/cross-stage convergence kickback for %s: sentinel "
+                "panel %r does not match current stage %s (panel %r) — routing "
+                "forward normally (issue #1139 invalid-transition fix)",
+                project.id, decision.stage_label, project.current_stage.value,
+                _STAGE_PANEL_LABEL.get(project.current_stage),
+            )
+            continue
         if decision.escalate:
             # AUTONOMOUS exhaustion handling (mirrors the execution path,
             # commit 3068830e3): a convergence panel NEVER parks a project at
@@ -1646,6 +1728,27 @@ def _decide_next_stage(
         # next tick observe IN_PROGRESS + all-tasks-done → RESEARCH_COMPLETE.
         return Stage.IN_PROGRESS
     if cur == Stage.IN_PROGRESS:
+        # issue #1139 D6: a task the implementer repeatedly cannot make pass is
+        # recorded UNVERIFIABLE by the task-verifier (reopened `[ ]`, NEVER
+        # force-accepted to `[X]`). Left alone, that reopened task keeps
+        # _all_tasks_done False forever and the project wedges at in_progress. So
+        # RE-PLAN the approach (a legal IN_PROGRESS→PLANNED edge, the same target
+        # as execution exhaustion), write a deterministic note naming the tasks,
+        # and clear the store so the re-planned cycle starts clean. This is the
+        # honest loop-breaker that replaced the fail-open force-accept.
+        from llmxive.state import unverifiable as _unverifiable
+
+        if _unverifiable.has_unverifiable(project.id, repo_root=repo_root):
+            _entries = _unverifiable.load(project.id, repo_root=repo_root)
+            _write_unverifiable_replan_feedback(project_dir, _entries)
+            _unverifiable.clear(project.id, repo_root=repo_root)
+            logger.warning(
+                "%s has %d repeatedly-unverifiable task(s) the implementer could "
+                "not make pass — re-planning (IN_PROGRESS→PLANNED; NOT "
+                "force-accepting incomplete work) [issue #1139 D6]",
+                project.id, len(_entries),
+            )
+            return Stage.PLANNED
         # Spec 023 defect #25: research_complete now requires the analysis to
         # have actually RUN and produced real artifacts (execution_status.ok),
         # not just all task checkboxes ticked. Until the dedicated execution
@@ -1704,16 +1807,22 @@ def _decide_next_stage(
                 rec = execution_status.load(project.id, repo_root=repo_root) or {}
                 if (execution_status.replan_rounds(project.id, repo_root=repo_root)
                         >= execution_status.MAX_REPLAN_ROUNDS):
+                    _fc = rec.get("failure_class") or "unknown"
                     logger.warning(
                         "execution fix-loop exhausted ALL model tiers AND all %d "
-                        "re-plans for %s (%d total failed attempts) — the analysis is "
-                        "not executable in this environment; terminal "
-                        "VALIDATOR_REJECTED rather than another unbounded lap",
+                        "re-plans for %s (%d total failed attempts, "
+                        "failure_class=%s) — the analysis is not executable in "
+                        "this environment; terminal AGENT_BLOCKED (an "
+                        "operator-clearable, re-openable sink) rather than "
+                        "VALIDATOR_REJECTED, so an infra/data-blocked GOOD idea is "
+                        "NOT conflated with an idea-quality rejection "
+                        "(issue #1139 P1-2 / sec 3.7)",
                         execution_status.MAX_REPLAN_ROUNDS, project.id,
                         execution_status.total_attempts(project.id, repo_root=repo_root),
+                        _fc,
                     )
                     _write_execution_replan_feedback(project_dir, rec)
-                    return Stage.VALIDATOR_REJECTED
+                    return Stage.AGENT_BLOCKED
                 _write_execution_replan_feedback(project_dir, rec)
                 execution_status.reset_fix_loop(project.id, repo_root=repo_root)
                 logger.info(

--- a/src/llmxive/pipeline/project_lease.py
+++ b/src/llmxive/pipeline/project_lease.py
@@ -1,0 +1,159 @@
+"""Per-project advisory lease — the IN-HOST half of the concurrent-persistence
+guard (issue #1139, defect D16: "concurrent persistence loses completed work").
+
+Background
+----------
+The Advance workflow runs a matrix of scheduler ticks that each pick a project,
+mutate its canonical state, and push to ``main``. ``scheduler.pick_for_worker``
+is deterministic only *at a fixed HEAD*: two ticks that started from DIFFERENT
+commits can pick the SAME project and both write its state. The rebase-race in
+``scripts/ci/commit-and-push.sh`` then does a per-file, last-writer-wins merge,
+so one tick's freshly-computed counters (``fix_rounds`` / ``replan_rounds`` /
+convergence rounds) can be silently overwritten by the other — completed work
+is lost.
+
+This module provides a kernel-enforced ``fcntl.flock`` lease keyed by project
+id, so two ticks that share a filesystem can never co-mutate one project's state
+at the same time. It mirrors ``llmxive.state.project_id_lock`` exactly (same
+``os.open`` + ``fcntl.flock`` approach, same non-POSIX no-op fallback) rather
+than forking a divergent lock implementation (Constitution I). Where
+``project_id_lock`` guards a single shared critical section (ID allocation) with
+one lock file, this keys the lock file by ``project_id`` so DIFFERENT projects
+proceed in parallel while the SAME project serializes.
+
+Scope: in-host only. Cross-RUNNER protection still relies on the CAS push
+-----------------------------------------------------------------------
+``fcntl.flock`` is only meaningful between processes that share the same
+filesystem/host. On GitHub Actions each matrix worker runs on its OWN VM, so
+this lease does NOT serialize ticks across separate runners — that half of the
+guarantee still relies on the compare-and-swap push in
+``scripts/ci/commit-and-push.sh`` (rebase-onto-latest-origin/main, then a
+re-fetch verify that HEAD actually landed; a lost race fails loud and the
+project stays schedulable). The lease closes the gap that CAS cannot: two ticks
+on the SAME host (a local ``python -m llmxive run`` fan-out, a future
+single-runner multi-worker deployment, or an overlapping re-drive that escaped
+the per-index ``concurrency`` group) mutating one project's on-disk state
+concurrently.
+
+Relationship to ``llmxive.pipeline.lock``
+-----------------------------------------
+``pipeline.lock`` is a TTL YAML-sentinel advisory lock (holder run id + expiry)
+that the scheduler consults so it never *picks* an actively-held project. That
+lock is a check-then-write on a YAML file — it has a TOCTOU window and gives no
+kernel guarantee. This lease is complementary: it is the atomic, kernel-enforced
+mutual-exclusion primitive that a ``pipeline.lock`` acquire/mutate cycle can be
+wrapped in to close that window on a single host. It intentionally does NOT
+duplicate the TTL/holder bookkeeping — flock is released automatically when the
+holding process exits, so there is no stale-lock class to reclaim.
+
+How ``scheduler.py`` should adopt it (wiring is owned elsewhere)
+---------------------------------------------------------------
+This module only provides the primitive; wiring it into the scheduler is done in
+a separate change. The intended adoption::
+
+    from llmxive.pipeline.project_lease import project_lease
+
+    with project_lease(project_id, repo_root=repo_root) as acquired:
+        if not acquired:
+            # Another in-host tick already owns this project this cycle;
+            # skip it and let pick_for_worker fall through to the next
+            # candidate rather than co-mutating its state.
+            continue
+        # ... pick -> run_one_step -> persist for `project_id` ...
+
+Use non-blocking acquisition (the default) in the scheduler so a contended
+project is skipped, not waited on — waiting would just serialize the whole tick
+behind one project. Pass ``blocking=True`` only where you genuinely must run the
+critical section (e.g. a single-project CLI command) and can afford to wait.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+
+def _leases_dir(repo_root: Path) -> Path:
+    return repo_root / "state" / "leases"
+
+
+def _lease_path(repo_root: Path, project_id: str) -> Path:
+    if not project_id or "/" in project_id or "\\" in project_id or project_id in (".", ".."):
+        # Guard against a project id escaping the leases directory. Real ids are
+        # "PROJ-###-slug" and never contain path separators.
+        raise ValueError(f"unsafe project_id for lease file: {project_id!r}")
+    return _leases_dir(repo_root) / f"{project_id}.lock"
+
+
+@contextlib.contextmanager
+def project_lease(
+    project_id: str,
+    *,
+    repo_root: Path,
+    blocking: bool = False,
+) -> Iterator[bool]:
+    """Hold a per-project advisory lease on ``state/leases/<project_id>.lock``
+    for the duration of the with-block.
+
+    Yields ``True`` if the lease was acquired (this block now holds exclusive
+    in-host ownership of ``project_id``), or ``False`` if it is already held by
+    another open file description (only possible in the default non-blocking
+    mode). When ``False`` is yielded no lock is held and the caller MUST NOT
+    mutate the project — skip it this cycle.
+
+    Args:
+        project_id: canonical project id (``PROJ-###-slug``); keys the lock file.
+        repo_root: repository root; the lock lives under ``<repo_root>/state/leases``.
+        blocking: if ``True``, block until the lease is acquired (always yields
+            ``True``). If ``False`` (default), acquire without waiting and yield
+            ``False`` when the project is already leased.
+
+    On POSIX, uses ``fcntl.flock`` (``LOCK_EX`` blocking / ``LOCK_EX | LOCK_NB``
+    non-blocking). ``flock`` is tied to the open file description, so two
+    independent ``os.open`` calls of the same lock file conflict even within one
+    process — which is exactly what lets a re-entrant same-project acquire in the
+    same process return ``False``. The lease is released on exit (and, as a
+    kernel guarantee, whenever the holding process dies), so there is no stale
+    lease to reclaim.
+
+    On non-POSIX platforms (Windows), ``fcntl`` is unavailable; the lease
+    degrades to a no-op that yields ``True`` with a stderr warning (llmXive is
+    POSIX-only; this is defense-in-depth, matching ``project_id_lock``).
+    """
+    lease_file = _lease_path(repo_root, project_id)
+    lease_file.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        import fcntl
+    except ImportError:
+        print(
+            "[project_lease] fcntl unavailable (non-POSIX?); "
+            "in-host concurrent-safety NOT enforced",
+            file=sys.stderr,
+        )
+        yield True
+        return
+
+    fd = os.open(str(lease_file), os.O_CREAT | os.O_RDWR, 0o644)
+    acquired = False
+    try:
+        flags = fcntl.LOCK_EX if blocking else (fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            fcntl.flock(fd, flags)
+            acquired = True
+        except BlockingIOError:
+            # Non-blocking acquire found the project already leased. Yield False
+            # WITHOUT holding a lock — the caller must skip this project.
+            acquired = False
+        yield acquired
+    finally:
+        if acquired:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                os.close(fd)
+        else:
+            os.close(fd)

--- a/src/llmxive/pipeline/scheduler.py
+++ b/src/llmxive/pipeline/scheduler.py
@@ -46,6 +46,7 @@ from collections import defaultdict
 from datetime import UTC, datetime
 from pathlib import Path
 
+from llmxive.pipeline import advance_ledger
 from llmxive.pipeline import lock as lockmod
 from llmxive.state import project as project_store
 from llmxive.types import Project, Stage
@@ -229,7 +230,16 @@ def _eligible_candidates(
     stage: Stage | None,
 ) -> list[Project]:
     """Return projects eligible for scheduling: non-terminal, non-locked,
-    and (if `stage` is given) at that exact stage."""
+    NOT on an advance-error hold, and (if `stage` is given) at that exact stage.
+
+    The advance-error hold (issue #1139, defect D5) is the fix for the every-tick
+    re-pick of a permanently-failing project: a project whose typed ledger record
+    (:mod:`llmxive.pipeline.advance_ledger`) is still active for its CURRENT stage
+    is skipped while it is inside a transient backoff window or held in a
+    ``rerouted``/``terminal`` disposition awaiting a re-plan / operator. A record
+    for a different stage is stale (the project advanced past the failing step) and
+    is ignored, so a hold can never permanently strand a project. Terminal STAGES
+    (``_NEVER_PICK``) and locks are still honoured exactly as before."""
     projects = project_store.list_all(repo_root=repo_root)
     out: list[Project] = []
     for p in projects:
@@ -238,6 +248,8 @@ def _eligible_candidates(
         if lockmod.is_locked(p.id, repo_root=repo_root):
             continue
         if stage is not None and p.current_stage != stage:
+            continue
+        if advance_ledger.is_on_hold(p, repo_root=repo_root):
             continue
         out.append(p)
     return out

--- a/src/llmxive/speckit/_reference_repair.py
+++ b/src/llmxive/speckit/_reference_repair.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -47,6 +48,24 @@ from llmxive.speckit._research_guard import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ReplacementResult:
+    """Outcome of searching for a replacement for ONE dead reference.
+
+    ``url`` is the verified, re-probed replacement (``None`` when none was used).
+    ``reason`` makes the WHY actionable — distinguishing a LEGITIMATE no-op
+    (``"no_verified_replacement"`` — the librarian searched and found nothing
+    reachable) from a SYSTEMIC breakage (``"resolver_error: <Type>: <detail>"`` —
+    the resolver/network itself broke). Both still fail-open (the dead URL falls
+    through to the FR-006 gate), but a systemic breakage is logged as a WARNING so
+    "the repair machinery is down" is not silently indistinguishable from "there
+    is genuinely no replacement." ``reason`` is ``""`` on a successful swap.
+    """
+
+    url: str | None
+    reason: str = ""
 
 # Reachability probe budget for a candidate replacement (seconds). Matches the
 # hard gate's default so "reachable here" == "reachable at the gate".
@@ -96,7 +115,7 @@ def _name_tokens_from_url(url: str) -> str:
     out: list[str] = []
     for seg in raw:
         seg = seg.strip()
-        if not seg or "." in seg and re.search(r"\.[a-z0-9]{1,6}$", seg):
+        if not seg or ("." in seg and re.search(r"\.[a-z0-9]{1,6}$", seg)):
             # Skip filenames / hostnames with extensions (x.csv, host.co).
             if seg.lower() in _URL_NOISE_TOKENS:
                 continue
@@ -136,7 +155,9 @@ def _derive_intent(research_md_text: str, url: str) -> str:
     return " ".join(toks[:24]).strip()
 
 
-def _find_replacement_url(intent: str, *, project_dir: Path, repo_root: Path) -> str | None:
+def _find_replacement_url(
+    intent: str, *, project_dir: Path, repo_root: Path
+) -> ReplacementResult:
     """Ask the librarian for a VERIFIED, reachable replacement URL for ``intent``.
 
     Uses the planner's existing verified-URL source
@@ -146,11 +167,16 @@ def _find_replacement_url(intent: str, *, project_dir: Path, repo_root: Path) ->
     candidates. The chosen URL is then RE-PROBED with the research-guard's own
     ``_probe`` so it is guaranteed to pass the identical hard gate.
 
-    Returns the replacement URL, or ``None`` when nothing verified+reachable was
-    found. NEVER raises — a search/network failure degrades to ``None``.
+    Returns a :class:`ReplacementResult`. NEVER raises — but instead of
+    flattening every failure to a bare ``None`` (which made a systemic resolver/
+    network breakage indistinguishable from a legitimate "nothing found"), it
+    threads a typed ``reason``: ``"resolver_error: …"`` when the resolver itself
+    raised (systemic — logged as a WARNING), ``"no_verified_replacement"`` when it
+    searched and found nothing reachable (a legitimate no-op), and ``""`` on a
+    successful swap.
     """
     if not intent.strip():
-        return None
+        return ReplacementResult(None, "empty_intent")
     try:
         # Imported lazily: dataset_resolver pulls ``requests``/``urllib3`` and
         # the registry-search path, which offline unit tests monkeypatch.
@@ -162,9 +188,16 @@ def _find_replacement_url(intent: str, *, project_dir: Path, repo_root: Path) ->
             repo_root=repo_root,
             budget_s=_RESOLVE_BUDGET_S,
         )
-    except Exception as exc:  # noqa: BLE001 — degrade, never crash the plan run.
-        logger.warning("reference-repair: librarian search failed for %r: %s", intent, exc)
-        return None
+    except Exception as exc:  # degrade, never crash the plan run.
+        # Systemic breakage (resolver bug / network down): keep fail-open but make
+        # the WHY actionable rather than an indistinguishable None.
+        reason = f"resolver_error: {type(exc).__name__}: {exc}"
+        logger.warning(
+            "reference-repair: librarian search BROKE for %r (%s) — degrading to "
+            "unresolved; this is a systemic failure, NOT 'no replacement found'",
+            intent, reason,
+        )
+        return ReplacementResult(None, reason)
 
     for ds in resolved.datasets:
         if ds.status != "verified":
@@ -179,8 +212,8 @@ def _find_replacement_url(intent: str, *, project_dir: Path, repo_root: Path) ->
                 _probe(cand_url, timeout=_PROBE_TIMEOUT)
             except UnreachableReference:
                 continue
-            return cand_url
-    return None
+            return ReplacementResult(cand_url, "")
+    return ReplacementResult(None, "no_verified_replacement")
 
 
 def _project_slug(project_dir: Path) -> str:
@@ -290,30 +323,39 @@ def repair_research_references(
     unresolved: list[str] = []
     for dead_url, reason in dead:
         intent = _derive_intent(research_md, dead_url)
-        replacement = _find_replacement_url(
+        result = _find_replacement_url(
             intent, project_dir=project_dir, repo_root=repo_root
         )
-        if replacement and replacement != dead_url:
-            updated = updated.replace(dead_url, replacement)
+        if result.url and result.url != dead_url:
+            updated = updated.replace(dead_url, result.url)
             repairs.append(
                 {
                     "dead_url": dead_url,
                     "reason": reason,
-                    "replacement_url": replacement,
+                    "replacement_url": result.url,
                     "intent": intent,
                 }
             )
             logger.info(
                 "reference-repair: swapped dead %r → verified %r (intent=%r)",
-                dead_url, replacement, intent,
+                dead_url, result.url, intent,
             )
         else:
             unresolved.append(dead_url)
-            logger.info(
-                "reference-repair: NO verified replacement for dead %r (intent=%r) "
-                "— leaving for the FR-006 gate",
-                dead_url, intent,
-            )
+            if result.reason.startswith("resolver_error:"):
+                # Systemic breakage — surface it distinctly (WARNING) so an
+                # outage isn't silently read as "no replacement exists".
+                logger.warning(
+                    "reference-repair: could NOT repair dead %r (intent=%r) due to "
+                    "a SYSTEMIC failure (%s) — leaving for the FR-006 gate",
+                    dead_url, intent, result.reason,
+                )
+            else:
+                logger.info(
+                    "reference-repair: NO verified replacement for dead %r "
+                    "(intent=%r, %s) — leaving for the FR-006 gate",
+                    dead_url, intent, result.reason or "no_verified_replacement",
+                )
 
     if repairs:
         updated = _append_repair_note(updated, repairs)
@@ -325,4 +367,4 @@ def repair_research_references(
     return files, unresolved
 
 
-__all__ = ["repair_research_references"]
+__all__ = ["ReplacementResult", "repair_research_references"]

--- a/src/llmxive/speckit/plan_cmd.py
+++ b/src/llmxive/speckit/plan_cmd.py
@@ -24,7 +24,6 @@ from llmxive.backends.router import GENERATION_MAX_TOKENS, reasoning_chat
 from llmxive.librarian.dataset_resolver import (
     render_planner_block,
     resolve_datasets,
-    write_manifest,
 )
 from llmxive.speckit.runner import run_script
 from llmxive.speckit.slash_command import SlashCommandAgent, SlashCommandContext
@@ -120,18 +119,45 @@ class PlannerAgent(SlashCommandAgent):
         )
         spec_path = feature_dir / "spec.md"
         spec_text = spec_path.read_text(encoding="utf-8") if spec_path.exists() else ""
+        # Weak resolver: reachable + format-sniffed cite-only candidates (a
+        # candidate PROPOSER; no dead write-only manifest is persisted — D7).
         resolved = resolve_datasets(
             spec_text,
             project_dir=ctx.project_dir,
             repo_root=ctx.project_dir.parent.parent,
         )
-        write_manifest(resolved, project_dir=ctx.project_dir)
+        weak_block = render_planner_block(resolved)
+        # PROACTIVE strong discovery at PLAN time (D11): run the SAME
+        # records+field HARD-verifier the execution stage uses, sharing the SAME
+        # on-disk cache (``.specify/memory/discovered_data_source.yaml``), so the
+        # planner plans around a REAL verified source instead of only the weak
+        # reachability sniff — and execution later reads the cache instead of
+        # re-discovering. Best-effort: offline / no-LLM degrades to just the weak
+        # block (never crashes a plan run), and the outcome is cached.
+        strong_block = self._plan_time_discovered_block(ctx.project_dir)
+        dataset_block = "\n\n".join(b for b in (strong_block, weak_block) if b)
         return {
             "feature_dir": str(feature_dir),
             "spec_path": str(spec_path),
             "script_result": result,
-            "dataset_block": render_planner_block(resolved),
+            "dataset_block": dataset_block,
         }
+
+    @staticmethod
+    def _plan_time_discovered_block(project_dir: Path) -> str:
+        """Proactively populate the shared discovery cache and render the verified
+        source (D11). Returns '' offline / when nothing is discovered / on any
+        failure — a plan run must never crash on data discovery."""
+        try:
+            from llmxive.execution.data_source import (
+                ensure_discovered_source,
+                render_feedback_block,
+            )
+
+            return render_feedback_block(ensure_discovered_source(project_dir))
+        except Exception as exc:  # never block planning on discovery
+            logger.warning("plan-time data-source discovery skipped: %s", exc)
+            return ""
 
     def build_prompt(
         self,

--- a/src/llmxive/state/_io.py
+++ b/src/llmxive/state/_io.py
@@ -1,0 +1,77 @@
+"""Shared atomic state-file I/O (issue #1139 / Constitution I).
+
+Before this module, only ``publication.py`` and ``revision_history.py`` wrote
+state atomically, each with its own private ``_atomic_write`` copy; every other
+state store did a bare ``path.write_text(...)`` — a crash mid-write truncates the
+JSON/YAML and the next ``load()`` reads ``{}`` or raises. Two overlapping pipeline
+ticks (different HEADs, same project) could also silently lose an update because
+the read-modify-write stores had no compare-and-swap.
+
+This is the ONE shared helper all state stores route through: a temp file in the
+destination directory written and ``os.replace``-d into place (atomic on POSIX),
+plus an optional mtime-based compare-and-swap for read-modify-write callers.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def atomic_write_text(path: Path, content: str, *, encoding: str = "utf-8") -> None:
+    """Write ``content`` to ``path`` atomically (temp file + ``os.replace``).
+
+    A reader either sees the complete previous file or the complete new file,
+    never a truncated one. Parent directories are created as needed.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding=encoding) as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+
+
+class StaleWriteError(RuntimeError):
+    """Raised by :func:`atomic_write_text_cas` when the file changed on disk
+    since the caller last read it (lost-update guard for read-modify-write
+    stores mutated by concurrent pipeline ticks)."""
+
+
+def read_mtime_ns(path: Path) -> int | None:
+    """Return the file's mtime in ns, or ``None`` if it does not exist. Callers
+    capture this before a read-modify-write and pass it to
+    :func:`atomic_write_text_cas` as the expected version token."""
+    try:
+        return Path(path).stat().st_mtime_ns
+    except FileNotFoundError:
+        return None
+
+
+def atomic_write_text_cas(
+    path: Path,
+    content: str,
+    *,
+    expected_mtime_ns: int | None,
+    encoding: str = "utf-8",
+) -> None:
+    """Atomic write that first verifies the on-disk file still matches the
+    ``expected_mtime_ns`` captured before the read-modify-write. If another
+    writer landed in between, raise :class:`StaleWriteError` so the caller can
+    re-read and retry instead of clobbering the newer state.
+    """
+    path = Path(path)
+    current = read_mtime_ns(path)
+    if current != expected_mtime_ns:
+        raise StaleWriteError(
+            f"{path} changed since read (expected mtime {expected_mtime_ns}, "
+            f"found {current}); refusing to overwrite newer state"
+        )
+    atomic_write_text(path, content, encoding=encoding)

--- a/src/llmxive/state/citations.py
+++ b/src/llmxive/state/citations.py
@@ -15,6 +15,7 @@ import yaml
 
 from llmxive.config import repo_root as _repo_root
 from llmxive.contract_validate import validate
+from llmxive.state._io import atomic_write_text
 from llmxive.types import Citation
 
 
@@ -44,8 +45,7 @@ def save(project_id: str, citations: list[Citation], *, repo_root: Path | None =
     for item in payload:
         validate("citation", item)
     path = _citations_path(project_id, repo_root=repo_root)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(yaml.safe_dump(payload, sort_keys=True), encoding="utf-8")
+    atomic_write_text(path, yaml.safe_dump(payload, sort_keys=True))
     return path
 
 

--- a/src/llmxive/state/claims.py
+++ b/src/llmxive/state/claims.py
@@ -13,6 +13,7 @@ import yaml
 
 from llmxive.claims.models import Claim, ClaimKind, ClaimStatus
 from llmxive.config import repo_root as _repo_root
+from llmxive.state._io import atomic_write_text
 
 
 def _state_root() -> Path:
@@ -73,8 +74,7 @@ def load(project_id: str, *, repo_root: Path | None = None) -> list[Claim]:
 def save(project_id: str, claims: list[Claim], *, repo_root: Path | None = None) -> Path:
     payload = [_claim_to_dict(c) for c in claims]
     path = _claims_path(project_id, repo_root=repo_root)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(yaml.safe_dump(payload, sort_keys=True), encoding="utf-8")
+    atomic_write_text(path, yaml.safe_dump(payload, sort_keys=True))
     return path
 
 

--- a/src/llmxive/state/escalations.py
+++ b/src/llmxive/state/escalations.py
@@ -32,6 +32,7 @@ from pathlib import Path
 import yaml
 
 from llmxive.config import repo_root as _repo_root
+from llmxive.state._io import atomic_write_text
 
 logger = logging.getLogger(__name__)
 
@@ -90,10 +91,9 @@ def write_record(
     if not record.timestamp:
         record.timestamp = datetime.now(UTC).isoformat()
     out_dir = _dir(repo_root)
-    out_dir.mkdir(parents=True, exist_ok=True)
     safe_ts = record.timestamp.replace(":", "").replace("+", "Z")
     path = out_dir / f"{record.project_id}__{safe_ts}.yaml"
-    path.write_text(yaml.safe_dump(asdict(record), sort_keys=False), encoding="utf-8")
+    atomic_write_text(path, yaml.safe_dump(asdict(record), sort_keys=False))
     logger.warning(
         "escalation recorded for %s (%s: %d/%d rounds): %s",
         record.project_id, record.loop, record.rounds_used, record.bound, path,
@@ -190,8 +190,8 @@ def file_engine_failure_issue(
         number = int(json.loads(out).get("number", 0))
     except (json.JSONDecodeError, ValueError):
         number = 0
-    ledger.parent.mkdir(parents=True, exist_ok=True)
-    ledger.write_text(
+    atomic_write_text(
+        ledger,
         yaml.safe_dump(
             {
                 "issue_number": number,
@@ -200,7 +200,6 @@ def file_engine_failure_issue(
                 "filed_at": datetime.now(UTC).isoformat(),
             }
         ),
-        encoding="utf-8",
     )
     return number or None
 
@@ -280,7 +279,7 @@ def update_digest(*, repo_root: Path | None = None, gh=None) -> int | None:
                 continue
             if not data.get("digest_id"):
                 data["digest_id"] = str(number)
-                p.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+                atomic_write_text(p, yaml.safe_dump(data, sort_keys=False))
     return number
 
 

--- a/src/llmxive/state/execution_status.py
+++ b/src/llmxive/state/execution_status.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any
 
 from llmxive.config import repo_root as _repo_root
+from llmxive.state._io import atomic_write_text
 
 logger = logging.getLogger(__name__)
 
@@ -212,10 +213,21 @@ def record(
     reason: str,
     artifacts: list[str],
     failures: list[str],
+    failure_class: str | None = None,
+    evidence: list[str] | None = None,
     repo_root: Path | None = None,
 ) -> dict[str, Any]:
     """Persist one execution attempt. Bumps ``fix_rounds`` on failure (so the
-    bounded auto-fix loop terminates), resets it to 0 on success."""
+    bounded auto-fix loop terminates), resets it to 0 on success.
+
+    ``failure_class`` is the durable :class:`llmxive.execution.failure_class.FailureClass`
+    value (compute_env / data_unreachable / fabrication / execution_bug /
+    unknown) the runner classified this failure as — persisted so downstream
+    re-plan feedback and terminal routing branch on the REAL cause instead of
+    re-parsing ``reason``/``failures`` strings (issue #1139 P1-2). ``evidence``
+    is the short list of matched signature strings that justified the class.
+    Both are cleared on success.
+    """
     existing = load(project_id, repo_root=repo_root) or {}
     prior_rounds = existing.get("fix_rounds", 0)
     prior_rounds = int(prior_rounds) if isinstance(prior_rounds, int) and prior_rounds >= 0 else 0
@@ -243,12 +255,20 @@ def record(
         #     so the routing layer can finally cap the outer loop.
         "total_attempts": 0 if ok else prior_attempts + 1,
         "replan_rounds": 0 if ok else _nonneg_int(existing.get("replan_rounds")),
+        # Durable failure classification (issue #1139 P1-2): the runner already
+        # knows whether this was a compute-env wall, an unreachable data source,
+        # fabrication, or an ordinary code bug — persist it so re-plan feedback
+        # and terminal routing branch on the real cause, not a re-parse of
+        # `reason`. Cleared on success.
+        "failure_class": None if ok else (failure_class or None),
+        "evidence": [] if ok else [str(e)[:600] for e in (evidence or [])][:20],
         "updated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
     d = _dir(repo_root)
     d.mkdir(parents=True, exist_ok=True)
-    _path(project_id, repo_root=repo_root).write_text(
-        json.dumps(rec, indent=2) + "\n", encoding="utf-8"
+    atomic_write_text(
+        _path(project_id, repo_root=repo_root),
+        json.dumps(rec, indent=2) + "\n",
     )
     return rec
 
@@ -278,8 +298,9 @@ def bump_model_tier(
     existing.setdefault("project_id", project_id)
     d = _dir(repo_root)
     d.mkdir(parents=True, exist_ok=True)
-    _path(project_id, repo_root=repo_root).write_text(
-        json.dumps(existing, indent=2) + "\n", encoding="utf-8"
+    atomic_write_text(
+        _path(project_id, repo_root=repo_root),
+        json.dumps(existing, indent=2) + "\n",
     )
     return nxt
 
@@ -320,8 +341,9 @@ def reset_fix_loop(project_id: str, *, repo_root: Path | None = None) -> None:
     existing["updated_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     d = _dir(repo_root)
     d.mkdir(parents=True, exist_ok=True)
-    _path(project_id, repo_root=repo_root).write_text(
-        json.dumps(existing, indent=2) + "\n", encoding="utf-8"
+    atomic_write_text(
+        _path(project_id, repo_root=repo_root),
+        json.dumps(existing, indent=2) + "\n",
     )
 
 
@@ -369,8 +391,9 @@ def record_offload(
     }
     d = _dir(repo_root)
     d.mkdir(parents=True, exist_ok=True)
-    _path(project_id, repo_root=repo_root).write_text(
-        json.dumps(rec, indent=2) + "\n", encoding="utf-8"
+    atomic_write_text(
+        _path(project_id, repo_root=repo_root),
+        json.dumps(rec, indent=2) + "\n",
     )
     return rec
 
@@ -400,8 +423,9 @@ def clear_offload(project_id: str, *, repo_root: Path | None = None) -> None:
     existing["updated_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     d = _dir(repo_root)
     d.mkdir(parents=True, exist_ok=True)
-    _path(project_id, repo_root=repo_root).write_text(
-        json.dumps(existing, indent=2) + "\n", encoding="utf-8"
+    atomic_write_text(
+        _path(project_id, repo_root=repo_root),
+        json.dumps(existing, indent=2) + "\n",
     )
 
 

--- a/src/llmxive/state/paper_status.py
+++ b/src/llmxive/state/paper_status.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 from llmxive.config import repo_root as _repo_root
+from llmxive.state._io import atomic_write_text
 
 logger = logging.getLogger(__name__)
 
@@ -80,8 +81,7 @@ def _save(
     record["updated_at"] = datetime.now(UTC).isoformat()
     record.setdefault("repair_rounds", 0)
     p = _path(paper_id, repo_root=repo_root)
-    p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+    atomic_write_text(p, json.dumps(record, indent=2) + "\n")
     return record
 
 

--- a/src/llmxive/state/project.py
+++ b/src/llmxive/state/project.py
@@ -15,7 +15,21 @@ import yaml
 
 from llmxive.config import repo_root as _repo_root
 from llmxive.contract_validate import validate
+from llmxive.state._io import (
+    StaleWriteError,
+    atomic_write_text,
+    atomic_write_text_cas,
+    read_mtime_ns,
+)
 from llmxive.types import Project
+
+
+class _Unset:
+    """Sentinel type: ``expected_mtime_ns`` was not supplied (``None`` is a
+    valid token meaning "the file did not exist when read")."""
+
+
+_UNSET = _Unset()
 
 
 def _state_root() -> Path:
@@ -36,34 +50,58 @@ def load(project_id: str, *, repo_root: Path | None = None) -> Project:
     return Project.model_validate(raw)
 
 
-def save(project: Project, *, repo_root: Path | None = None) -> Path:
+def save(
+    project: Project,
+    *,
+    repo_root: Path | None = None,
+    expected_mtime_ns: int | None | _Unset = _UNSET,
+) -> Path:
+    """Persist the canonical project state to ``state/projects/<id>.yaml``.
+
+    The write is ATOMIC (temp file + ``os.replace`` via the shared
+    :func:`llmxive.state._io.atomic_write_text`), so a crash mid-write can
+    never leave a truncated YAML that the next ``load()`` reads as ``{}``.
+
+    ``expected_mtime_ns`` opts into a best-effort compare-and-swap: when the
+    caller passes the file's mtime captured *before* its read-modify-write
+    (as :func:`update` does), the write is rejected with
+    :class:`~llmxive.state._io.StaleWriteError` if another writer landed in
+    between — guarding against two overlapping pipeline ticks silently losing
+    each other's update. The default (unset) keeps the plain atomic write for
+    the many callers that supply a fully-formed ``Project``.
+    """
     payload = project.model_dump(mode="json", exclude_none=False)
     validate("project-state", payload)
     path = _project_state_path(project.id, repo_root=repo_root)
     path.parent.mkdir(parents=True, exist_ok=True)
-    # Audit trail: append every stage transition (with timestamp + last_run_id)
-    # to state/projects/<PROJ-ID>.history.jsonl. This makes manual override
-    # detectable post-hoc — a stage transition without a corresponding
-    # runlog entry from the previous agent is suspicious.
+    # Audit trail: capture the prior stage BEFORE the write so a transition
+    # can be appended to state/projects/<PROJ-ID>.history.jsonl. Appending
+    # only AFTER a successful write keeps the trail free of phantom
+    # transitions when a compare-and-swap write is rejected + retried (see
+    # `update`). This makes manual override detectable post-hoc — a stage
+    # transition without a corresponding runlog entry is suspicious.
     try:
-        prev = load(project.id, repo_root=repo_root)
-        if prev.current_stage != project.current_stage:
-            import json as _json
-            from datetime import datetime as _dt
-            history = path.with_suffix(".history.jsonl")
-            history.parent.mkdir(parents=True, exist_ok=True)
-            entry = {
-                "at": _dt.now(UTC).isoformat(),
-                "from_stage": prev.current_stage.value,
-                "to_stage": project.current_stage.value,
-                "last_run_id": project.last_run_id,
-            }
-            with history.open("a", encoding="utf-8") as fh:
-                fh.write(_json.dumps(entry, sort_keys=True) + "\n")
+        prev: Project | None = load(project.id, repo_root=repo_root)
     except FileNotFoundError:
-        # First save for a new project — no history yet.
-        pass
-    path.write_text(yaml.safe_dump(payload, sort_keys=True), encoding="utf-8")
+        prev = None  # First save for a new project — no history yet.
+    content = yaml.safe_dump(payload, sort_keys=True)
+    if isinstance(expected_mtime_ns, _Unset):
+        atomic_write_text(path, content)
+    else:
+        atomic_write_text_cas(path, content, expected_mtime_ns=expected_mtime_ns)
+    if prev is not None and prev.current_stage != project.current_stage:
+        import json as _json
+        from datetime import datetime as _dt
+        history = path.with_suffix(".history.jsonl")
+        history.parent.mkdir(parents=True, exist_ok=True)
+        entry = {
+            "at": _dt.now(UTC).isoformat(),
+            "from_stage": prev.current_stage.value,
+            "to_stage": project.current_stage.value,
+            "last_run_id": project.last_run_id,
+        }
+        with history.open("a", encoding="utf-8") as fh:
+            fh.write(_json.dumps(entry, sort_keys=True) + "\n")
     return path
 
 
@@ -75,13 +113,33 @@ def update(
     field whose value doesn't satisfy the schema raises.
 
     Used by the spec-013 implementer + publisher to advance stages.
+
+    This is a genuine read-modify-write, so it uses a best-effort
+    compare-and-swap: the file's mtime is captured BEFORE the read, and the
+    save is rejected if another writer landed in between. On such a
+    :class:`~llmxive.state._io.StaleWriteError` the project is re-read and the
+    partial ``fields`` re-applied ONCE onto the newer state, so two
+    overlapping pipeline ticks cannot silently clobber each other's update.
     """
-    proj = load(project_id, repo_root=repo_root)
-    data = proj.model_dump(mode="json")
-    data.update(fields)
-    new_proj = Project.model_validate(data)
-    save(new_proj, repo_root=repo_root)
-    return new_proj
+    path = _project_state_path(project_id, repo_root=repo_root)
+    last_error: StaleWriteError | None = None
+    for _attempt in range(2):
+        # Capture mtime BEFORE the read: if a concurrent writer lands between
+        # here and the save, the token is stale and the CAS write is rejected
+        # (never the reverse ordering, which could pass CAS on stale content).
+        mtime = read_mtime_ns(path)
+        proj = load(project_id, repo_root=repo_root)
+        data = proj.model_dump(mode="json")
+        data.update(fields)
+        new_proj = Project.model_validate(data)
+        try:
+            save(new_proj, repo_root=repo_root, expected_mtime_ns=mtime)
+        except StaleWriteError as exc:
+            last_error = exc
+            continue
+        return new_proj
+    assert last_error is not None
+    raise last_error
 
 
 def list_all(*, repo_root: Path | None = None) -> list[Project]:

--- a/src/llmxive/state/publication.py
+++ b/src/llmxive/state/publication.py
@@ -12,12 +12,11 @@ Contract: specs/013-paper-revision-implementer/contracts/publication-yaml.md
 from __future__ import annotations
 
 import json
-import os
-import tempfile
 from pathlib import Path
 
 import yaml
 
+from llmxive.state._io import atomic_write_text
 from llmxive.types import DOIVersion, Publication
 
 _MIRROR_FIELDS = ("doi", "doi_url", "zenodo_id", "volume", "issue", "doi_versions")
@@ -29,18 +28,6 @@ def _yaml_path(project_id: str, *, repo_root: Path) -> Path:
 
 def _metadata_path(project_id: str, *, repo_root: Path) -> Path:
     return repo_root / "projects" / project_id / "paper" / "metadata.json"
-
-
-def _atomic_write(path: Path, content: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(content)
-        os.replace(tmp, path)
-    except Exception:
-        Path(tmp).unlink(missing_ok=True)
-        raise
 
 
 def load(project_id: str, *, repo_root: Path) -> Publication | None:
@@ -63,7 +50,7 @@ def save(
         raise ValueError(
             f"pub.project_id={pub.project_id!r} != project_id={project_id!r}"
         )
-    _atomic_write(
+    atomic_write_text(
         _yaml_path(project_id, repo_root=repo_root),
         yaml.safe_dump(pub.model_dump(mode="json"), sort_keys=False),
     )
@@ -116,4 +103,4 @@ def _mirror_to_metadata_json(
     data["volume"] = pub.volume
     data["issue"] = pub.issue
     data["doi_versions"] = [v.model_dump(mode="json") for v in pub.doi_versions]
-    _atomic_write(p, json.dumps(data, indent=2, sort_keys=False) + "\n")
+    atomic_write_text(p, json.dumps(data, indent=2, sort_keys=False) + "\n")

--- a/src/llmxive/state/results.py
+++ b/src/llmxive/state/results.py
@@ -15,6 +15,7 @@ import yaml
 
 from llmxive.config import repo_root as _repo_root
 from llmxive.results.receipt import Receipt
+from llmxive.state._io import atomic_write_text
 
 
 def _state_root() -> Path:
@@ -73,9 +74,8 @@ def save(project_id: str, receipt: Receipt,
          *, repo_root: Path | None = None) -> Path:
     """Persist a receipt to state/results/<PROJECT-ID>/<result_id>.yaml."""
     path = _receipt_path(project_id, receipt.result_id, repo_root=repo_root)
-    path.parent.mkdir(parents=True, exist_ok=True)
     payload = _receipt_to_dict(receipt)
-    path.write_text(yaml.safe_dump(payload, sort_keys=True), encoding="utf-8")
+    atomic_write_text(path, yaml.safe_dump(payload, sort_keys=True))
     return path
 
 

--- a/src/llmxive/state/reviews.py
+++ b/src/llmxive/state/reviews.py
@@ -22,6 +22,7 @@ import yaml
 
 from llmxive.config import repo_root as _repo_root
 from llmxive.contract_validate import validate
+from llmxive.state._io import atomic_write_text
 from llmxive.types import ReviewRecord
 
 _FRONTMATTER_RE: re.Pattern[str] = re.compile(
@@ -75,9 +76,8 @@ def write(
         review_type=review_type,
         repo_root=repo_root,
     )
-    path.parent.mkdir(parents=True, exist_ok=True)
     frontmatter = yaml.safe_dump(payload, sort_keys=True).rstrip("\n")
-    path.write_text(f"---\n{frontmatter}\n---\n\n{body.strip()}\n", encoding="utf-8")
+    atomic_write_text(path, f"---\n{frontmatter}\n---\n\n{body.strip()}\n")
     return path
 
 

--- a/src/llmxive/state/revision_history.py
+++ b/src/llmxive/state/revision_history.py
@@ -17,12 +17,11 @@ Contracts:
 
 from __future__ import annotations
 
-import os
-import tempfile
 from pathlib import Path
 
 import yaml
 
+from llmxive.state._io import atomic_write_text
 from llmxive.types import ImplementerLog, RevisionHistory, RevisionRound
 
 
@@ -35,20 +34,6 @@ def _round_path(project_id: str, round_number: int, *, repo_root: Path) -> Path:
         repo_root / "specs" / "auto-revisions" / project_id
         / f"round-{round_number}" / "implementer-log.yaml"
     )
-
-
-def _atomic_write(path: Path, content: str) -> None:
-    """Write `content` to `path` atomically (tmpfile + rename) so a
-    crash mid-write doesn't leave a half-written YAML behind."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(content)
-        os.replace(tmp, path)
-    except Exception:
-        Path(tmp).unlink(missing_ok=True)
-        raise
 
 
 def load(project_id: str, *, repo_root: Path) -> RevisionHistory:
@@ -73,7 +58,7 @@ def append_round(
         raise ValueError(f"round {round.round_number} already recorded")
     hist.rounds.append(round)
     hist.rounds.sort(key=lambda r: r.round_number)
-    _atomic_write(
+    atomic_write_text(
         _hist_path(project_id, repo_root=repo_root),
         yaml.safe_dump(hist.model_dump(mode="json"), sort_keys=False),
     )
@@ -117,7 +102,7 @@ def save_round(
         raise ValueError(
             f"log.project_id={log.project_id!r} != project_id={project_id!r}"
         )
-    _atomic_write(
+    atomic_write_text(
         _round_path(project_id, round_number, repo_root=repo_root),
         yaml.safe_dump(log.model_dump(mode="json"), sort_keys=False),
     )

--- a/src/llmxive/state/runlog.py
+++ b/src/llmxive/state/runlog.py
@@ -17,6 +17,7 @@ from pydantic import ValidationError as PydanticValidationError
 
 from llmxive.config import repo_root as _repo_root
 from llmxive.contract_validate import validate
+from llmxive.state._io import atomic_write_text
 from llmxive.types import Outcome, RunLogEntry
 
 
@@ -83,12 +84,17 @@ def append_entry(entry: RunLogEntry, *, repo_root: Path | None = None) -> Path:
         validate("run-log-entry", payload)
     except ValidationError:
         invalid_dir = log_dir / ".invalid"
-        invalid_dir.mkdir(exist_ok=True)
-        (invalid_dir / f"{entry.entry_id}.json").write_text(
-            json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8"
+        # Full-file dump of the parked invalid entry — write atomically so a
+        # crash mid-dump can't leave a truncated postmortem artifact.
+        atomic_write_text(
+            invalid_dir / f"{entry.entry_id}.json",
+            json.dumps(payload, indent=2, sort_keys=True),
         )
         raise
 
+    # The run-log itself is append-only (one JSONL line per invocation); an
+    # append cannot be made atomic the way a full-file rewrite can, so it is
+    # left as a bare append (POSIX single-write append is the tolerable case).
     with log_file.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(payload, sort_keys=True) + "\n")
     return log_file

--- a/src/llmxive/state/unverifiable.py
+++ b/src/llmxive/state/unverifiable.py
@@ -1,0 +1,137 @@
+"""Per-project registry of REPEATEDLY-UNVERIFIABLE tasks (issue #1139, defect D6).
+
+The independent task-verifier used to FORCE-ACCEPT a task after ``REJECT_CAP``
+consecutive INCOMPLETE verdicts — flipping genuinely-undone work to ``[X]`` so a
+project could escape an unbreakable redo loop. That is a fail-open: incomplete
+work counted as done. This store replaces that escape hatch. When a task hits
+``REJECT_CAP`` consecutive INCOMPLETE verdicts it is REOPENED (``[ ]``, never
+``[X]``) and recorded HERE, and the verifier stops re-judging it (which is what
+actually breaks the loop — the task is not lied about, it is escalated).
+
+CROSS-CLUSTER CONTRACT (consumed by the pipeline graph / kickback router):
+  * File:   ``state/unverifiable_tasks/<project_id>.json``
+  * Schema: ``{"project_id": str,
+              "tasks": [{"task_key": str, "reject_count": int,
+                         "last_reason": str, "first_seen": iso8601,
+                         "last_seen": iso8601}],
+              "updated_at": iso8601}``
+  * The CORE pipeline routes a project to ``research_full_revision`` when
+    :func:`has_unverifiable` is true (a task the implementer cannot make pass
+    needs a re-plan, not another redo lap), and calls :func:`clear` once the
+    project has been kicked back so the next cycle starts clean.
+
+All writes go through :func:`llmxive.state._io.atomic_write_text` (Constitution I:
+one shared atomic writer — a crash mid-write never truncates the JSON).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from llmxive.config import repo_root as _repo_root
+from llmxive.state._io import atomic_write_text
+
+
+def _dir(repo_root: Path | None) -> Path:
+    root = repo_root or _repo_root()
+    return root / "state" / "unverifiable_tasks"
+
+
+def _path(project_id: str, *, repo_root: Path | None = None) -> Path:
+    return _dir(repo_root) / f"{project_id}.json"
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def load(project_id: str, *, repo_root: Path | None = None) -> list[dict[str, Any]]:
+    """Return the recorded unverifiable-task entries for ``project_id`` (``[]`` if
+    none). Each entry is a dict with the contract keys documented above."""
+    p = _path(project_id, repo_root=repo_root)
+    if not p.is_file():
+        return []
+    try:
+        rec = json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return []
+    tasks = rec.get("tasks") if isinstance(rec, dict) else None
+    return [t for t in tasks if isinstance(t, dict)] if isinstance(tasks, list) else []
+
+
+def recorded_keys(project_id: str, *, repo_root: Path | None = None) -> set[str]:
+    """The set of ``task_key``s already flagged unverifiable — the verifier skips
+    these (they are not re-judged until :func:`clear` is called)."""
+    return {
+        str(t["task_key"])
+        for t in load(project_id, repo_root=repo_root)
+        if isinstance(t, dict) and t.get("task_key")
+    }
+
+
+def has_unverifiable(project_id: str, *, repo_root: Path | None = None) -> bool:
+    """True iff ``project_id`` has ANY recorded unverifiable task — the signal CORE
+    uses to route the project to ``research_full_revision``."""
+    return bool(load(project_id, repo_root=repo_root))
+
+
+def record_unverifiable(
+    project_id: str,
+    task_key: str,
+    reason: str,
+    *,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    """Record (or bump) ``task_key`` as repeatedly-unverifiable for ``project_id``.
+
+    A new task_key starts at ``reject_count=1``; a repeat call increments it and
+    refreshes ``last_reason`` / ``last_seen`` (``first_seen`` is preserved). In
+    normal operation the verifier records each key ONCE (it stops re-judging a
+    recorded task), so ``reject_count`` counts the number of times the task has
+    re-entered the unverifiable state across kickback cycles. Returns the written
+    record."""
+    tasks = load(project_id, repo_root=repo_root)
+    now = _now()
+    by_key = {t.get("task_key"): t for t in tasks}
+    entry = by_key.get(task_key)
+    if entry is None:
+        tasks.append(
+            {
+                "task_key": task_key,
+                "reject_count": 1,
+                "last_reason": (reason or "").strip()[:600],
+                "first_seen": now,
+                "last_seen": now,
+            }
+        )
+    else:
+        entry["reject_count"] = int(entry.get("reject_count", 0)) + 1
+        entry["last_reason"] = (reason or "").strip()[:600]
+        entry["last_seen"] = now
+        entry.setdefault("first_seen", now)
+    rec = {"project_id": project_id, "tasks": tasks, "updated_at": now}
+    atomic_write_text(
+        _path(project_id, repo_root=repo_root),
+        json.dumps(rec, indent=2, sort_keys=False) + "\n",
+    )
+    return rec
+
+
+def clear(project_id: str, *, repo_root: Path | None = None) -> None:
+    """Drop ALL unverifiable records for ``project_id`` (the whole file).
+
+    CORE calls this after routing the project to ``research_full_revision`` so the
+    re-planned cycle starts with a clean slate."""
+    _path(project_id, repo_root=repo_root).unlink(missing_ok=True)
+
+
+__all__ = [
+    "clear",
+    "has_unverifiable",
+    "load",
+    "record_unverifiable",
+    "recorded_keys",
+]

--- a/tests/integration/test_dataset_resolver.py
+++ b/tests/integration/test_dataset_resolver.py
@@ -169,25 +169,37 @@ def test_resolve_datasets_candidates_tried_granularity(file_server, monkeypatch)
     assert result.datasets[0].candidates[0]["url"].endswith("good.csv")
 
 
-def test_write_manifest_roundtrip(tmp_path):
-    import yaml
+def test_resolve_datasets_is_a_candidate_proposer_no_dead_manifest(file_server, monkeypatch):
+    """D7: ``resolve_datasets`` is a candidate PROPOSER only — it returns a
+    ``ResolvedDatasets`` for in-process consumption (``render_planner_block``) and
+    must NOT persist the dead write-only ``resolved_datasets.yaml`` manifest.
 
-    from llmxive.librarian.dataset_resolver import (
-        ResolvedDatasets,
-        ResolvedIntent,
-        write_manifest,
+    Guards against re-introducing ``write_manifest`` (removed) or any resolver-side
+    manifest write.
+    """
+    import llmxive.librarian.dataset_resolver as dr
+    from llmxive.librarian.dataset_sources import DatasetCandidate
+
+    # ``write_manifest`` is gone entirely.
+    assert not hasattr(dr, "write_manifest")
+
+    root, base = file_server
+    (root / "good.csv").write_text("a,b\n1,2\n3,4\n")
+    monkeypatch.setattr(
+        dr, "_gather_candidates",
+        lambda intent: [DatasetCandidate("DS", f"{base}/good.csv", "good", "huggingface")],
     )
-    rd = ResolvedDatasets(datasets=[
-        ResolvedIntent("QM9", "verified",
-                       candidates=[{"url": "https://x/y", "source": "huggingface",
-                                    "format": "parquet", "relevance": 0.9,
-                                    "sample_check": {"downloaded_bytes": 10, "parsed": True}}],
-                       candidates_tried=[]),
-    ])
-    path = write_manifest(rd, project_dir=tmp_path)
-    doc = yaml.safe_load(path.read_text())
-    assert doc["datasets"][0]["intent"] == "QM9"
-    assert doc["datasets"][0]["candidates"][0]["url"] == "https://x/y"
+    monkeypatch.setattr(dr, "extract_dataset_intents", lambda spec: ["DS"])
+
+    proj = root / "projects" / "PROJ-X"
+    proj.mkdir(parents=True)
+    rd = dr.resolve_datasets("the DS dataset", project_dir=proj, repo_root=root, top_n=3)
+
+    # The return value still drives the planner block (candidate proposer)...
+    assert rd.datasets[0].status == "verified"
+    assert dr.render_planner_block(rd)
+    # ... but NO dead manifest was written to disk.
+    assert not (proj / ".specify" / "memory" / "resolved_datasets.yaml").exists()
 
 
 def test_unresolved_intents_lists(tmp_path):

--- a/tests/integration/test_drain_under_review.py
+++ b/tests/integration/test_drain_under_review.py
@@ -1,0 +1,134 @@
+"""Drain the stranded ``[~]`` backlog (issue #1139, defect D6).
+
+Exercises both the LLM-FREE reclassification core (:func:`task_verifier.drain_under_review`)
+over a REAL mixed tasks.md and the maintenance script's end-to-end ``main`` against a
+synthetic repo — no mocks; only real files.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from llmxive.agents import task_verifier as tv
+from llmxive.state import project as project_store
+from llmxive.state import unverifiable
+from llmxive.types import Project, Stage
+
+_MIXED = """\
+# Tasks
+
+- [~] T001 implement code/present.py
+- [~] T002 create results/missing.json
+- [~] T003 investigate the tradeoffs of the approach
+- [~] T004 generate data/empty.csv with rows
+- [X] T005 prior done in code/done.py
+- [ ] T006 not started yet
+"""
+
+
+def _seed_project(tmp_path: Path, pid: str = "PROJ-401-drain") -> tuple[Path, Path]:
+    """Create projects/<pid>/specs/001-x/tasks.md with the mixed marks + the
+    referenced artifact files. Returns (project_dir, tasks_path)."""
+    project_dir = tmp_path / "projects" / pid
+    fdir = project_dir / "specs" / "001-x"
+    (project_dir / "code").mkdir(parents=True, exist_ok=True)
+    (project_dir / "code" / "present.py").write_text("X = 1\n", encoding="utf-8")
+    (project_dir / "code" / "done.py").write_text("Y = 2\n", encoding="utf-8")
+    fdir.mkdir(parents=True, exist_ok=True)
+    tasks = fdir / "tasks.md"
+    tasks.write_text(_MIXED, encoding="utf-8")
+    return project_dir, tasks
+
+
+def test_drain_reclassifies_mixed_marks(tmp_path: Path) -> None:
+    project_dir, tasks = _seed_project(tmp_path)
+
+    res = tv.drain_under_review(project_dir, tasks, apply=True)
+
+    text = tasks.read_text(encoding="utf-8")
+    # T001: artifact present → accepted [X]; T005 stays [X].
+    assert "- [X] T001" in text and "- [X] T005" in text
+    # T002 & T004: production task, artifact missing → reopened [ ]; T006 stays [ ].
+    assert "- [ ] T002" in text and "- [ ] T004" in text and "- [ ] T006" in text
+    # T003: ambiguous (no artifact path) → LEFT [~] for the semantic verifier.
+    assert "- [~] T003" in text
+    assert res["accepted"] == 1
+    assert res["reopened"] == 2
+    assert res["ambiguous"] == 1
+    assert res["before"]["~"] == 4 and res["after"]["~"] == 1
+
+
+def test_drain_dry_run_writes_nothing(tmp_path: Path) -> None:
+    project_dir, tasks = _seed_project(tmp_path)
+    original = tasks.read_text(encoding="utf-8")
+
+    res = tv.drain_under_review(project_dir, tasks, apply=False)
+
+    # The projected counts are computed, but the file on disk is UNCHANGED.
+    assert tasks.read_text(encoding="utf-8") == original
+    assert res["after"]["~"] == 1 and res["before"]["~"] == 4  # projection only
+
+
+def test_drain_records_unverifiable_at_reject_cap(tmp_path: Path) -> None:
+    """A ``[~]`` production task whose artifact is missing AND whose stored
+    reject_count already reached REJECT_CAP is recorded UNVERIFIABLE (never accepted)."""
+    project_dir, tasks = _seed_project(tmp_path)
+    # Seed the reject-count state so T002 has already hit the cap.
+    import yaml
+    state = project_dir / ".specify" / "memory" / "task_verify.yaml"
+    state.parent.mkdir(parents=True, exist_ok=True)
+    state.write_text(yaml.safe_dump({"T002": tv.REJECT_CAP}), encoding="utf-8")
+
+    res = tv.drain_under_review(project_dir, tasks, apply=True)
+
+    assert "T002" in res["unverifiable"]
+    recorded = unverifiable.load("PROJ-401-drain", repo_root=tmp_path)
+    assert [t["task_key"] for t in recorded] == ["T002"], recorded
+    # T004 hit the same missing-artifact reopen but had NO cap count → NOT recorded.
+    assert "- [ ] T004" in tasks.read_text(encoding="utf-8")
+
+
+def test_drain_reopens_already_unverifiable_task(tmp_path: Path) -> None:
+    project_dir, tasks = _seed_project(tmp_path)
+    # T001's artifact exists (would normally accept) but it is already flagged
+    # unverifiable → it must be reopened [ ], NOT accepted.
+    unverifiable.record_unverifiable(
+        "PROJ-401-drain", "T001", "prior failure", repo_root=tmp_path
+    )
+
+    tv.drain_under_review(project_dir, tasks, apply=True)
+
+    text = tasks.read_text(encoding="utf-8")
+    assert "- [ ] T001" in text and "- [X] T001" not in text
+
+
+def test_script_main_end_to_end(tmp_path: Path, capsys) -> None:
+    """The maintenance script enumerates in_progress projects and drains their
+    ``[~]`` tasks: dry-run leaves tasks.md untouched, ``--apply`` reclassifies."""
+    from scripts.maintenance import drain_under_review as script
+
+    pid = "PROJ-402-cli"
+    _project_dir, tasks = _seed_project(tmp_path, pid)
+    now = datetime.now(UTC)
+    project = Project(
+        id=pid, title="X", field="computer science",
+        current_stage=Stage.IN_PROGRESS, created_at=now, updated_at=now,
+        speckit_research_dir="specs/001-x",
+    )
+    project_store.save(project, repo_root=tmp_path)
+
+    original = tasks.read_text(encoding="utf-8")
+
+    # Dry-run: prints a table, writes nothing.
+    rc = script.main(["--repo-root", str(tmp_path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "DRY-RUN" in out and pid in out
+    assert tasks.read_text(encoding="utf-8") == original
+
+    # Apply: reclassifies the [~] tasks.
+    rc = script.main(["--repo-root", str(tmp_path), "--apply"])
+    assert rc == 0
+    text = tasks.read_text(encoding="utf-8")
+    assert "- [X] T001" in text and "- [ ] T002" in text and "- [~] T003" in text

--- a/tests/integration/test_production_flags_active.py
+++ b/tests/integration/test_production_flags_active.py
@@ -1,0 +1,339 @@
+"""Offline integration test: the SHIPPED production run-time feature-flag combo.
+
+``llmxive.cli._cmd_run`` turns on three feature flags in production via
+``os.environ.setdefault`` (``cli.py`` ~L75/L81/L89)::
+
+    LLMXIVE_GROUNDING_GUARD=1   # F-19 factual-grounding guard (LLM + real HTTP)
+    LLMXIVE_CLAIM_LAYER=1       # spec 016 claim-verification layer
+    LLMXIVE_CLAIM_FILL=1        # spec 017/018 authoritative-fill + mode routing
+
+Every consumer defaults those flags OFF, and ``tests/conftest.py``'s autouse
+``_isolate_run_side_effect_flags`` fixture *snapshots and restores* the three
+keys around each offline test (so an in-process ``_cmd_run`` call cannot leak
+them into a network-free reviser suite that asserts exact backend call counts).
+The side effect: the FLAG-ON production combination was exercised ONLY under
+``LLMXIVE_REAL_TESTS=1`` (the ``tests/real_call`` + ``slow`` suites) — never by
+the fast per-PR ``-m "not slow"`` gate. So the shipped runtime config's
+flag-gated branches were never asserted by the offline gate (issue #1139, D17).
+
+This module closes that gap. Each test EXPLICITLY opts in to the relevant flag
+with ``monkeypatch.setenv`` — which wins for the duration of the test body,
+regardless of the autouse restore that runs at teardown — then drives the REAL
+flag-gated consumer branch, stubbing ONLY the network/LLM boundary that branch
+reaches (the claim-processing service, the grounding pass, ``fill_claim``, the
+mode selector). Each positive case asserts the guarded branch was ENTERED and
+behaved (the stub really ran + the branch's own logic mutated the output); each
+negative control proves the flag genuinely gates the branch (boundary NOT called
++ output untouched). Nothing here touches the real network.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llmxive.agents.citation_guard import GuardReport
+from llmxive.claims import resolve as resolve_mod
+from llmxive.claims.models import Claim, ClaimKind, ClaimStatus, Verdict
+from llmxive.claims.pointer import GateReport
+from llmxive.convergence.revisers import _self_consistency as sc
+from llmxive.fill.models import FillProvenance, FillResult
+
+_ARTIFACT_PATH = "projects/PROJ-001-demo/specs/spec.md"
+_PROJECT_ID = "PROJ-001-demo"  # what _extract_project_id pulls from the path
+
+
+def _numeric_claim(*, kind: ClaimKind = ClaimKind.NUMERIC) -> Claim:
+    """A minimal, valid non-RESULT claim for the resolver-path tests."""
+    return Claim(
+        claim_id="c_test",
+        kind=kind,
+        raw_text="9987 knots",
+        canonical="9987 knots",
+        context="the smallest example has 9987 knots",
+        artifact_path=_ARTIFACT_PATH,
+        source_type="external",
+        status=ClaimStatus.NOT_ENOUGH_INFO,
+        resolved_value=None,
+        evidence=None,
+        resolver=None,
+        attempts=1,
+        updated_at="2026-07-15T00:00:00Z",
+    )
+
+
+# ---------------------------------------------------------------------------
+# LLMXIVE_CLAIM_LAYER — _self_consistency._verify_claims (cli.py L81; branch L336)
+# Boundary stubbed: llmxive.claims.service.process_document (LLM extract + HTTP resolve)
+# ---------------------------------------------------------------------------
+
+def test_claim_layer_branch_runs_when_flag_on(monkeypatch, tmp_path):
+    monkeypatch.setenv("LLMXIVE_CLAIM_LAYER", "1")
+
+    calls: list[tuple[str, str]] = []
+
+    def fake_process_document(text, *, artifact_path, project_id, backend,
+                              model, repo_root, stage_label=None):
+        calls.append((artifact_path, project_id))
+        return ("VERIFIED " + text, [], GateReport(blocked=False))
+
+    monkeypatch.setattr(
+        "llmxive.claims.service.process_document", fake_process_document
+    )
+
+    artifacts = {_ARTIFACT_PATH: "the answer is 42"}
+    out = sc._verify_claims(artifacts, backend=object(), model="m", repo_root=tmp_path)
+
+    # Branch ENTERED (flag on + backend present): the service really ran, on the
+    # right path/project (real _extract_project_id + per-artifact loop executed).
+    assert calls == [(_ARTIFACT_PATH, _PROJECT_ID)]
+    # Real merge logic ran: the rewritten body replaced the original.
+    assert out[_ARTIFACT_PATH] == "VERIFIED the answer is 42"
+
+
+def test_claim_layer_branch_skipped_when_flag_off(monkeypatch, tmp_path):
+    monkeypatch.delenv("LLMXIVE_CLAIM_LAYER", raising=False)
+
+    def boom(*a, **k):  # pragma: no cover - must never be reached
+        raise AssertionError("process_document called with LLMXIVE_CLAIM_LAYER off")
+
+    monkeypatch.setattr("llmxive.claims.service.process_document", boom)
+
+    artifacts = {_ARTIFACT_PATH: "the answer is 42"}
+    out = sc._verify_claims(artifacts, backend=object(), model="m", repo_root=tmp_path)
+
+    assert out == artifacts  # flag gates the branch: body untouched, no call
+
+
+# ---------------------------------------------------------------------------
+# LLMXIVE_GROUNDING_GUARD — _self_consistency._ground_factual_claims
+# (cli.py L75; branch L410). Boundary: grounding_guard.verify_grounding_and_clean
+# ---------------------------------------------------------------------------
+
+def test_grounding_guard_branch_runs_when_flag_on(monkeypatch, tmp_path):
+    monkeypatch.setenv("LLMXIVE_GROUNDING_GUARD", "1")
+
+    calls: list[str] = []
+
+    def fake_verify(text, *, backend, model, repo_root):
+        calls.append(text)
+        return ("[UNVERIFIED] " + text, GuardReport(flagged_count=1, flagged_values=["42"]))
+
+    monkeypatch.setattr(
+        "llmxive.agents.grounding_guard.verify_grounding_and_clean", fake_verify
+    )
+
+    artifacts = {_ARTIFACT_PATH: "42 knots per Smith 2004"}
+    out = sc._ground_factual_claims(artifacts, backend=object(), model="m", repo_root=tmp_path)
+
+    # Branch ENTERED: the grounding pass really ran on the real artifact body.
+    assert calls == ["42 knots per Smith 2004"]
+    # Real flagged-count logic ran: the flagged rewrite replaced the body.
+    assert out[_ARTIFACT_PATH] == "[UNVERIFIED] 42 knots per Smith 2004"
+
+
+def test_grounding_guard_branch_skipped_when_flag_off(monkeypatch, tmp_path):
+    monkeypatch.delenv("LLMXIVE_GROUNDING_GUARD", raising=False)
+
+    def boom(*a, **k):  # pragma: no cover - must never be reached
+        raise AssertionError("verify_grounding_and_clean called with guard flag off")
+
+    monkeypatch.setattr(
+        "llmxive.agents.grounding_guard.verify_grounding_and_clean", boom
+    )
+
+    artifacts = {_ARTIFACT_PATH: "42 knots per Smith 2004"}
+    out = sc._ground_factual_claims(artifacts, backend=object(), model="m", repo_root=tmp_path)
+
+    assert out == artifacts  # flag gates the branch: body untouched, no call
+
+
+# ---------------------------------------------------------------------------
+# LLMXIVE_CLAIM_FILL — claims.resolve._maybe_fill (cli.py L89; branch L164)
+# Boundary stubbed: llmxive.fill.service.fill_claim (OEIS/Wikipedia/Wikidata fetch)
+# ---------------------------------------------------------------------------
+
+def _filled_result() -> FillResult:
+    prov = FillProvenance(
+        value="9988",
+        source_id="A002863",
+        url="https://oeis.org/A002863",
+        quote="13 9988",
+        channel="oeis",
+        conflicts=[],
+    )
+    return FillResult.filled("9988", prov, ["oeis"])
+
+
+def test_claim_fill_branch_upgrades_verdict_when_flag_on(monkeypatch, tmp_path):
+    monkeypatch.setenv("LLMXIVE_CLAIM_FILL", "1")
+
+    calls: list[str] = []
+
+    def fake_fill_claim(claim, *, backend, model, repo_root):
+        calls.append(claim.claim_id)
+        return _filled_result()
+
+    monkeypatch.setattr("llmxive.fill.service.fill_claim", fake_fill_claim)
+
+    claim = _numeric_claim()
+    original = Verdict(status=ClaimStatus.NOT_ENOUGH_INFO, value=None,
+                       evidence=None, resolver="resolve_numeric_or_citation")
+    out = resolve_mod._maybe_fill(claim, original, backend=object(),
+                                  model="m", repo_root=tmp_path)
+
+    # Branch ENTERED: fill_claim really ran, and the real upgrade logic converted
+    # a NOT_ENOUGH_INFO verdict into a VERIFIED one carrying fill provenance.
+    assert calls == ["c_test"]
+    assert out.status == ClaimStatus.VERIFIED
+    assert out.value == "9988"
+    assert out.resolver == "fill:oeis"
+    assert out.evidence["filled"] is True
+    assert out.evidence["fill"]["source_id"] == "A002863"
+
+
+def test_claim_fill_branch_skipped_when_flag_off(monkeypatch, tmp_path):
+    monkeypatch.delenv("LLMXIVE_CLAIM_FILL", raising=False)
+
+    def boom(*a, **k):  # pragma: no cover - must never be reached
+        raise AssertionError("fill_claim called with LLMXIVE_CLAIM_FILL off")
+
+    monkeypatch.setattr("llmxive.fill.service.fill_claim", boom)
+
+    claim = _numeric_claim()
+    original = Verdict(status=ClaimStatus.NOT_ENOUGH_INFO, value=None,
+                       evidence=None, resolver="resolve_numeric_or_citation")
+    out = resolve_mod._maybe_fill(claim, original, backend=object(),
+                                  model="m", repo_root=tmp_path)
+
+    assert out is original  # flag gates the branch: verdict unchanged, no call
+
+
+def test_claim_fill_never_fills_result_claims_even_when_flag_on(monkeypatch, tmp_path):
+    # spec 017 T019 constraint: RESULT claims are never filled. Even with the
+    # flag ON the branch is entered but the RESULT guard short-circuits BEFORE
+    # the fill_claim boundary — real flag-gated logic, still no network.
+    monkeypatch.setenv("LLMXIVE_CLAIM_FILL", "1")
+
+    def boom(*a, **k):  # pragma: no cover - must never be reached
+        raise AssertionError("fill_claim called for a RESULT claim")
+
+    monkeypatch.setattr("llmxive.fill.service.fill_claim", boom)
+
+    claim = _numeric_claim(kind=ClaimKind.RESULT)
+    original = Verdict(status=ClaimStatus.NOT_ENOUGH_INFO, value=None,
+                       evidence=None, resolver="resolve_result")
+    out = resolve_mod._maybe_fill(claim, original, backend=object(),
+                                  model="m", repo_root=tmp_path)
+
+    assert out is original
+
+
+# ---------------------------------------------------------------------------
+# LLMXIVE_CLAIM_FILL — mode routing in claims.resolve.resolve (branch L644)
+# Boundary stubbed: llmxive.verify.mode.select_mode (LLM mode classifier)
+# ---------------------------------------------------------------------------
+
+def test_resolve_mode_routing_runs_when_fill_flag_on(monkeypatch, tmp_path):
+    monkeypatch.setenv("LLMXIVE_CLAIM_FILL", "1")
+
+    sentinel = Verdict(status=ClaimStatus.VERIFIED, value="7",
+                       evidence={"mode": "computational"}, resolver="compute")
+    mode_calls: list[str] = []
+    comp_calls: list[str] = []
+
+    def fake_select_mode(claim, *, backend=None, model=None, repo_root=None):
+        mode_calls.append(claim.claim_id)
+        return "computational"
+
+    def fake_resolve_computational(claim, *, backend, model, repo_root):
+        comp_calls.append(claim.claim_id)
+        return sentinel
+
+    monkeypatch.setattr("llmxive.verify.mode.select_mode", fake_select_mode)
+    monkeypatch.setattr(
+        "llmxive.claims.resolve._resolve_computational", fake_resolve_computational
+    )
+
+    out = resolve_mod.resolve(_numeric_claim(), backend=object(),
+                              model="m", repo_root=tmp_path)
+
+    # Branch ENTERED: the fill-gated mode routing ran (select_mode consulted,
+    # computational resolver dispatched) and its verdict was returned as-is.
+    assert mode_calls == ["c_test"]
+    assert comp_calls == ["c_test"]
+    assert out is sentinel
+
+
+def test_resolve_mode_routing_skipped_when_fill_flag_off(monkeypatch, tmp_path):
+    monkeypatch.delenv("LLMXIVE_CLAIM_FILL", raising=False)
+
+    def boom_select_mode(*a, **k):  # pragma: no cover - must never be reached
+        raise AssertionError("select_mode called with LLMXIVE_CLAIM_FILL off")
+
+    fallback = Verdict(status=ClaimStatus.NOT_ENOUGH_INFO, value=None,
+                       evidence=None, resolver="stub_resolver")
+
+    monkeypatch.setattr("llmxive.verify.mode.select_mode", boom_select_mode)
+    # Stub the normal kind-dispatch so the off-path stays network-free.
+    monkeypatch.setattr(
+        "llmxive.claims.resolve.select_resolver",
+        lambda kind: (lambda claim, *, backend, model, repo_root: fallback),
+    )
+
+    out = resolve_mod.resolve(_numeric_claim(), backend=object(),
+                              model="m", repo_root=tmp_path)
+
+    assert out is fallback  # flag gates mode routing: fell straight to dispatch
+
+
+# ---------------------------------------------------------------------------
+# Capstone: the exact three-flag production combination active together.
+# ---------------------------------------------------------------------------
+
+def test_all_three_production_flags_active_together(monkeypatch, tmp_path):
+    """Mirror cli._cmd_run: all three flags ON at once, every guarded branch runs."""
+    monkeypatch.setenv("LLMXIVE_GROUNDING_GUARD", "1")
+    monkeypatch.setenv("LLMXIVE_CLAIM_LAYER", "1")
+    monkeypatch.setenv("LLMXIVE_CLAIM_FILL", "1")
+
+    entered: set[str] = set()
+
+    def fake_process_document(text, *, artifact_path, project_id, backend,
+                              model, repo_root, stage_label=None):
+        entered.add("claim_layer")
+        return ("VERIFIED " + text, [], GateReport(blocked=False))
+
+    def fake_verify(text, *, backend, model, repo_root):
+        entered.add("grounding_guard")
+        return ("[UNVERIFIED] " + text, GuardReport(flagged_count=1, flagged_values=["x"]))
+
+    def fake_fill_claim(claim, *, backend, model, repo_root):
+        entered.add("claim_fill")
+        return _filled_result()
+
+    monkeypatch.setattr("llmxive.claims.service.process_document", fake_process_document)
+    monkeypatch.setattr(
+        "llmxive.agents.grounding_guard.verify_grounding_and_clean", fake_verify
+    )
+    monkeypatch.setattr("llmxive.fill.service.fill_claim", fake_fill_claim)
+
+    artifacts = {_ARTIFACT_PATH: "the answer is 42"}
+    assert sc._verify_claims(
+        artifacts, backend=object(), model="m", repo_root=tmp_path
+    )[_ARTIFACT_PATH] == "VERIFIED the answer is 42"
+    assert sc._ground_factual_claims(
+        artifacts, backend=object(), model="m", repo_root=tmp_path
+    )[_ARTIFACT_PATH] == "[UNVERIFIED] the answer is 42"
+
+    original = Verdict(status=ClaimStatus.NOT_ENOUGH_INFO, value=None,
+                       evidence=None, resolver="resolve_numeric_or_citation")
+    filled = resolve_mod._maybe_fill(_numeric_claim(), original, backend=object(),
+                                     model="m", repo_root=tmp_path)
+    assert filled.status == ClaimStatus.VERIFIED
+
+    # All three shipped flag-gated branches were exercised in one offline test.
+    assert entered == {"claim_layer", "grounding_guard", "claim_fill"}
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/unit/test_advance_error_recording.py
+++ b/tests/unit/test_advance_error_recording.py
@@ -47,9 +47,14 @@ def test_record_advance_error_writes_and_increments(tmp_path, monkeypatch) -> No
     cli._record_advance_error(p, RuntimeError("dead reference: HTTP 404"))
     rec = json.loads((tmp_path / "state" / "advance_errors" / "PROJ-901-x.json")
                      .read_text(encoding="utf-8"))
-    assert rec["count"] == 2  # recurring failure is counted, not dismissed
+    # INVARIANT (issue #1139): a recurring failure is COUNTED, not dismissed. The
+    # schema is now typed (consecutive_count instead of a bare count) and carries a
+    # control disposition the scheduler honours.
+    assert rec["consecutive_count"] == 2
     assert "404" in rec["last_error"]
     assert rec["stage"] == "brainstormed"
+    for key in ("class", "fingerprint", "status", "retry_after", "remediation"):
+        assert key in rec
 
 
 def test_run_exits_zero_and_records_on_project_failure(tmp_path, monkeypatch) -> None:
@@ -58,11 +63,44 @@ def test_run_exits_zero_and_records_on_project_failure(tmp_path, monkeypatch) ->
     _make_project(tmp_path, pid)
 
     def _boom(project):
-        raise RuntimeError("research.md reference is unreachable (HTTP 404)")
+        raise RuntimeError("research.md reference is unreachable: 'https://x/' (HTTP 404)")
     monkeypatch.setattr(graph, "run_one_step", _boom)
 
     args = argparse.Namespace(agent=None, stage=None, max_tasks=1, project=pid,
                               worker=None, workers=None, personality=None)
     rc = cli._cmd_run(args)
-    assert rc == 0  # did NOT crash the worker
-    assert (tmp_path / "state" / "advance_errors" / f"{pid}.json").exists()
+    assert rc == 0  # INVARIANT: did NOT crash the worker
+    rec_path = tmp_path / "state" / "advance_errors" / f"{pid}.json"
+    assert rec_path.exists()  # INVARIANT: the failure is recorded
+    # The typed record classifies the dead reference as permanent -> rerouted.
+    rec = json.loads(rec_path.read_text(encoding="utf-8"))
+    assert rec["fingerprint"] == "unreachable_reference"
+    assert rec["class"] == "permanent"
+    assert rec["status"] == "rerouted"
+
+
+def test_run_clears_record_on_successful_step(tmp_path, monkeypatch) -> None:
+    """The SUCCESS path (run_one_step returns without raising) clears the ledger
+    so consecutive_count reflects CONSECUTIVE failures, not lifetime failures."""
+    monkeypatch.setenv("LLMXIVE_REPO_ROOT", str(tmp_path))
+    pid = "PROJ-903-x"
+    p = _make_project(tmp_path, pid)
+    # Pre-seed a recorded failure.
+    cli._record_advance_error(
+        p, RuntimeError("every backend in chain ['dartmouth', 'local'] failed")
+    )
+    rec_path = tmp_path / "state" / "advance_errors" / f"{pid}.json"
+    assert rec_path.exists()
+
+    # Now a step SUCCEEDS (advances the stage).
+    def _advance(project):
+        return project.model_copy(update={"current_stage": Stage.PROJECT_INITIALIZED})
+    monkeypatch.setattr(graph, "run_one_step", _advance)
+
+    args = argparse.Namespace(agent=None, stage=None, max_tasks=1, project=pid,
+                              worker=None, workers=None, personality=None)
+    rc = cli._cmd_run(args)
+    assert rc == 0
+    rec = json.loads(rec_path.read_text(encoding="utf-8"))
+    assert rec["status"] == "cleared"
+    assert rec["consecutive_count"] == 0

--- a/tests/unit/test_advance_ledger.py
+++ b/tests/unit/test_advance_ledger.py
@@ -1,0 +1,234 @@
+"""Typed advancement-failure ledger (issue #1139, defect D5).
+
+Real files, real functions — no mocks (Constitution III). Exercises the shared
+:mod:`llmxive.pipeline.advance_ledger` module both ``cli.py`` and the scheduler
+route through: the 9-fingerprint classifier, exponential-backoff dispositions,
+and the record read/write/clear lifecycle against tmp files.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from llmxive.pipeline import advance_ledger as al
+from llmxive.types import Project, Stage
+
+# One representative real message per fingerprint (verbatim shapes from the recon
+# / the live state/advance_errors/*.json records) → expected (fingerprint, class).
+_CASES: list[tuple[str, str, al.ErrorClass]] = [
+    (
+        "research.md reference is unreachable: 'https://trec.nist.gov/data/robust/04/' "
+        "(HTTP 404). FR-006 admits NO transient-retry leniency",
+        al.FP_UNREACHABLE_REFERENCE,
+        al.ErrorClass.PERMANENT,
+    ),
+    (
+        "speckit refused to emit a 'template' artifact at /x/tasks.md.\n  Rules fired: "
+        "unfilled_bracket_density=31 bracket markers; sample=['[User Story 1]']",
+        al.FP_TEMPLATE_REJECTION,
+        al.ErrorClass.PERMANENT,
+    ),
+    (
+        "every backend in chain ['dartmouth', 'local'] failed; errors: "
+        "dartmouth(outage): every model in chain ['qwen.qwen3.5-122b'] failed on "
+        "backend 'dartmouth'",  # nests "every model in chain" -> ordering matters
+        al.FP_BACKEND_CHAIN_FAILED,
+        al.ErrorClass.TRANSIENT,
+    ),
+    (
+        "invalid transition paper_analyzed -> paper_planned",
+        al.FP_INVALID_TRANSITION,
+        al.ErrorClass.INVARIANT,
+    ),
+    (
+        "[Errno 17] File exists: '/home/runner/work/llmXive/llmXive/projects/"
+        "PROJ-770-x/code'",
+        al.FP_FILESYSTEM_FILE_EXISTS,
+        al.ErrorClass.DETERMINISTIC_REPAIR,
+    ),
+    (
+        "every model in chain ['qwen.qwen3.5-122b', 'google.gemma-3-27b-it'] failed "
+        "on backend 'dartmouth'",
+        al.FP_MODEL_CHAIN_FAILED,
+        al.ErrorClass.TRANSIENT,
+    ),
+    (
+        "Clarifier left 3 of 3 markers unresolved (attempt 1/5); will not advance.",
+        al.FP_UNRESOLVED_MARKERS,
+        al.ErrorClass.EMITTER_CONTEXT,
+    ),
+    (
+        "PROJ-654: no paper/source/*.tex draft to seed from — the ingested paper "
+        "LaTeX is missing",
+        al.FP_NO_SEED_DRAFT,
+        al.ErrorClass.EMITTER_CONTEXT,
+    ),
+    (
+        "Tasker produced only 0 task IDs (need >= 5; total chars: 11382). "
+        "Re-running on next cycle.",
+        al.FP_TASKER_ZERO_TASKS,
+        al.ErrorClass.EMITTER_CONTEXT,
+    ),
+]
+
+
+def _proj(pid: str, stage: Stage = Stage.PROJECT_INITIALIZED) -> Project:
+    now = datetime.now(UTC)
+    return Project(
+        id=pid, title=pid, field="test", current_stage=stage,
+        created_at=now, updated_at=now,
+    )
+
+
+@pytest.mark.parametrize("message,fingerprint,klass", _CASES)
+def test_classifier_maps_each_fingerprint_to_correct_class(
+    message: str, fingerprint: str, klass: al.ErrorClass
+) -> None:
+    fp, cls = al.classify_message(message)
+    assert fp == fingerprint
+    assert cls == klass
+    # classify(exc) delegates to classify_message and must agree.
+    assert al.classify(RuntimeError(message)) == (fingerprint, klass)
+
+
+def test_backend_chain_wins_over_nested_model_chain() -> None:
+    # The outer backend-chain failure embeds a "every model in chain" substring;
+    # it must classify as backend_chain (transient), not model_chain.
+    msg = ("every backend in chain ['dartmouth', 'local'] failed; errors: "
+           "dartmouth: every model in chain ['x'] failed on backend 'dartmouth'")
+    assert al.classify_message(msg)[0] == al.FP_BACKEND_CHAIN_FAILED
+
+
+def test_unknown_message_defaults_to_transient() -> None:
+    fp, cls = al.classify_message("something totally unrecognized happened")
+    assert fp == al.FP_UNKNOWN
+    assert cls == al.ErrorClass.TRANSIENT  # safe default: backoff, not abandon
+
+
+def test_backoff_monotonic_and_capped() -> None:
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    delays = [
+        (al.compute_retry_after(base, n) - base).total_seconds()
+        for n in range(0, al.BACKOFF_CAP + 3)
+    ]
+    # Strictly increasing up to the cap...
+    for i in range(al.BACKOFF_CAP):
+        assert delays[i] < delays[i + 1], (i, delays)
+    # ...then saturated (count beyond the cap does not grow the window).
+    capped = al.BASE_BACKOFF_SECONDS * (2 ** al.BACKOFF_CAP)
+    assert delays[al.BACKOFF_CAP] == capped
+    assert delays[al.BACKOFF_CAP + 1] == capped
+    assert delays[al.BACKOFF_CAP + 2] == capped
+    # Non-decreasing overall.
+    assert delays == sorted(delays)
+
+
+def test_transient_disposition_sets_future_retry_after() -> None:
+    ls = datetime(2026, 1, 1, tzinfo=UTC)
+    status, retry_after = al.disposition(
+        al.ErrorClass.TRANSIENT, last_seen=ls, consecutive_count=1
+    )
+    assert status == al.LedgerStatus.RETRY_SCHEDULED
+    assert retry_after is not None and retry_after > ls
+
+
+def test_deterministic_repair_also_backs_off() -> None:
+    ls = datetime(2026, 1, 1, tzinfo=UTC)
+    status, retry_after = al.disposition(
+        al.ErrorClass.DETERMINISTIC_REPAIR, last_seen=ls, consecutive_count=2
+    )
+    assert status == al.LedgerStatus.RETRY_SCHEDULED
+    assert retry_after is not None and retry_after > ls  # spaced, not every-tick
+
+
+def test_invariant_sets_no_retry_after() -> None:
+    status, retry_after = al.disposition(
+        al.ErrorClass.INVARIANT, last_seen=datetime.now(UTC), consecutive_count=5
+    )
+    assert status == al.LedgerStatus.TERMINAL
+    assert retry_after is None  # never consumes retry budget
+
+
+@pytest.mark.parametrize(
+    "klass", [al.ErrorClass.PERMANENT, al.ErrorClass.EMITTER_CONTEXT]
+)
+def test_permanent_and_emitter_reroute_without_retry_after(klass) -> None:
+    status, retry_after = al.disposition(
+        klass, last_seen=datetime.now(UTC), consecutive_count=3
+    )
+    assert status == al.LedgerStatus.REROUTED
+    assert retry_after is None  # do NOT re-dispatch unchanged
+
+
+def test_record_failure_increments_consecutive_count(tmp_path) -> None:
+    p = _proj("PROJ-701-x", Stage.PROJECT_INITIALIZED)
+    msg = "every backend in chain ['dartmouth', 'local'] failed"
+    r1 = al.record_failure(p, RuntimeError(msg), repo_root=tmp_path)
+    r2 = al.record_failure(p, RuntimeError(msg), repo_root=tmp_path)
+    assert r1["consecutive_count"] == 1
+    assert r2["consecutive_count"] == 2
+    assert r2["first_seen"] == r1["first_seen"]  # streak start preserved
+    assert r2["class"] == al.ErrorClass.TRANSIENT.value
+    assert r2["fingerprint"] == al.FP_BACKEND_CHAIN_FAILED
+    assert r2["status"] == al.LedgerStatus.RETRY_SCHEDULED.value
+    assert r2["stage"] == "project_initialized"
+    # On-disk record matches the returned record.
+    assert al.load_record("PROJ-701-x", repo_root=tmp_path) == r2
+
+
+def test_invalid_transition_record_is_terminal_no_retry(tmp_path) -> None:
+    p = _proj("PROJ-702-x", Stage.PROJECT_INITIALIZED)
+    rec = al.record_failure(
+        p, RuntimeError("invalid transition in_progress -> clarified"),
+        repo_root=tmp_path,
+    )
+    assert rec["class"] == al.ErrorClass.INVARIANT.value
+    assert rec["status"] == al.LedgerStatus.TERMINAL.value
+    assert rec["retry_after"] is None
+
+
+def test_clear_resets_consecutive_count(tmp_path) -> None:
+    p = _proj("PROJ-703-x", Stage.PROJECT_INITIALIZED)
+    msg = "every backend in chain ['dartmouth', 'local'] failed"
+    al.record_failure(p, RuntimeError(msg), repo_root=tmp_path)
+    al.record_failure(p, RuntimeError(msg), repo_root=tmp_path)
+    assert al.load_record("PROJ-703-x", repo_root=tmp_path)["consecutive_count"] == 2
+
+    assert al.clear(p, repo_root=tmp_path) is True
+    cleared = al.load_record("PROJ-703-x", repo_root=tmp_path)
+    assert cleared["status"] == al.LedgerStatus.CLEARED.value
+    assert cleared["consecutive_count"] == 0
+    assert cleared["retry_after"] is None
+
+    # A subsequent failure restarts the CONSECUTIVE streak at 1.
+    r = al.record_failure(p, RuntimeError(msg), repo_root=tmp_path)
+    assert r["consecutive_count"] == 1
+
+
+def test_clear_is_noop_without_a_record(tmp_path) -> None:
+    p = _proj("PROJ-704-x")
+    assert al.clear(p, repo_root=tmp_path) is False
+
+
+def test_is_schedulable_backoff_gate() -> None:
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    future = {
+        "status": al.LedgerStatus.RETRY_SCHEDULED.value,
+        "retry_after": (now + timedelta(hours=1)).isoformat(),
+    }
+    past = {
+        "status": al.LedgerStatus.RETRY_SCHEDULED.value,
+        "retry_after": (now - timedelta(hours=1)).isoformat(),
+    }
+    assert al.is_schedulable(None, now=now) is True
+    assert al.is_schedulable({"status": "cleared"}, now=now) is True
+    assert al.is_schedulable(future, now=now) is False  # inside backoff window
+    assert al.is_schedulable(past, now=now) is True  # backoff elapsed
+    # Hold statuses are never schedulable, regardless of any retry_after.
+    assert al.is_schedulable({"status": "rerouted", "retry_after": None}, now=now) is False
+    assert al.is_schedulable(
+        {"status": "terminal", "retry_after": (now - timedelta(days=9)).isoformat()},
+        now=now,
+    ) is False  # a past retry_after does NOT resurrect a terminal record

--- a/tests/unit/test_citation_fetcher_access_gated.py
+++ b/tests/unit/test_citation_fetcher_access_gated.py
@@ -1,13 +1,19 @@
-"""A bot-blocked/paywalled real host must NOT hard-block advancement.
+"""A bot-blocked/paywalled real host classifies as PENDING, not a false MISMATCH.
 
-The research-accept / paper-accept citation gate blocks UNREACHABLE + MISMATCH
-citations. Real academic sources (publisher pages, OEIS behind Cloudflare,
-KnotInfo, rate-limited registrars) frequently 403/401/429 an automated client —
-the host EXISTS, it just gates the body. Classifying that as UNREACHABLE
-false-flagged real references as fabricated and trapped projects at
-research_review. These pin the access-gated -> PENDING (non-blocking, honestly
-unverified) classification while keeping 404/DNS -> MISMATCH/UNREACHABLE (the
-anti-fabrication gate is preserved).
+Real academic sources (publisher pages, OEIS behind Cloudflare, KnotInfo,
+rate-limited registrars) frequently 403/401/429 an automated client — the host
+EXISTS, it just gates the body. Classifying that as UNREACHABLE false-flagged
+real references as fabricated. These tests pin the access-gated -> PENDING
+classification while keeping 404/DNS -> MISMATCH/UNREACHABLE (the
+anti-fabrication classification is preserved).
+
+Issue #1139 D14/D15 changed what PENDING MEANS at the gate: existence is no
+longer verification. A bare URL/DOI with no cross-checkable cited title now
+classifies PENDING (not a false VERIFIED), and the reference gate is POSITIVE —
+a project advances only when EVERY citation is VERIFIED, so PENDING now BLOCKS
+(bounded retry / substitution upstream) rather than silently passing. These
+tests assert the classification layer here; the positive-gate behavior lives in
+``test_reference_gate_positive.py``.
 """
 
 from __future__ import annotations
@@ -17,8 +23,9 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from agents.tools import citation_fetcher as cf  # noqa: E402
-from llmxive.types import VerificationStatus  # noqa: E402
+from agents.tools import citation_fetcher as cf
+
+from llmxive.types import VerificationStatus
 
 
 class _Resp:
@@ -64,17 +71,45 @@ def test_url_500_is_still_unreachable(monkeypatch):
     assert out.status == VerificationStatus.UNREACHABLE
 
 
-def test_pending_does_not_block_the_gate():
-    """A PENDING citation must NOT be counted by has_blocking_citations (only
-    UNREACHABLE + MISMATCH block) — that's what makes access-gated refs advanceable.
-    UNREACHABLE/MISMATCH still block (anti-fabrication gate intact)."""
-    from types import SimpleNamespace
+def test_pending_blocks_the_gate(tmp_path):
+    """D15 (issue #1139): the reference gate is now POSITIVE — a project advances
+    ONLY when EVERY citation is currently VERIFIED. A PENDING (present-but-
+    unverified) citation now BLOCKS; a fully-VERIFIED set advances. UNREACHABLE /
+    MISMATCH remain blocking (anti-fabrication gate intact). REAL round-trip
+    through the production citations store + gate."""
+    from datetime import UTC, datetime
 
-    from llmxive.agents.advancement import _has_blocking_citations
-    pending = SimpleNamespace(verification_status=VerificationStatus.PENDING)
-    unreachable = SimpleNamespace(verification_status=VerificationStatus.UNREACHABLE)
-    assert _has_blocking_citations([pending]) is False
-    assert _has_blocking_citations([pending, unreachable]) is True
+    from llmxive.agents.reference_validator import has_blocking_citations
+    from llmxive.state import citations as citations_store
+    from llmxive.types import Citation, CitationKind
+
+    project_id = "PROJ-901-gate"
+
+    def _cite(status, *, cite_id="c-001"):
+        return Citation(
+            cite_id=cite_id,
+            artifact_path=f"projects/{project_id}/specs/plan.md",
+            artifact_hash="0" * 64,
+            kind=CitationKind.URL,
+            value="https://example.com/paper",
+            cited_title="A Real Cited Title",
+            verification_status=status,
+            verified_at=datetime.now(UTC),
+        )
+
+    citations_store.save(project_id, [_cite(VerificationStatus.PENDING)], repo_root=tmp_path)
+    assert has_blocking_citations(project_id, repo_root=tmp_path) is True
+
+    citations_store.save(project_id, [_cite(VerificationStatus.UNREACHABLE)], repo_root=tmp_path)
+    assert has_blocking_citations(project_id, repo_root=tmp_path) is True
+
+    citations_store.save(
+        project_id,
+        [_cite(VerificationStatus.VERIFIED, cite_id="c-001"),
+         _cite(VerificationStatus.VERIFIED, cite_id="c-002")],
+        repo_root=tmp_path,
+    )
+    assert has_blocking_citations(project_id, repo_root=tmp_path) is False
 
 
 def test_is_real_title_rejects_urls_dois_ids():
@@ -85,14 +120,16 @@ def test_is_real_title_rejects_urls_dois_ids():
     assert cf._is_real_title("") is False
 
 
-def test_url_as_cited_title_does_not_false_mismatch():
-    """The reference resolved to the REAL paper (fetched_title) but the citation
-    stored a URL in cited_title — must be VERIFIED on existence, not MISMATCH."""
+def test_bare_url_cited_title_is_pending_not_verified():
+    """D14 (issue #1139): the citation stored a URL/DOI in cited_title, so there is
+    no real cited title to cross-check. The reference RESOLVED to a readable page,
+    but existence != verification — classify PENDING (present-but-unverified,
+    bounded retry/substitution), NOT VERIFIED on existence alone."""
     out = cf._classify_match(
         "https://doi.org/10.48550/arXiv.2503.10452",        # cited_title is a URL
         "[2503.10452] DynaCode: A Dynamic Complexity-Aware Code Benchmark",  # real title
     )
-    assert out == VerificationStatus.VERIFIED
+    assert out == VerificationStatus.PENDING
 
 
 def test_real_title_still_mismatches_when_unrelated():

--- a/tests/unit/test_data_source_cache.py
+++ b/tests/unit/test_data_source_cache.py
@@ -1,0 +1,229 @@
+"""D8 — the execution-side data-source DISCOVERY CACHE (issue #1139).
+
+Locks the poison-cache fixes in ``llmxive.execution.data_source``:
+
+- a TRANSIENT discovery error (timeout / connection / 5xx / 429) is NOT persisted
+  and the NEXT tick re-discovers (the reproduced ``rediscovery_calls == 0`` bug);
+- the cache key is a REAL key (intent + required_fields + plan-hash +
+  VERIFIER_VERSION) stored INSIDE the record, so a change to any of those is a
+  MISS (no stale reuse);
+- ``status == "none"`` has a TTL + bounded retry count; ``verified`` is durable;
+- a legacy ``status == "error"`` record (from the old poison writer) is never
+  trusted — it is always re-discovered.
+
+Only the actual discovery boundary (``discover_data_source``) and the LLM-distill
+boundary (``_distill_data_need``) are stubbed; the cache-key / freshness / TTL
+logic under test runs for real.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+
+import requests
+import yaml
+
+import llmxive.execution.data_source as ds
+import llmxive.librarian.data_source_discovery as dsd
+from llmxive.librarian.data_source_discovery import VerifiedSource
+
+
+def _fixed_distill(monkeypatch, intent="knot invariants dataset", fields=("crossing_number",)):
+    monkeypatch.setattr(ds, "_distill_data_need", lambda raw: (intent, list(fields)))
+
+
+def _source(ref="database-knotinfo", count=250):
+    return VerifiedSource(
+        kind="pypi_package", ref=ref,
+        access_python="import database_knotinfo; print('RECORDS=%d' % 250)",
+        record_count=count, sample_fields=["crossing_number"], field_coverage=1.0,
+    )
+
+
+def _proj(tmp_path, name="PROJ-1"):
+    p = tmp_path / "projects" / name
+    p.mkdir(parents=True)
+    return p
+
+
+# --- the reproduced poison bug: transient error not cached, and retried --------
+
+
+def test_transient_error_not_cached_and_retries(tmp_path, monkeypatch):
+    proj = _proj(tmp_path)
+    _fixed_distill(monkeypatch)
+    calls: list[str] = []
+
+    def fake_discover(intent, required_fields=None):
+        calls.append(intent)
+        if len(calls) == 1:
+            raise requests.exceptions.ReadTimeout(
+                "HTTPSConnectionPool(host='hf.co'): Read timed out. (transient)"
+            )
+        return _source()
+
+    monkeypatch.setattr(dsd, "discover_data_source", fake_discover)
+
+    rec1 = ds.ensure_discovered_source(proj)
+    assert rec1["status"] == "error"
+    assert rec1["transient"] is True
+    # The transient error is NOT persisted (so the next tick can retry).
+    assert not ds._cache_path(proj).exists()
+
+    rec2 = ds.ensure_discovered_source(proj)
+    # rediscovery_calls > 0 after the transient error (the poison bug had 0).
+    assert len(calls) == 2
+    assert rec2["status"] == "verified"
+    assert rec2["ref"] == "database-knotinfo"
+    assert ds._cache_path(proj).exists()
+
+
+def test_non_transient_error_also_not_cached(tmp_path, monkeypatch):
+    proj = _proj(tmp_path, "PROJ-1b")
+    _fixed_distill(monkeypatch)
+    calls: list[int] = []
+
+    def fake_discover(intent, required_fields=None):
+        calls.append(1)
+        if len(calls) == 1:
+            raise ValueError("a real bug, not transient")
+        return _source()
+
+    monkeypatch.setattr(dsd, "discover_data_source", fake_discover)
+
+    rec1 = ds.ensure_discovered_source(proj)
+    assert rec1["status"] == "error" and rec1["transient"] is False
+    assert not ds._cache_path(proj).exists()  # errors of any kind are not cached
+    rec2 = ds.ensure_discovered_source(proj)
+    assert len(calls) == 2 and rec2["status"] == "verified"
+
+
+# --- real cache key: invalidate on intent / field / plan change ----------------
+
+
+def test_cache_key_invalidates_on_intent_change(tmp_path, monkeypatch):
+    proj = _proj(tmp_path, "PROJ-2")
+    monkeypatch.setattr(
+        dsd, "discover_data_source",
+        lambda intent, required_fields=None: _source(ref="pkg-" + intent.split()[0]),
+    )
+
+    monkeypatch.setattr(ds, "_distill_data_need", lambda raw: ("alpha dataset", ["f1"]))
+    rec1 = ds.ensure_discovered_source(proj)
+    assert rec1["ref"] == "pkg-alpha"
+    key1 = rec1["cache_key"]
+
+    monkeypatch.setattr(ds, "_distill_data_need", lambda raw: ("beta dataset", ["f1"]))
+    rec2 = ds.ensure_discovered_source(proj)
+    assert rec2["cache_key"] != key1
+    assert rec2["ref"] == "pkg-beta"  # re-discovered, not the stale alpha
+
+
+def test_cache_key_invalidates_on_field_change(tmp_path, monkeypatch):
+    proj = _proj(tmp_path, "PROJ-3")
+    calls: list[list[str] | None] = []
+
+    def fake_discover(intent, required_fields=None):
+        calls.append(required_fields)
+        return _source()
+
+    monkeypatch.setattr(dsd, "discover_data_source", fake_discover)
+
+    monkeypatch.setattr(ds, "_distill_data_need", lambda raw: ("ds", ["a"]))
+    key1 = ds.ensure_discovered_source(proj)["cache_key"]
+    monkeypatch.setattr(ds, "_distill_data_need", lambda raw: ("ds", ["a", "b"]))
+    key2 = ds.ensure_discovered_source(proj)["cache_key"]
+    assert key1 != key2
+    assert len(calls) == 2  # re-discovered on the required-field change
+
+
+def test_cache_key_invalidates_on_plan_change(tmp_path, monkeypatch):
+    proj = _proj(tmp_path, "PROJ-4")
+    _fixed_distill(monkeypatch)  # intent held constant
+    calls: list[int] = []
+    monkeypatch.setattr(
+        dsd, "discover_data_source",
+        lambda intent, required_fields=None: (calls.append(1), _source())[1],
+    )
+
+    monkeypatch.setattr(ds, "_raw_data_sections", lambda pd: "plan version A")
+    key1 = ds.ensure_discovered_source(proj)["cache_key"]
+    monkeypatch.setattr(ds, "_raw_data_sections", lambda pd: "plan version B — changed")
+    key2 = ds.ensure_discovered_source(proj)["cache_key"]
+    assert key1 != key2  # a changed plan/spec invalidates
+    assert len(calls) == 2
+
+
+def test_verified_is_durable_no_rediscovery(tmp_path, monkeypatch):
+    proj = _proj(tmp_path, "PROJ-5")
+    _fixed_distill(monkeypatch)
+    calls: list[int] = []
+    monkeypatch.setattr(
+        dsd, "discover_data_source",
+        lambda intent, required_fields=None: (calls.append(1), _source())[1],
+    )
+    rec1 = ds.ensure_discovered_source(proj)
+    rec2 = ds.ensure_discovered_source(proj)
+    assert rec1["status"] == rec2["status"] == "verified"
+    assert len(calls) == 1  # durable — a same-key verified record is not re-searched
+
+
+# --- none: TTL + bounded retry -------------------------------------------------
+
+
+def test_none_status_ttl_and_bounded_retry(tmp_path, monkeypatch):
+    proj = _proj(tmp_path, "PROJ-6")
+    _fixed_distill(monkeypatch)
+    calls: list[int] = []
+    monkeypatch.setattr(
+        dsd, "discover_data_source",
+        lambda intent, required_fields=None: (calls.append(1), None)[1],
+    )
+
+    rec1 = ds.ensure_discovered_source(proj)
+    assert rec1["status"] == "none" and rec1["retry_count"] == 1
+    assert len(calls) == 1
+
+    # Fresh none → reused, NOT re-searched.
+    rec2 = ds.ensure_discovered_source(proj)
+    assert len(calls) == 1 and rec2["retry_count"] == 1
+
+    # Age the record past the TTL → re-searched, retry_count increments.
+    cache = ds._cache_path(proj)
+    doc = yaml.safe_load(cache.read_text())
+    stale = _dt.datetime.now(_dt.UTC) - _dt.timedelta(days=ds._NONE_TTL_DAYS + 5)
+    doc["searched_at"] = stale.isoformat()
+    cache.write_text(yaml.safe_dump(doc))
+    rec3 = ds.ensure_discovered_source(proj)
+    assert len(calls) == 2 and rec3["retry_count"] == 2
+
+    # Exhaust the retry budget → durable none even when stale (no more searches).
+    doc = yaml.safe_load(cache.read_text())
+    doc["retry_count"] = ds._NONE_MAX_RETRIES
+    doc["searched_at"] = (_dt.datetime.now(_dt.UTC) - _dt.timedelta(days=60)).isoformat()
+    cache.write_text(yaml.safe_dump(doc))
+    calls_before = len(calls)
+    rec4 = ds.ensure_discovered_source(proj)
+    assert len(calls) == calls_before  # not re-searched — budget spent
+    assert rec4["status"] == "none"
+
+
+# --- legacy poison invalidation ------------------------------------------------
+
+
+def test_legacy_error_cache_is_treated_as_miss(tmp_path, monkeypatch):
+    proj = _proj(tmp_path, "PROJ-7")
+    # Seed a legacy poison record exactly as the OLD writer produced it: a
+    # ``status: error`` with no cache_key, which used to be returned forever.
+    cache = ds._cache_path(proj)
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text("status: error\nreason: 'HTTPSConnectionPool: Read timed out'\n")
+
+    _fixed_distill(monkeypatch)
+    monkeypatch.setattr(
+        dsd, "discover_data_source",
+        lambda intent, required_fields=None: _source(),
+    )
+    rec = ds.ensure_discovered_source(proj)
+    # The poison error is NOT returned; discovery re-runs and finds the real source.
+    assert rec["status"] == "verified"
+    assert rec["ref"] == "database-knotinfo"

--- a/tests/unit/test_data_url_verify.py
+++ b/tests/unit/test_data_url_verify.py
@@ -1,0 +1,122 @@
+"""D9 — a data URL must prove RECORDS (not just sniff parseable) to verify.
+
+Locks the fix to ``data_source_discovery._verify_data_url`` +
+``dataset_resolver.sample_records``: a URL is verified only when a streamed
+sample both sniffs as a dataset format AND parses into ``record_count > 0`` real
+records with a real ``field_coverage``. A format-sniff-only "parsed" (the old
+``record_count=0`` + ``field_coverage=1.0`` free pass) is REJECTED.
+
+Real HTTP over an ephemeral localhost server (only ``requests``' network endpoint
+is a real socket; all parsing/gate logic is exercised for real). Run with
+``LLMXIVE_ALLOW_LOCALHOST=1``.
+"""
+from __future__ import annotations
+
+import functools
+import http.server
+import socketserver
+import threading
+
+import pytest
+
+from llmxive.librarian.data_source_discovery import _verify_data_url
+from llmxive.librarian.dataset_resolver import sample_records
+
+
+@pytest.fixture
+def file_server(tmp_path):
+    handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=str(tmp_path))
+    httpd = socketserver.TCPServer(("127.0.0.1", 0), handler)
+    port = httpd.server_address[1]
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    yield tmp_path, f"http://127.0.0.1:{port}"
+    httpd.shutdown()
+
+
+# --- sample_records: real record + field extraction ----------------------------
+
+
+def test_sample_records_counts_csv_rows_and_fields(file_server):
+    root, base = file_server
+    (root / "d.csv").write_text("crossing_number,braid_index\n3,2\n4,3\n5,2\n")
+    sr = sample_records(f"{base}/d.csv")
+    assert sr.parsed is True
+    assert sr.record_count == 3
+    assert "crossing_number" in sr.fields and "braid_index" in sr.fields
+
+
+def test_sample_records_counts_json_array(file_server):
+    root, base = file_server
+    (root / "d.json").write_text('[{"crossing_number": 3}, {"crossing_number": 4}]')
+    sr = sample_records(f"{base}/d.json")
+    assert sr.parsed is True and sr.record_count == 2
+    assert sr.fields == ["crossing_number"]
+
+
+def test_sample_records_counts_jsonl(file_server):
+    root, base = file_server
+    (root / "d.jsonl").write_text('{"a": 1, "b": 2}\n{"a": 3, "b": 4}\n{"a": 5, "b": 6}\n')
+    sr = sample_records(f"{base}/d.jsonl")
+    assert sr.parsed is True and sr.record_count == 3
+    assert sr.fields == ["a", "b"]
+
+
+def test_header_only_csv_yields_zero_records(file_server):
+    # Sniffs as CSV (2 columns) but has NO data rows → not record-verifiable.
+    root, base = file_server
+    (root / "empty.csv").write_text("a,b\n")
+    sr = sample_records(f"{base}/empty.csv")
+    assert sr.record_count == 0
+    assert sr.parsed is False  # 0 records => not a verified sample
+
+
+# --- _verify_data_url: records + coverage gate ---------------------------------
+
+
+def test_data_url_verified_with_records_and_coverage(file_server):
+    root, base = file_server
+    (root / "d.csv").write_text("crossing_number,braid_index\n3,2\n4,3\n")
+    proposal = {"kind": "data_url", "ref": f"{base}/d.csv",
+                "access_python": "import pandas as pd; pd.read_csv(url)"}
+    vs = _verify_data_url(proposal, required_fields=["crossing number"])
+    assert vs is not None
+    assert vs.kind == "data_url"
+    assert vs.record_count == 2  # real count, NOT 0
+    assert vs.field_coverage >= 0.5  # real coverage from parsed header
+
+
+def test_data_url_zero_records_rejected_even_without_required_fields(file_server):
+    # This is the killed false-pass: no required_fields USED to grant coverage=1.0
+    # on a record_count=0 sniff. Now a 0-record URL is rejected outright.
+    root, base = file_server
+    (root / "empty.csv").write_text("a,b\n")
+    proposal = {"kind": "data_url", "ref": f"{base}/empty.csv", "access_python": "x"}
+    assert _verify_data_url(proposal, required_fields=None) is None
+
+
+def test_data_url_html_rejected(file_server):
+    root, base = file_server
+    (root / "page.html").write_text("<html><body>not a dataset</body></html>")
+    proposal = {"kind": "data_url", "ref": f"{base}/page.html", "access_python": "x"}
+    assert _verify_data_url(proposal, required_fields=None) is None
+
+
+def test_data_url_wrong_schema_scores_low_coverage(file_server):
+    root, base = file_server
+    # Two columns (so it sniffs as CSV) but NEITHER matches the required schema.
+    (root / "names.csv").write_text("id,name\n1,foo\n2,bar\n3,baz\n")
+    proposal = {"kind": "data_url", "ref": f"{base}/names.csv", "access_python": "x"}
+    vs = _verify_data_url(
+        proposal, required_fields=["crossing number", "braid index", "volume"]
+    )
+    # It loads records, but none of the required columns are present → 0 coverage
+    # (the caller's coverage gate then rejects it as the wrong dataset).
+    assert vs is not None and vs.record_count == 3
+    assert vs.field_coverage == 0.0
+
+
+def test_non_http_ref_rejected():
+    # A pip package name is not a data URL.
+    assert _verify_data_url(
+        {"kind": "data_url", "ref": "database-knotinfo", "access_python": "x"}
+    ) is None

--- a/tests/unit/test_issue_1139_core.py
+++ b/tests/unit/test_issue_1139_core.py
@@ -1,0 +1,444 @@
+"""Regression tests locking the CORE fixes for GitHub issue #1139.
+
+Each test pins ONE already-implemented fix against the exact anti-pattern the
+recon reproduced, using REAL temp dirs + REAL functions. The only monkeypatched
+seams are the named external boundaries (the LaTeX builder, the Kaggle offload
+backend, and the paper-gate's sibling verifiers) — never the code under test.
+
+Mapping (defect → test):
+  D1  paper-complete gate consumes the producer's own pdf_path (not a hard-coded
+      source/main.pdf the producer never writes) + requires PDF freshness
+      → test_paper_complete_gate_consumes_producer_pdf_path
+  D4  durable execution FailureClass taxonomy + class-specific re-plan guidance
+      → test_failure_class_from_signals
+        test_execution_status_round_trips_failure_class
+        test_replan_feedback_is_class_specific
+  D12 one backend-independent semantic gate; the GPU-offload path rejoins it
+      → test_verify_artifact_bundle_rejects_fabrication
+        test_offload_complete_rejects_fabricated_bundle
+  D2  execution repair reopens tasks via the SSoT feature-dir pointer, not the
+      first lexicographic specs/*/tasks.md
+      → test_reopen_uses_pointer_feature_dir
+  D3  routing ignores a stale/cross-stage convergence kickback instead of
+      returning an illegal lifecycle edge
+      → test_decide_next_stage_ignores_stale_cross_stage_kickback
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+import yaml
+
+from llmxive.agents.lifecycle import is_valid_transition
+from llmxive.execution import offload as offload_mod
+from llmxive.execution.analysis_runner import (
+    AnalysisRunResult,
+    RunCommandResult,
+    verify_artifact_bundle,
+)
+from llmxive.execution.failure_class import REPLAN_GUIDANCE, FailureClass
+from llmxive.execution.stage import (
+    _compute_infra_failures,
+    _data_unavailable_failures,
+    _poll_offload,
+    _reopen_failing_tasks,
+)
+from llmxive.pipeline import graph
+from llmxive.state import execution_status
+from llmxive.state import project as project_store
+from llmxive.types import Project, Stage
+
+
+@pytest.fixture(autouse=True)
+def _allow_localhost(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLMXIVE_ALLOW_LOCALHOST", "1")
+
+
+def _mk_project_dir(tmp_path: Path, project_id: str) -> Path:
+    proj = tmp_path / "projects" / project_id
+    proj.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "state" / "execution_status").mkdir(parents=True, exist_ok=True)
+    return proj
+
+
+# ---------------------------------------------------------------------------
+# D1 — paper-complete gate consumes the producer's returned pdf_path
+# ---------------------------------------------------------------------------
+
+
+def test_paper_complete_gate_consumes_producer_pdf_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The gate must accept the producer's OWN ``pdf_path`` (paper/pdf/main.pdf),
+    not a hard-coded paper/source/main.pdf the builder never writes. Negatives:
+    a missing pdf_path file and a PDF older than its source both reject."""
+    pid = "PROJ-575-pdf-gate"
+    proj = _mk_project_dir(tmp_path, pid)
+    source = proj / "paper" / "source" / "main.tex"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("\\documentclass{article}\\begin{document}x\\end{document}\n",
+                      encoding="utf-8")
+    pdf = proj / "paper" / "pdf" / "main.pdf"
+    pdf.parent.mkdir(parents=True, exist_ok=True)
+    pdf.write_bytes(b"%PDF-1.5 real bytes")
+
+    # Fresh PDF: source older than the produced PDF.
+    old = datetime(2026, 1, 1).timestamp()
+    new = datetime(2026, 1, 2).timestamp()
+    os.utime(source, (old, old))
+    os.utime(pdf, (new, new))
+
+    # The producer returns ok + its real pdf_path (paper/pdf/main.pdf).
+    def _fake_build(project_id, *, main_tex="main.tex", repo_root=None):
+        return {"ok": True, "pdf_path": str(pdf)}
+
+    monkeypatch.setattr("llmxive.agents.latex_build.build_paper", _fake_build)
+    # Stub the OTHER preconditions so this test isolates the PDF-path logic.
+    monkeypatch.setattr(graph, "_all_paper_tasks_done", lambda pd: True)
+    monkeypatch.setattr(
+        "llmxive.agents.citation_guard.project_unverified_markers",
+        lambda *a, **k: [],
+    )
+    monkeypatch.setattr(
+        "llmxive.agents.reference_validator.has_blocking_citations",
+        lambda *a, **k: False,
+    )
+    monkeypatch.setattr(
+        "llmxive.agents.proofreader.proofreader_clean", lambda *a, **k: True
+    )
+
+    assert graph._paper_complete_preconditions_met(
+        pid, proj, repo_root=tmp_path
+    ) is True
+
+    # Negative 1: the producer reports a pdf_path that does not exist on disk.
+    pdf.unlink()
+    assert graph._paper_complete_preconditions_met(
+        pid, proj, repo_root=tmp_path
+    ) is False
+
+    # Negative 2: a STALE PDF (older than its source) must not satisfy the gate.
+    pdf.write_bytes(b"%PDF-1.5 stale")
+    os.utime(source, (new, new))   # source now newer than pdf
+    os.utime(pdf, (old, old))
+    assert graph._paper_complete_preconditions_met(
+        pid, proj, repo_root=tmp_path
+    ) is False
+
+
+# ---------------------------------------------------------------------------
+# D4 — durable failure classification + class-specific re-plan guidance
+# ---------------------------------------------------------------------------
+
+
+def test_failure_class_from_signals() -> None:
+    """The single taxonomy maps already-computed signals to one durable class,
+    with the priority the re-plan must address first. Grounded on the REAL
+    signature matchers for the compute/data cases."""
+    # compute-env dominates.
+    assert FailureClass.from_signals(
+        compute_infra=True, data_unavailable=False, fabrication=False,
+        hollow=False, has_command_failures=True,
+    ) is FailureClass.COMPUTE_ENV
+    # data-unreachable next.
+    assert FailureClass.from_signals(
+        compute_infra=False, data_unavailable=True, fabrication=False,
+        hollow=False, has_command_failures=True,
+    ) is FailureClass.DATA_UNREACHABLE
+    # fabrication / hollow → fabrication.
+    assert FailureClass.from_signals(
+        compute_infra=False, data_unavailable=False, fabrication=True,
+        hollow=False, has_command_failures=False,
+    ) is FailureClass.FABRICATION
+    assert FailureClass.from_signals(
+        compute_infra=False, data_unavailable=False, fabrication=False,
+        hollow=True, has_command_failures=False,
+    ) is FailureClass.FABRICATION
+    # a plain command failure → an ordinary code bug.
+    assert FailureClass.from_signals(
+        compute_infra=False, data_unavailable=False, fabrication=False,
+        hollow=False, has_command_failures=True,
+    ) is FailureClass.EXECUTION_BUG
+    # nothing recognized → unknown.
+    assert FailureClass.from_signals(
+        compute_infra=False, data_unavailable=False, fabrication=False,
+        hollow=False, has_command_failures=False,
+    ) is FailureClass.UNKNOWN
+
+    # Grounding: the real signature matchers produce the booleans above.
+    cuda = ["python code/train.py -> rc=1\n    RuntimeError: CUDA out of memory"]
+    hf = ["python code/load.py -> rc=1\n    HfUriError: Repository id must be 'namespace/name'"]
+    assert _compute_infra_failures(cuda)
+    assert not _compute_infra_failures(hf)
+    assert _data_unavailable_failures(hf)
+    assert not _data_unavailable_failures(cuda)
+
+
+def test_execution_status_round_trips_failure_class(tmp_path: Path) -> None:
+    """A failed record persists the durable class + evidence; a success clears
+    both back to None/[]."""
+    (tmp_path / "state" / "execution_status").mkdir(parents=True)
+    pid = "PROJ-843-fc"
+    execution_status.record(
+        pid, ok=False, reason="HfUriError: dataset not found",
+        artifacts=[], failures=["python code/load.py -> rc=1"],
+        failure_class="data_unreachable",
+        evidence=["python code/load.py"],
+        repo_root=tmp_path,
+    )
+    rec = execution_status.load(pid, repo_root=tmp_path)
+    assert rec is not None
+    assert rec["failure_class"] == "data_unreachable"
+    assert rec["evidence"] == ["python code/load.py"]
+
+    # Success clears the class + evidence.
+    execution_status.record(
+        pid, ok=True, reason="ok", artifacts=["data/results.json"],
+        failures=[], repo_root=tmp_path,
+    )
+    rec2 = execution_status.load(pid, repo_root=tmp_path)
+    assert rec2 is not None
+    assert rec2["failure_class"] is None
+    assert rec2["evidence"] == []
+
+
+def test_replan_feedback_is_class_specific(tmp_path: Path) -> None:
+    """The re-plan note branches on the durable class: a compute-env failure gets
+    GPU/offload guidance, a data-unreachable failure gets verified-source guidance,
+    and the two notes are NOT the same generic 'CPU-tractable' text."""
+    proj_c = _mk_project_dir(tmp_path, "PROJ-262-compute")
+    proj_d = _mk_project_dir(tmp_path, "PROJ-261-data")
+
+    compute_text = graph._write_execution_replan_feedback(
+        proj_c,
+        {"failure_class": "compute_env", "reason": "CUDA out of memory",
+         "failures": ["python code/train.py -> rc=1"], "artifacts": [],
+         "model_tier": 1},
+    )
+    data_text = graph._write_execution_replan_feedback(
+        proj_d,
+        {"failure_class": "data_unreachable",
+         "reason": "HfUriError: dataset unreachable",
+         "failures": ["python code/load.py -> rc=1"], "artifacts": []},
+    )
+
+    # Each carries its own class-specific guidance verbatim.
+    assert REPLAN_GUIDANCE[FailureClass.COMPUTE_ENV] in compute_text
+    assert REPLAN_GUIDANCE[FailureClass.DATA_UNREACHABLE] in data_text
+    # The diagnosed class is named in each.
+    assert "compute_env" in compute_text
+    assert "data_unreachable" in data_text
+    # Compute guidance is GPU/offload-shaped; the data note must NOT reuse it.
+    assert "GPU" in compute_text and "offload" in compute_text
+    assert REPLAN_GUIDANCE[FailureClass.COMPUTE_ENV] not in data_text
+    # Distinct, class-appropriate strings (not one generic template).
+    assert compute_text != data_text
+
+
+# ---------------------------------------------------------------------------
+# D12 — one backend-independent semantic gate
+# ---------------------------------------------------------------------------
+
+
+def _write_fabricated_bundle(proj: Path) -> None:
+    """A blatantly fabricated bundle: an RNG metric + a self-declared 'simulated
+    metrics' result (mirrors recon-F _probe_offload.py)."""
+    code = proj / "code"
+    code.mkdir(parents=True, exist_ok=True)
+    (code / "run.py").write_text(
+        "import random\n"
+        "acc = random.random()  # fabricated: not a real measurement\n"
+        "print('simulated metrics', acc)\n",
+        encoding="utf-8",
+    )
+    data = proj / "data"
+    data.mkdir(parents=True, exist_ok=True)
+    (data / "results.json").write_text(
+        json.dumps({"accuracy": 0.99, "note": "simulated metrics"}),
+        encoding="utf-8",
+    )
+
+
+def _write_clean_bundle(proj: Path) -> None:
+    """A real-numbers bundle: measured arithmetic, no fabrication signals."""
+    code = proj / "code"
+    code.mkdir(parents=True, exist_ok=True)
+    (code / "analysis.py").write_text(
+        "import json\n"
+        "values = [1.0, 2.0, 3.0, 4.0]\n"
+        "mean = sum(values) / len(values)\n"
+        "json.dump({'mean': mean, 'n': len(values)},\n"
+        "          open('data/results.json', 'w'))\n",
+        encoding="utf-8",
+    )
+    data = proj / "data"
+    data.mkdir(parents=True, exist_ok=True)
+    (data / "results.json").write_text(
+        json.dumps({"mean": 2.5, "n": 4}), encoding="utf-8"
+    )
+
+
+def test_verify_artifact_bundle_rejects_fabrication(tmp_path: Path) -> None:
+    """The shared semantic gate rejects a fabricated bundle (fabrication reason)
+    and accepts a real-numbers bundle."""
+    fab = _mk_project_dir(tmp_path, "PROJ-604-fab")
+    _write_fabricated_bundle(fab)
+    gate = verify_artifact_bundle(fab, ["data/results.json"])
+    assert gate.ok is False
+    assert "fabricat" in gate.reason().lower()
+
+    clean = _mk_project_dir(tmp_path, "PROJ-604-clean")
+    _write_clean_bundle(clean)
+    good = verify_artifact_bundle(clean, ["data/results.json"])
+    assert good.ok is True, good.reason()
+
+
+def test_offload_complete_rejects_fabricated_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A completed Kaggle offload whose retrieved bundle is fabricated must NOT
+    advance to research_complete: it rejoins the SAME semantic gate, is rejected,
+    and the project is not recorded ok (mirrors recon-F _probe_offload.py).
+
+    Note: the local-fallback ``execution_status.record`` writes a fresh record
+    that does not carry the offload sub-record, so 'marked failed' is observed as
+    'no longer pending' (+ not-ok) rather than a literal status=='failed' string.
+    """
+    pid = "PROJ-777-offload"
+    proj = _mk_project_dir(tmp_path, pid)
+    _write_fabricated_bundle(proj)
+
+    # An offload kernel is in flight.
+    execution_status.record_offload(
+        pid, status="running", kernel_ref="kref/abc", repo_root=tmp_path
+    )
+
+    # Stub the Kaggle boundary only.
+    monkeypatch.setattr(offload_mod, "poll", lambda ref: "complete")
+    monkeypatch.setattr(
+        offload_mod, "retrieve", lambda ref, pd: ["data/results.json"]
+    )
+    monkeypatch.setattr(offload_mod, "is_available", lambda: False)
+    monkeypatch.setattr(offload_mod, "dispatch", lambda pd, repo: None)
+
+    advanced = _poll_offload(proj, tmp_path)
+
+    assert advanced is False
+    assert execution_status.is_ok(pid, repo_root=tmp_path) is False
+    # Not stuck polling and not advanced: the fabricated bundle was rejected.
+    assert execution_status.is_offload_pending(pid, repo_root=tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# D2 — execution repair reopens tasks via the SSoT feature-dir pointer
+# ---------------------------------------------------------------------------
+
+
+def test_reopen_uses_pointer_feature_dir(tmp_path: Path) -> None:
+    """A multi-cycle project (specs/001-old + specs/010-current) must reopen the
+    failing task in the pointer-canonical CURRENT dir, leaving the stale first-
+    glob dir untouched (mirror image of the recon-A repro)."""
+    pid = "PROJ-002-pointer"
+    proj = _mk_project_dir(tmp_path, pid)
+    (tmp_path / "state" / "projects").mkdir(parents=True, exist_ok=True)
+
+    task_line = "- [x] T001 run code/analysis.py to produce results\n"
+    old_dir = proj / "specs" / "001-old"
+    cur_dir = proj / "specs" / "010-current"
+    old_dir.mkdir(parents=True)
+    cur_dir.mkdir(parents=True)
+    (old_dir / "tasks.md").write_text(task_line, encoding="utf-8")
+    (cur_dir / "tasks.md").write_text(task_line, encoding="utf-8")
+
+    # Canonical state: the research pointer names 010-current (NOT the first glob).
+    now = datetime.now(UTC)
+    project = Project(
+        id=pid,
+        title="pointer regression",
+        field="test",
+        current_stage=Stage.IN_PROGRESS,
+        created_at=now,
+        updated_at=now,
+        speckit_research_dir=f"projects/{pid}/specs/010-current",
+    )
+    project_store.save(project, repo_root=tmp_path)
+
+    res = AnalysisRunResult(
+        ok=False,
+        commands=[
+            RunCommandResult(
+                "python code/analysis.py", False, 1, 0.5, False,
+                "NameError: name 'sys' is not defined",
+            ),
+        ],
+    )
+
+    reopened = _reopen_failing_tasks(proj, res)
+
+    cur_after = (cur_dir / "tasks.md").read_text(encoding="utf-8")
+    old_after = (old_dir / "tasks.md").read_text(encoding="utf-8")
+    assert reopened >= 1
+    assert "- [ ] T001" in cur_after, "the pointer-canonical dir was not reopened"
+    assert "- [x] T001" in old_after, "the STALE first-glob dir must stay untouched"
+
+
+# ---------------------------------------------------------------------------
+# D3 — routing ignores a stale/cross-stage kickback, never an illegal edge
+# ---------------------------------------------------------------------------
+
+
+def test_decide_next_stage_ignores_stale_cross_stage_kickback(
+    tmp_path: Path
+) -> None:
+    """A leftover convergence sentinel naming to_stage=paper_planned, consumed at
+    PAPER_ANALYZED (whose only legal edge is PAPER_IN_PROGRESS), must be IGNORED —
+    _decide_next_stage returns the LEGAL edge, never paper_planned, never raises.
+    Also pins the edge-registry invariant for the recorded advance-error pairs."""
+    # The invariant that made the recorded advance_errors illegal in the first
+    # place: none of these cross-stage sentinel edges are valid transitions.
+    illegal_pairs = [
+        (Stage.PAPER_ANALYZED, Stage.PAPER_PLANNED),  # PROJ-575, 601
+        (Stage.IN_PROGRESS, Stage.CLARIFIED),         # PROJ-577, 606
+        (Stage.IN_PROGRESS, Stage.SPECIFIED),         # PROJ-644
+    ]
+    for src, dst in illegal_pairs:
+        assert is_valid_transition(src, dst) is False, f"{src} -> {dst}"
+
+    pid = "PROJ-575-stale-kb"
+    proj = _mk_project_dir(tmp_path, pid)
+    # A paper project at PAPER_ANALYZED (schema requires the paper pointer set).
+    now = datetime.now(UTC)
+    project = Project(
+        id=pid,
+        title="stale kickback regression",
+        field="test",
+        current_stage=Stage.PAPER_ANALYZED,
+        created_at=now,
+        updated_at=now,
+        speckit_paper_dir=f"projects/{pid}/paper/specs/001-paper",
+    )
+
+    # Seed a STALE paper-side kickback sentinel targeting paper_planned.
+    mem = proj / "paper" / ".specify" / "memory"
+    mem.mkdir(parents=True, exist_ok=True)
+    (mem / "convergence_kickback.yaml").write_text(
+        yaml.safe_dump({
+            "to_stage": "paper_planned",
+            "stage": "paper_tasks",
+            "reason": "paper tasks panel did not converge",
+            "worst_severity": "requirement",
+            "unresolved_concerns": [],
+        }),
+        encoding="utf-8",
+    )
+
+    result = graph._decide_next_stage(project, proj, repo_root=tmp_path)
+
+    assert result != Stage.PAPER_PLANNED
+    assert result == Stage.PAPER_IN_PROGRESS
+    assert is_valid_transition(project.current_stage, result) is True

--- a/tests/unit/test_paper_resolver_pointer.py
+++ b/tests/unit/test_paper_resolver_pointer.py
@@ -1,0 +1,140 @@
+"""Paper-agent feature-dir pointer resolution (issue #1139, defect D2).
+
+THE BUG: ``PaperWritingAgent`` and ``PaperFigureGenerationAgent`` resolved the
+paper-stage spec/plan by globbing ``paper/specs/*/spec.md`` (or ``plan.md``) and
+picking the FIRST (alphabetically-oldest) match. On a project that cycled
+through convergence kickbacks the paper feature dirs accumulate
+(``001-old``, ``010-current``); first-glob then resolves the STALE prior cycle
+while the pipeline's authoritative ``speckit_paper_dir`` pointer references the
+current one — so the writer/figure agents composed against a superseded
+spec/plan (spec 023 defect #17).
+
+These tests build a REAL tmp project tree with TWO paper feature dirs and a REAL
+saved Project whose pointer references the CURRENT (010-current) dir, then call
+the agents' real ``build_messages`` and assert the CURRENT spec/plan text is
+injected — never the stale 001-old text.
+
+The fallback in ``feature_dir_for`` picks the FIRST candidate (001-old here), so
+selecting 010-current can only happen via the pointer — this is a strict
+pointer-first assertion, not merely "pick the latest".
+"""
+
+from __future__ import annotations
+
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+
+from llmxive.agents.base import AgentContext
+from llmxive.agents.paper_figure_generation import PaperFigureGenerationAgent
+from llmxive.agents.paper_writing import PaperWritingAgent
+from llmxive.config import repo_root as _repo_root
+from llmxive.state import project as project_store
+from llmxive.types import AgentRegistryEntry, Project, Stage
+
+# The real repo root, captured before any per-test LLMXIVE_REPO_ROOT override,
+# so we can copy the genuine prompt templates into the hermetic tmp repo.
+_REAL_REPO = _repo_root()
+
+PROJECT_ID = "PROJ-900-paperptr"
+OLD_SPEC_MARK = "STALE-OLD-SPEC-001-do-not-use"
+OLD_PLAN_MARK = "STALE-OLD-PLAN-001-do-not-use"
+CUR_SPEC_MARK = "CURRENT-SPEC-010-pointer-target"
+CUR_PLAN_MARK = "CURRENT-PLAN-010-pointer-target"
+
+
+def _build_repo(tmp_path: Path) -> Path:
+    """Create a hermetic repo with two paper feature dirs + a pointer → 010."""
+    repo = tmp_path
+    # Real prompt templates (build_messages renders them via repo_root).
+    (repo / "agents" / "prompts").mkdir(parents=True)
+    for name in ("paper_writing.md", "paper_figure_generation.md"):
+        shutil.copyfile(
+            _REAL_REPO / "agents" / "prompts" / name,
+            repo / "agents" / "prompts" / name,
+        )
+
+    paper_specs = repo / "projects" / PROJECT_ID / "paper" / "specs"
+    old = paper_specs / "001-old"
+    current = paper_specs / "010-current"
+    old.mkdir(parents=True)
+    current.mkdir(parents=True)
+    (old / "spec.md").write_text(f"# {OLD_SPEC_MARK}\n", encoding="utf-8")
+    (old / "plan.md").write_text(f"# {OLD_PLAN_MARK}\n", encoding="utf-8")
+    (current / "spec.md").write_text(f"# {CUR_SPEC_MARK}\n", encoding="utf-8")
+    (current / "plan.md").write_text(f"# {CUR_PLAN_MARK}\n", encoding="utf-8")
+
+    (repo / "state" / "projects").mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC)
+    project = Project(
+        id=PROJECT_ID,
+        title="Pointer resolution demo",
+        field="testing",
+        current_stage=Stage.PAPER_IN_PROGRESS,
+        points_research={},
+        points_paper={},
+        created_at=now,
+        updated_at=now,
+        artifact_hashes={},
+        speckit_paper_dir=f"projects/{PROJECT_ID}/paper/specs/010-current",
+    )
+    project_store.save(project, repo_root=repo)
+    return repo
+
+
+def _entry(name: str, prompt_path: str) -> AgentRegistryEntry:
+    return AgentRegistryEntry(
+        name=name,
+        purpose="paper feature-dir pointer resolution test",
+        prompt_path=prompt_path,
+        prompt_version="1.0.0",
+        default_backend="dartmouth",
+        fallback_backends=[],
+        default_model="openai.gpt-oss-120b",
+        wall_clock_budget_seconds=60,
+        paid_opt_in=False,
+    )
+
+
+def _user_message(messages: list) -> str:
+    return next(m.content for m in messages if m.role == "user")
+
+
+def test_paper_writing_uses_pointer_spec_and_plan(tmp_path: Path, monkeypatch) -> None:
+    repo = _build_repo(tmp_path)
+    monkeypatch.setenv("LLMXIVE_REPO_ROOT", str(repo))
+
+    ctx = AgentContext(
+        project_id=PROJECT_ID,
+        run_id="r",
+        task_id="T001",
+        inputs=[],
+        metadata={"target_section": "introduction", "target_path": ""},
+    )
+    agent = PaperWritingAgent(_entry("paper_writer", "agents/prompts/paper_writing.md"))
+    user = _user_message(agent.build_messages(ctx))
+
+    assert CUR_SPEC_MARK in user, "writer must use the pointer (010-current) spec.md"
+    assert CUR_PLAN_MARK in user, "writer must use the pointer (010-current) plan.md"
+    assert OLD_SPEC_MARK not in user, "writer must NOT use the stale (001-old) spec.md"
+    assert OLD_PLAN_MARK not in user, "writer must NOT use the stale (001-old) plan.md"
+
+
+def test_paper_figure_generation_uses_pointer_plan(tmp_path: Path, monkeypatch) -> None:
+    repo = _build_repo(tmp_path)
+    monkeypatch.setenv("LLMXIVE_REPO_ROOT", str(repo))
+
+    ctx = AgentContext(
+        project_id=PROJECT_ID,
+        run_id="r",
+        task_id="T002",
+        inputs=[],
+        metadata={"figure_id": "fig1", "target_path": "", "data_source_path": ""},
+    )
+    agent = PaperFigureGenerationAgent(
+        _entry("paper_figure", "agents/prompts/paper_figure_generation.md")
+    )
+    user = _user_message(agent.build_messages(ctx))
+
+    assert CUR_PLAN_MARK in user, "figure agent must use the pointer (010-current) plan.md"
+    assert OLD_PLAN_MARK not in user, "figure agent must NOT use the stale (001-old) plan.md"

--- a/tests/unit/test_plan_time_discovery.py
+++ b/tests/unit/test_plan_time_discovery.py
@@ -1,0 +1,125 @@
+"""D11 — the planner runs PROACTIVE strong discovery at plan time.
+
+Locks ``plan_cmd.PlannerAgent.mechanical_step``: it invokes the same
+records+field HARD-verifier the execution stage uses (``discover_data_source``
+via ``ensure_discovered_source``), sharing the SAME on-disk cache
+(``.specify/memory/discovered_data_source.yaml``), and surfaces the verified
+source to the planner prompt — instead of only the weak reachability resolver.
+It degrades gracefully offline (never crashes a plan run) and writes no dead
+weak-manifest.
+
+Only the discovery + LLM-distill boundaries and the setup-plan script runner are
+stubbed; the wiring under test (shared cache, block rendering) runs for real.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+import llmxive.execution.data_source as ds
+import llmxive.librarian.data_source_discovery as dsd
+import llmxive.speckit.plan_cmd as plan_cmd
+from llmxive.librarian.data_source_discovery import VerifiedSource
+from llmxive.librarian.dataset_resolver import ResolvedDatasets
+from llmxive.speckit.plan_cmd import PlannerAgent
+from llmxive.speckit.slash_command import SlashCommandContext
+from llmxive.types import BackendName
+
+
+def _make_ctx(project_id: str, proj: Path, tmp_path: Path) -> SlashCommandContext:
+    return SlashCommandContext(
+        project_id=project_id, project_dir=proj, run_id="r", task_id="t",
+        inputs=[], expected_outputs=[], prompt_template_path=tmp_path / "x.md",
+        default_backend=BackendName.DARTMOUTH, fallback_backends=[],
+        default_model="m", prompt_version="1.0.0", agent_name="planner",
+    )
+
+
+def test_mechanical_step_uses_strong_discovery_and_shares_cache(tmp_path, monkeypatch):
+    proj = tmp_path / "projects" / "PROJ-STRONG"
+    fdir = proj / "specs" / "001-x"
+    fdir.mkdir(parents=True)
+    (fdir / "spec.md").write_text("- **FR-001**: load the KnotInfo dataset\n")
+
+    monkeypatch.setattr(PlannerAgent, "_feature_dir", lambda self, ctx: fdir)
+    monkeypatch.setattr(plan_cmd, "run_script", lambda *a, **k: {"ok": True})
+    # Weak resolver contributes nothing here (avoid network); the strong verified
+    # discovery is the path under test.
+    monkeypatch.setattr(
+        plan_cmd, "resolve_datasets", lambda *a, **k: ResolvedDatasets(datasets=[])
+    )
+
+    calls: list[str] = []
+
+    def fake_discover(intent, required_fields=None):
+        calls.append(intent)
+        return VerifiedSource(
+            kind="pypi_package", ref="database-knotinfo",
+            access_python="import database_knotinfo", record_count=250,
+            sample_fields=["crossing_number"], field_coverage=1.0,
+        )
+
+    monkeypatch.setattr(dsd, "discover_data_source", fake_discover)
+    monkeypatch.setattr(
+        ds, "_distill_data_need", lambda raw: ("knotinfo dataset", ["crossing_number"])
+    )
+
+    ctx = _make_ctx("PROJ-STRONG", proj, tmp_path)
+    mech = PlannerAgent().mechanical_step(ctx)
+
+    # Proactive strong discovery actually ran at plan time.
+    assert calls, "discover_data_source was not invoked at plan time"
+    # It shares the SAME execution cache on disk.
+    cache = proj / ".specify" / "memory" / "discovered_data_source.yaml"
+    assert cache.exists()
+    assert yaml.safe_load(cache.read_text())["status"] == "verified"
+    # The verified source is surfaced to the planner block.
+    assert "database-knotinfo" in mech["dataset_block"]
+    # No dead weak-manifest was written (D7).
+    assert not (proj / ".specify" / "memory" / "resolved_datasets.yaml").exists()
+
+
+def test_execution_reads_the_plan_time_cache(tmp_path, monkeypatch):
+    """The execution backstop reuses the plan-time verified record (shared cache)
+    without re-discovering."""
+    proj = tmp_path / "projects" / "PROJ-SHARE"
+    fdir = proj / "specs" / "001-x"
+    fdir.mkdir(parents=True)
+    (fdir / "spec.md").write_text("- **FR-001**: load the KnotInfo dataset\n")
+
+    monkeypatch.setattr(PlannerAgent, "_feature_dir", lambda self, ctx: fdir)
+    monkeypatch.setattr(plan_cmd, "run_script", lambda *a, **k: {"ok": True})
+    monkeypatch.setattr(
+        plan_cmd, "resolve_datasets", lambda *a, **k: ResolvedDatasets(datasets=[])
+    )
+    calls: list[int] = []
+    monkeypatch.setattr(
+        dsd, "discover_data_source",
+        lambda intent, required_fields=None: (calls.append(1), VerifiedSource(
+            kind="pypi_package", ref="database-knotinfo",
+            access_python="import database_knotinfo", record_count=250,
+            sample_fields=["crossing_number"], field_coverage=1.0,
+        ))[1],
+    )
+    monkeypatch.setattr(
+        ds, "_distill_data_need", lambda raw: ("knotinfo dataset", ["crossing_number"])
+    )
+
+    ctx = _make_ctx("PROJ-SHARE", proj, tmp_path)
+    PlannerAgent().mechanical_step(ctx)          # plan time: discovers + caches
+    rec = ds.ensure_discovered_source(proj)      # execution backstop: reads cache
+    assert rec["status"] == "verified" and rec["ref"] == "database-knotinfo"
+    assert len(calls) == 1  # execution reused the plan-time cache, no re-discovery
+
+
+def test_plan_time_block_degrades_offline(tmp_path, monkeypatch):
+    proj = tmp_path / "projects" / "PROJ-OFF"
+    proj.mkdir(parents=True)
+
+    def boom(project_dir):
+        raise RuntimeError("offline / no backend")
+
+    monkeypatch.setattr(ds, "ensure_discovered_source", boom)
+    # Must not raise — a plan run never crashes on data discovery.
+    assert PlannerAgent._plan_time_discovered_block(proj) == ""

--- a/tests/unit/test_project_lease.py
+++ b/tests/unit/test_project_lease.py
@@ -1,0 +1,122 @@
+"""Real-flock tests for the per-project advisory lease (issue #1139, defect D16).
+
+Per Constitution Principle III these use REAL ``fcntl.flock`` on REAL files
+under pytest ``tmp_path`` — no mocks. They assert the three properties the
+scheduler will rely on:
+
+* acquiring the same project lease twice in one process fails the second
+  (non-blocking) acquire (yields ``False``) — the in-host mutual-exclusion;
+* releasing the lease (leaving the with-block) frees it for the next acquire;
+* different project ids are independent (two projects lease concurrently).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+from llmxive.pipeline.project_lease import project_lease
+
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("fcntl") is None,
+    reason="fcntl unavailable (non-POSIX)",
+)
+
+
+def test_yields_true_when_uncontended(tmp_path: Path) -> None:
+    """A fresh project acquires cleanly and yields True."""
+    with project_lease("PROJ-001-alpha", repo_root=tmp_path) as acquired:
+        assert acquired is True
+
+
+def test_lease_file_created_under_state_leases(tmp_path: Path) -> None:
+    """The lock file lands in state/leases/<project_id>.lock."""
+    with project_lease("PROJ-001-alpha", repo_root=tmp_path) as acquired:
+        assert acquired is True
+        assert (tmp_path / "state" / "leases" / "PROJ-001-alpha.lock").is_file()
+
+
+def test_same_project_twice_second_is_false(tmp_path: Path) -> None:
+    """THE core property: while one block holds the lease, a second
+    non-blocking acquire of the SAME project id yields False (not held).
+
+    fcntl.flock is tied to the open file description, so two independent
+    os.open calls of the same lock file conflict even within one process."""
+    with project_lease("PROJ-042-beta", repo_root=tmp_path) as first:
+        assert first is True
+        with project_lease("PROJ-042-beta", repo_root=tmp_path) as second:
+            assert second is False
+
+
+def test_releasing_frees_the_lease(tmp_path: Path) -> None:
+    """After the holding with-block exits, the project can be re-leased."""
+    with project_lease("PROJ-007-gamma", repo_root=tmp_path) as first:
+        assert first is True
+    # Outer block released — a fresh non-blocking acquire must now succeed.
+    with project_lease("PROJ-007-gamma", repo_root=tmp_path) as again:
+        assert again is True
+
+
+def test_different_projects_are_independent(tmp_path: Path) -> None:
+    """Two DIFFERENT project ids lease concurrently — no cross-project block."""
+    with project_lease("PROJ-100-x", repo_root=tmp_path) as a:
+        assert a is True
+        with project_lease("PROJ-200-y", repo_root=tmp_path) as b:
+            assert b is True
+
+
+def test_lease_released_on_exception(tmp_path: Path) -> None:
+    """If the with-block raises, the lease is released (no deadlock on retry)."""
+    with pytest.raises(RuntimeError, match="boom"):
+        with project_lease("PROJ-303-delta", repo_root=tmp_path) as acquired:
+            assert acquired is True
+            raise RuntimeError("boom")
+    # Must re-acquire immediately — the lease was freed despite the exception.
+    with project_lease("PROJ-303-delta", repo_root=tmp_path) as again:
+        assert again is True
+
+
+def test_blocking_acquire_succeeds_when_free(tmp_path: Path) -> None:
+    """blocking=True yields True immediately when uncontended."""
+    with project_lease("PROJ-404-eps", repo_root=tmp_path, blocking=True) as acquired:
+        assert acquired is True
+
+
+def test_cross_process_mutual_exclusion(tmp_path: Path) -> None:
+    """REAL cross-process guarantee: a forked child cannot acquire a project
+    the parent holds, and CAN acquire a different one. This is the scenario
+    the scheduler relies on (two in-host ticks racing for one project)."""
+    if not hasattr(os, "fork"):
+        pytest.skip("os.fork not available (non-POSIX)")
+
+    # Parent takes and HOLDS the lease on PROJ-500 for the child's lifetime.
+    with project_lease("PROJ-500-held", repo_root=tmp_path) as held:
+        assert held is True
+
+        r_same, w_same = os.pipe()
+        r_other, w_other = os.pipe()
+        pid = os.fork()
+        if pid == 0:  # child
+            os.close(r_same)
+            os.close(r_other)
+            try:
+                with project_lease("PROJ-500-held", repo_root=tmp_path) as c_same:
+                    os.write(w_same, b"1" if c_same else b"0")
+                with project_lease("PROJ-501-free", repo_root=tmp_path) as c_other:
+                    os.write(w_other, b"1" if c_other else b"0")
+            finally:
+                os._exit(0)
+
+        os.close(w_same)
+        os.close(w_other)
+        same = os.read(r_same, 1)
+        other = os.read(r_other, 1)
+        os.close(r_same)
+        os.close(r_other)
+        os.waitpid(pid, 0)
+
+    assert same == b"0", "child must NOT acquire a project the parent holds"
+    assert other == b"1", "child MUST acquire a different, free project"

--- a/tests/unit/test_proofreader_staleness.py
+++ b/tests/unit/test_proofreader_staleness.py
@@ -1,0 +1,149 @@
+"""Proofreader verdicts are bound to the source they were computed against.
+
+Issue #1139 D13: the recon probe (PROBE2) showed a stored "clean" verdict stayed
+"clean" after the paper source was rewritten to introduce typos — presence of a
+cached PASS was mistaken for a fresh verified verdict. ``proofreader_clean`` now
+re-derives the CURRENT source hash and only reports clean when the stored verdict
+still matches the source, the verifier version, and a freshness TTL.
+
+These are REAL tests: they run the production store path
+(``ProofreaderAgent.handle_response``) against real files on disk and read the
+verdict back through the production ``proofreader_clean`` gate.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import yaml
+
+from llmxive.agents.base import AgentContext
+from llmxive.agents.proofreader import (
+    PROOFREADER_VERDICT_TTL,
+    PROOFREADER_VERIFIER_VERSION,
+    ProofreaderAgent,
+    _source_hash,
+    proofreader_clean,
+)
+from llmxive.backends.base import ChatResponse
+
+_CLEAN_TEX = "\\section{Introduction}\nThis is a well written paragraph.\n"
+
+
+def _write_source(repo: Path, project_id: str, body: str = _CLEAN_TEX) -> Path:
+    src = repo / "projects" / project_id / "paper" / "source"
+    src.mkdir(parents=True, exist_ok=True)
+    (src / "main.tex").write_text(body, encoding="utf-8")
+    return src
+
+
+def _store_clean_verdict(project_id: str) -> list[str]:
+    """Run the real proofreader store path for a ``clean`` verdict.
+
+    ``handle_response`` resolves the repo via ``LLMXIVE_REPO_ROOT`` (set by the
+    caller) and does not touch ``self``, so a bare instance exercises the exact
+    production store code.
+    """
+    ctx = AgentContext(project_id=project_id, run_id="r1", task_id="t1", inputs=[])
+    resp = ChatResponse(
+        text="verdict: clean\nflags: []\n", model="local", backend="local"
+    )
+    agent = object.__new__(ProofreaderAgent)
+    return agent.handle_response(ctx, resp)
+
+
+def _flags_path(repo: Path, project_id: str) -> Path:
+    return (
+        repo / "projects" / project_id / "paper" / ".specify" / "memory"
+        / "proofreader_flags.yaml"
+    )
+
+
+def test_proofreader_clean_invalidated_by_source_edit(tmp_path, monkeypatch):
+    """PROBE2: clean verdict -> edit source -> NOT clean (the D13 regression)."""
+    monkeypatch.setenv("LLMXIVE_REPO_ROOT", str(tmp_path))
+    project_id = "PROJ-777-staleness"
+    src = _write_source(tmp_path, project_id)
+
+    _store_clean_verdict(project_id)
+    assert proofreader_clean(project_id, repo_root=tmp_path) is True
+
+    # Rewrite the source AFTER the clean verdict was recorded (introduce a typo).
+    (src / "main.tex").write_text(
+        "\\section{Introduction}\nThis is a wel written paragrpah.\n", encoding="utf-8"
+    )
+    assert proofreader_clean(project_id, repo_root=tmp_path) is False, (
+        "a stored clean verdict must not survive a later source edit"
+    )
+
+
+def test_proofreader_clean_true_when_source_unchanged(tmp_path, monkeypatch):
+    """The gate is not over-strict: an untouched source stays clean."""
+    monkeypatch.setenv("LLMXIVE_REPO_ROOT", str(tmp_path))
+    project_id = "PROJ-781-fresh"
+    _write_source(tmp_path, project_id)
+    _store_clean_verdict(project_id)
+    assert proofreader_clean(project_id, repo_root=tmp_path) is True
+
+
+def test_proofreader_clean_expires_after_ttl(tmp_path, monkeypatch):
+    """A clean verdict older than the TTL is stale even if the source is intact."""
+    monkeypatch.setenv("LLMXIVE_REPO_ROOT", str(tmp_path))
+    project_id = "PROJ-778-ttl"
+    _write_source(tmp_path, project_id)
+    _store_clean_verdict(project_id)
+
+    assert proofreader_clean(project_id, repo_root=tmp_path) is True
+    expired = datetime.now(UTC) + PROOFREADER_VERDICT_TTL + timedelta(days=1)
+    assert proofreader_clean(project_id, repo_root=tmp_path, now=expired) is False
+
+
+def test_proofreader_clean_invalidated_by_verifier_bump(tmp_path):
+    """A verdict produced by a different verifier version is stale."""
+    project_id = "PROJ-779-verbump"
+    src = _write_source(tmp_path, project_id)
+    doc = {
+        "verdict": "clean",
+        "flags": [],
+        "source_hash": _source_hash(src),
+        "verifier_version": PROOFREADER_VERIFIER_VERSION + "-OLD",
+        "verified_at": datetime.now(UTC).isoformat(),
+    }
+    path = _flags_path(tmp_path, project_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(doc, sort_keys=True), encoding="utf-8")
+    assert proofreader_clean(project_id, repo_root=tmp_path) is False
+
+
+def test_proofreader_clean_rejects_legacy_record_without_provenance(tmp_path):
+    """A legacy verdict (no source hash / version / timestamp) is treated as stale,
+    forcing a bounded re-proofread rather than a silent pass on existence."""
+    project_id = "PROJ-780-legacy"
+    _write_source(tmp_path, project_id)
+    path = _flags_path(tmp_path, project_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump({"verdict": "clean", "flags": []}, sort_keys=True),
+        encoding="utf-8",
+    )
+    assert proofreader_clean(project_id, repo_root=tmp_path) is False
+
+
+def test_proofreader_not_clean_when_flags_present(tmp_path, monkeypatch):
+    """A non-empty flag list is never clean (preserved base behavior), even with a
+    matching source hash."""
+    monkeypatch.setenv("LLMXIVE_REPO_ROOT", str(tmp_path))
+    project_id = "PROJ-782-flagged"
+    src = _write_source(tmp_path, project_id)
+    doc = {
+        "verdict": "clean",
+        "flags": [{"location": "main.tex:1", "issue": "typo"}],
+        "source_hash": _source_hash(src),
+        "verifier_version": PROOFREADER_VERIFIER_VERSION,
+        "verified_at": datetime.now(UTC).isoformat(),
+    }
+    path = _flags_path(tmp_path, project_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(doc, sort_keys=True), encoding="utf-8")
+    assert proofreader_clean(project_id, repo_root=tmp_path) is False

--- a/tests/unit/test_reference_gate_positive.py
+++ b/tests/unit/test_reference_gate_positive.py
@@ -1,0 +1,114 @@
+"""The reference gate is a POSITIVE gate: advance only when ALL citations verify.
+
+Issue #1139 D15: ``has_blocking_citations`` previously blocked ONLY ``UNREACHABLE``
+/ ``MISMATCH`` citations, so a ``PENDING`` (present-but-unverified) reference
+silently advanced research_review -> research_accepted / paper_review ->
+paper_accepted. The gate is inverted: a project may advance ONLY when EVERY
+citation is currently ``VERIFIED``; ``PENDING`` / ``UNREACHABLE`` / ``MISMATCH``
+/ any non-verified status blocks (bounded retry / substitution upstream).
+
+REAL tests: real ``Citation`` records are persisted through the production
+citations store and read back through the production gate.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from llmxive.agents.reference_validator import (
+    has_blocking_citations,
+    project_has_unverified_for_review,
+)
+from llmxive.state import citations as citations_store
+from llmxive.types import (
+    Citation,
+    CitationKind,
+    Project,
+    Stage,
+    VerificationStatus,
+)
+
+_PROJECT_ID = "PROJ-777-gate"
+
+
+def _cite(status: VerificationStatus, *, cite_id: str = "c-001") -> Citation:
+    return Citation(
+        cite_id=cite_id,
+        artifact_path=f"projects/{_PROJECT_ID}/specs/plan.md",
+        artifact_hash="0" * 64,
+        kind=CitationKind.URL,
+        value="https://example.com/some/paper",
+        cited_title="A Real Paper Title About Something",
+        verification_status=status,
+        verified_at=datetime.now(UTC),
+    )
+
+
+def _save(repo: Path, cits: list[Citation]) -> None:
+    citations_store.save(_PROJECT_ID, cits, repo_root=repo)
+
+
+def _project() -> Project:
+    now = datetime.now(UTC)
+    return Project(
+        id=_PROJECT_ID,
+        title="Gate fixture",
+        field="testing",
+        current_stage=Stage.RESEARCH_REVIEW,
+        created_at=now,
+        updated_at=now,
+        speckit_research_dir=f"projects/{_PROJECT_ID}/specs/001-x",
+    )
+
+
+def test_pending_blocks_the_gate(tmp_path):
+    """A PENDING citation is present-but-unverified -> BLOCKS (positive gate)."""
+    _save(tmp_path, [_cite(VerificationStatus.PENDING)])
+    assert has_blocking_citations(_PROJECT_ID, repo_root=tmp_path) is True
+
+
+def test_all_verified_advances(tmp_path):
+    """Every citation VERIFIED -> the gate does not block."""
+    _save(
+        tmp_path,
+        [
+            _cite(VerificationStatus.VERIFIED, cite_id="c-001"),
+            _cite(VerificationStatus.VERIFIED, cite_id="c-002"),
+        ],
+    )
+    assert has_blocking_citations(_PROJECT_ID, repo_root=tmp_path) is False
+
+
+def test_one_pending_among_verified_blocks(tmp_path):
+    """A single non-verified citation blocks even when the rest verify."""
+    _save(
+        tmp_path,
+        [
+            _cite(VerificationStatus.VERIFIED, cite_id="c-001"),
+            _cite(VerificationStatus.PENDING, cite_id="c-002"),
+        ],
+    )
+    assert has_blocking_citations(_PROJECT_ID, repo_root=tmp_path) is True
+
+
+def test_unreachable_and_mismatch_still_block(tmp_path):
+    """The anti-fabrication states remain blocking under the positive gate."""
+    _save(tmp_path, [_cite(VerificationStatus.UNREACHABLE)])
+    assert has_blocking_citations(_PROJECT_ID, repo_root=tmp_path) is True
+    _save(tmp_path, [_cite(VerificationStatus.MISMATCH)])
+    assert has_blocking_citations(_PROJECT_ID, repo_root=tmp_path) is True
+
+
+def test_no_citations_does_not_block(tmp_path):
+    """A project with no external references has nothing to verify -> advances."""
+    _save(tmp_path, [])
+    assert has_blocking_citations(_PROJECT_ID, repo_root=tmp_path) is False
+
+
+def test_project_wrapper_matches_positive_gate(tmp_path):
+    """project_has_unverified_for_review shares the positive-gate semantics."""
+    _save(tmp_path, [_cite(VerificationStatus.PENDING)])
+    assert project_has_unverified_for_review(_project(), repo_root=tmp_path) is True
+    _save(tmp_path, [_cite(VerificationStatus.VERIFIED)])
+    assert project_has_unverified_for_review(_project(), repo_root=tmp_path) is False

--- a/tests/unit/test_render_feedback_kind.py
+++ b/tests/unit/test_render_feedback_kind.py
@@ -1,0 +1,61 @@
+"""D10 — the execution-feedback renderer must branch on the source KIND.
+
+Locks ``data_source.render_feedback_block``: a ``pypi_package`` gets a
+``pip install`` line; a ``data_url`` gets a download/stream recipe and is NEVER
+told to ``pip install <url>``; and no verified block ever claims "loads 0 real
+records".
+"""
+from __future__ import annotations
+
+from llmxive.execution.data_source import render_feedback_block
+
+
+def test_pypi_render_has_pip_install():
+    rec = {
+        "status": "verified", "kind": "pypi_package", "ref": "database-knotinfo",
+        "access_python": "import database_knotinfo", "record_count": 250,
+        "sample_fields": ["crossing_number"],
+    }
+    block = render_feedback_block(rec)
+    assert "pip install database-knotinfo" in block
+    assert "requirements.txt" in block
+    assert "250" in block
+    assert "0 real records" not in block
+
+
+def test_data_url_render_no_pip_install():
+    url = "https://example.org/data/knots.csv"
+    rec = {
+        "status": "verified", "kind": "data_url", "ref": url,
+        "access_python": "import pandas as pd\npd.read_csv(url)", "record_count": 42,
+        "sample_fields": ["a", "b"],
+    }
+    block = render_feedback_block(rec)
+    # Never instruct installing a URL as a package.
+    assert "pip install http" not in block.lower()
+    assert "requirements.txt" not in block
+    # The URL is offered as a download/stream target instead.
+    assert f"`{url}`" in block
+    assert "download" in block.lower() or "stream" in block.lower()
+    assert "42" in block
+    assert "0 real records" not in block
+
+
+def test_missing_kind_defaults_to_pypi():
+    # A legacy verified record without a ``kind`` still renders the pip path.
+    rec = {"status": "verified", "ref": "somepkg", "access_python": "import somepkg",
+           "record_count": 7}
+    block = render_feedback_block(rec)
+    assert "pip install somepkg" in block
+
+
+def test_non_verified_records_render_empty():
+    assert render_feedback_block(None) == ""
+    assert render_feedback_block({"status": "none"}) == ""
+    assert render_feedback_block({"status": "error", "transient": True}) == ""
+
+
+def test_never_emits_zero_records_phrasing():
+    rec = {"status": "verified", "kind": "pypi_package", "ref": "pkg",
+           "access_python": "import pkg", "record_count": 5}
+    assert "0 real records" not in render_feedback_block(rec)

--- a/tests/unit/test_scheduler_honors_backoff.py
+++ b/tests/unit/test_scheduler_honors_backoff.py
@@ -1,0 +1,117 @@
+"""The scheduler honours the advance-error ledger (issue #1139, defect D5).
+
+``_eligible_candidates`` must EXCLUDE a project whose typed ledger record
+(:mod:`llmxive.pipeline.advance_ledger`) is still holding it out of scheduling —
+inside a transient backoff window, or in a rerouted/terminal disposition — and
+INCLUDE it again once the backoff elapses. A terminal/invariant record is never
+resurrected by backoff, and a record for a stage the project has since left is
+stale and ignored. Real project YAMLs + real ledger files (no mocks).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from llmxive.pipeline import advance_ledger as al
+from llmxive.pipeline import scheduler
+from llmxive.state import project as project_store
+from llmxive.types import Project, Stage
+
+
+def _make(repo: Path, pid: str, stage: Stage = Stage.PROJECT_INITIALIZED) -> Project:
+    now = datetime.now(UTC)
+    p = Project(
+        id=pid, title=pid, field="test", current_stage=stage,
+        created_at=now, updated_at=now, artifact_hashes={},
+    )
+    project_store.save(p, repo_root=repo)
+    return p
+
+
+def _repo(tmp_path: Path) -> Path:
+    for sub in ("projects", "run-log", "locks"):
+        (tmp_path / "state" / sub).mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def _eligible_ids(repo: Path) -> set[str]:
+    return {p.id for p in scheduler._eligible_candidates(repo_root=repo, stage=None)}
+
+
+def test_backoff_excludes_then_includes(tmp_path) -> None:
+    repo = _repo(tmp_path)
+    chain = "every backend in chain ['dartmouth', 'local'] failed"
+
+    # A: transient failure recorded NOW -> retry_after in the future -> HELD.
+    a = _make(repo, "PROJ-810-a")
+    al.record_failure(a, RuntimeError(chain), repo_root=repo, now=datetime.now(UTC))
+
+    # B: transient failure recorded 2 days ago -> retry_after long past -> ELIGIBLE.
+    b = _make(repo, "PROJ-811-b")
+    al.record_failure(
+        b, RuntimeError(chain), repo_root=repo,
+        now=datetime.now(UTC) - timedelta(days=2),
+    )
+
+    # C: no ledger record at all -> ELIGIBLE.
+    _make(repo, "PROJ-812-c")
+
+    ids = _eligible_ids(repo)
+    assert "PROJ-810-a" not in ids  # excluded: inside backoff window
+    assert "PROJ-811-b" in ids  # included: backoff elapsed
+    assert "PROJ-812-c" in ids  # included: no record
+
+
+def test_terminal_and_rerouted_records_are_held_not_resurrected(tmp_path) -> None:
+    repo = _repo(tmp_path)
+
+    # D: invariant (invalid transition) -> terminal, no retry_after -> HELD.
+    d = _make(repo, "PROJ-820-d", Stage.PROJECT_INITIALIZED)
+    al.record_failure(
+        d, RuntimeError("invalid transition in_progress -> clarified"), repo_root=repo
+    )
+
+    # E: permanent (dead reference) -> rerouted, no retry_after -> HELD.
+    e = _make(repo, "PROJ-821-e")
+    al.record_failure(
+        e, RuntimeError("research.md reference is unreachable: 'https://x/' (HTTP 404)"),
+        repo_root=repo,
+    )
+
+    ids = _eligible_ids(repo)
+    assert "PROJ-820-d" not in ids
+    assert "PROJ-821-e" not in ids
+
+    # Force a *past* retry_after onto the terminal record: a terminal disposition
+    # must NOT be resurrected by an elapsed backoff time.
+    rec = al.load_record("PROJ-820-d", repo_root=repo)
+    rec["retry_after"] = (datetime.now(UTC) - timedelta(days=30)).isoformat()
+    al.record_path("PROJ-820-d", repo).write_text(__import__("json").dumps(rec))
+    assert "PROJ-820-d" not in _eligible_ids(repo)  # still held
+
+
+def test_stale_record_for_earlier_stage_is_ignored(tmp_path) -> None:
+    repo = _repo(tmp_path)
+    # Fail at flesh_out_complete (future backoff -> would be held)...
+    f = _make(repo, "PROJ-830-f", Stage.FLESH_OUT_COMPLETE)
+    al.record_failure(
+        f, RuntimeError("every backend in chain ['dartmouth','local'] failed"),
+        repo_root=repo, now=datetime.now(UTC),
+    )
+    assert "PROJ-830-f" not in _eligible_ids(repo)  # held at flesh_out_complete
+
+    # ...then the project advances. The record is now for a stage it has left
+    # -> stale -> ignored -> ELIGIBLE again.
+    _make(repo, "PROJ-830-f", Stage.PROJECT_INITIALIZED)  # re-save at the later stage
+    assert "PROJ-830-f" in _eligible_ids(repo)
+
+
+def test_no_records_is_unchanged_behavior(tmp_path) -> None:
+    # With no ledger dir at all, eligibility is exactly as before (no regressions).
+    repo = _repo(tmp_path)
+    _make(repo, "PROJ-840-a")
+    _make(repo, "PROJ-841-b", Stage.FLESH_OUT_COMPLETE)
+    _make(repo, "PROJ-842-posted", Stage.POSTED)  # terminal stage still excluded
+    ids = _eligible_ids(repo)
+    assert ids == {"PROJ-840-a", "PROJ-841-b"}

--- a/tests/unit/test_state_atomic_io.py
+++ b/tests/unit/test_state_atomic_io.py
@@ -1,0 +1,456 @@
+"""Atomic + compare-and-swap state I/O (issue #1139 / defect D19).
+
+Before this work only ``publication.py`` and ``revision_history.py`` wrote
+state atomically (each with a duplicated private ``_atomic_write``); every
+other core state store did a bare ``path.write_text(...)`` and NONE did
+compare-and-swap. This suite exercises the ONE shared helper
+(:mod:`llmxive.state._io`) plus every owned store's public write API with
+REAL tmp files — a crash mid-write must leave the ORIGINAL intact and no
+leftover temp file, a normal write must round-trip, and each store's
+save/write must produce a file its own ``load`` reads back.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from llmxive.state import _io
+from llmxive.state._io import (
+    StaleWriteError,
+    atomic_write_text,
+    atomic_write_text_cas,
+    read_mtime_ns,
+)
+
+# ---------------------------------------------------------------------------
+# (a) mid-write failure leaves the ORIGINAL intact + no leftover temp file
+# ---------------------------------------------------------------------------
+
+
+def test_failed_replace_preserves_original_and_leaves_no_temp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    p = tmp_path / "state.yaml"
+    p.write_text("ORIGINAL", encoding="utf-8")
+
+    def boom(src: object, dst: object) -> None:
+        raise OSError("simulated crash during os.replace")
+
+    # Patch the ``os`` reference the module actually calls through.
+    monkeypatch.setattr(_io.os, "replace", boom)
+
+    with pytest.raises(OSError, match="simulated crash"):
+        atomic_write_text(p, "NEW-CONTENT-THAT-MUST-NOT-LAND")
+
+    # Original untouched — a reader never sees a truncated file.
+    assert p.read_text(encoding="utf-8") == "ORIGINAL"
+    # The temp file was cleaned up (no ``.state.yaml.XXXX`` debris).
+    leftovers = [
+        c.name for c in tmp_path.iterdir() if c.name.startswith(".state.yaml.")
+    ]
+    assert leftovers == [], f"leftover temp files: {leftovers}"
+
+
+def test_failed_write_on_new_path_creates_no_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    p = tmp_path / "sub" / "brand-new.json"
+
+    def boom(src: object, dst: object) -> None:
+        raise OSError("boom")
+
+    monkeypatch.setattr(_io.os, "replace", boom)
+    with pytest.raises(OSError):
+        atomic_write_text(p, "payload")
+
+    assert not p.exists()
+    # No orphan temp file in the freshly-created parent dir either.
+    assert [c for c in (tmp_path / "sub").iterdir()] == []
+
+
+# ---------------------------------------------------------------------------
+# (b) a normal write round-trips (incl. parent-dir creation + overwrite)
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_roundtrips_and_creates_parents(tmp_path: Path) -> None:
+    p = tmp_path / "a" / "b" / "c.txt"
+    atomic_write_text(p, "hello world")
+    assert p.read_text(encoding="utf-8") == "hello world"
+    # Overwrite in place.
+    atomic_write_text(p, "second version")
+    assert p.read_text(encoding="utf-8") == "second version"
+
+
+def test_cas_writes_when_token_is_current(tmp_path: Path) -> None:
+    p = tmp_path / "x.txt"
+    atomic_write_text(p, "v1")
+    atomic_write_text_cas(p, "v2", expected_mtime_ns=read_mtime_ns(p))
+    assert p.read_text(encoding="utf-8") == "v2"
+
+
+def test_cas_accepts_none_token_for_new_file(tmp_path: Path) -> None:
+    p = tmp_path / "new.txt"  # does not exist -> read_mtime_ns would be None
+    atomic_write_text_cas(p, "created", expected_mtime_ns=None)
+    assert p.read_text(encoding="utf-8") == "created"
+
+
+def test_cas_rejects_stale_token_and_keeps_content(tmp_path: Path) -> None:
+    p = tmp_path / "x.txt"
+    atomic_write_text(p, "v1")
+    stale = read_mtime_ns(p)
+    assert stale is not None
+    # Simulate a concurrent writer bumping the mtime after our read.
+    os.utime(p, ns=(stale + 1000, stale + 1000))
+    with pytest.raises(StaleWriteError):
+        atomic_write_text_cas(p, "v2", expected_mtime_ns=stale)
+    assert p.read_text(encoding="utf-8") == "v1"  # newer state preserved
+
+
+# ---------------------------------------------------------------------------
+# project.py — canonical state + compare-and-swap in update()
+# ---------------------------------------------------------------------------
+
+
+def _make_project(project_id: str = "PROJ-001-atomic"):
+    from llmxive.types import Project, Stage
+
+    now = datetime(2026, 7, 15, 12, 0, 0, tzinfo=UTC)
+    return Project(
+        id=project_id,
+        title="Atomic I/O test project",
+        field="computer science",
+        current_stage=Stage.BRAINSTORMED,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def test_project_save_load_roundtrip(tmp_path: Path) -> None:
+    from llmxive.state import project as project_store
+
+    proj = _make_project()
+    project_store.save(proj, repo_root=tmp_path)
+    loaded = project_store.load(proj.id, repo_root=tmp_path)
+    assert loaded.id == proj.id
+    assert loaded.title == proj.title
+
+
+def test_project_save_cas_rejects_stale_mtime(tmp_path: Path) -> None:
+    from llmxive.state import project as project_store
+
+    proj = _make_project()
+    project_store.save(proj, repo_root=tmp_path)
+    path = tmp_path / "state" / "projects" / f"{proj.id}.yaml"
+    stale = read_mtime_ns(path)
+    assert stale is not None
+    # A concurrent tick lands (bump mtime) after we captured ``stale``.
+    os.utime(path, ns=(stale + 1000, stale + 1000))
+    with pytest.raises(StaleWriteError):
+        project_store.save(proj, repo_root=tmp_path, expected_mtime_ns=stale)
+
+
+def test_project_update_merges_and_persists(tmp_path: Path) -> None:
+    from llmxive.state import project as project_store
+
+    proj = _make_project()
+    project_store.save(proj, repo_root=tmp_path)
+    updated = project_store.update(
+        proj.id, {"title": "renamed via update"}, repo_root=tmp_path
+    )
+    assert updated.title == "renamed via update"
+    assert project_store.load(proj.id, repo_root=tmp_path).title == "renamed via update"
+
+
+def test_project_update_retries_once_on_stale_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """update() re-reads + re-applies its partial fields ONCE when the CAS
+    write is rejected, so an overlapping tick cannot make it silently fail."""
+    from llmxive.state import project as project_store
+
+    proj = _make_project()
+    project_store.save(proj, repo_root=tmp_path)
+
+    calls = {"n": 0}
+
+    def flaky_cas(path, content, *, expected_mtime_ns, encoding="utf-8"):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise StaleWriteError("simulated concurrent write")
+        _io.atomic_write_text(path, content, encoding=encoding)
+
+    monkeypatch.setattr(project_store, "atomic_write_text_cas", flaky_cas)
+    updated = project_store.update(
+        proj.id, {"title": "won-the-retry"}, repo_root=tmp_path
+    )
+    assert calls["n"] == 2  # first attempt stale, second succeeds
+    assert updated.title == "won-the-retry"
+    assert project_store.load(proj.id, repo_root=tmp_path).title == "won-the-retry"
+
+
+# ---------------------------------------------------------------------------
+# citations.py
+# ---------------------------------------------------------------------------
+
+
+def test_citations_save_load_roundtrip(tmp_path: Path) -> None:
+    from llmxive.state import citations as citations_store
+    from llmxive.types import Citation
+
+    cite = Citation(
+        cite_id="cite-1",
+        artifact_path="projects/PROJ-001-atomic/paper/main.tex",
+        artifact_hash="a" * 64,
+        kind="doi",
+        value="10.5281/zenodo.1",
+        verification_status="pending",
+    )
+    citations_store.save("PROJ-001-atomic", [cite], repo_root=tmp_path)
+    loaded = citations_store.load("PROJ-001-atomic", repo_root=tmp_path)
+    assert len(loaded) == 1
+    assert loaded[0].cite_id == "cite-1"
+
+
+# ---------------------------------------------------------------------------
+# claims.py
+# ---------------------------------------------------------------------------
+
+
+def test_claims_save_load_roundtrip(tmp_path: Path) -> None:
+    from llmxive.claims.models import Claim, ClaimKind, ClaimStatus
+    from llmxive.state import claims as claims_store
+
+    claim = Claim(
+        claim_id="claim-1",
+        kind=ClaimKind.NUMERIC,
+        raw_text="the accuracy was 0.9",
+        canonical="accuracy = 0.9",
+        context="results section",
+        artifact_path="projects/PROJ-001-atomic/paper/main.tex",
+        source_type="computed",
+        status=ClaimStatus.PENDING,
+        resolved_value=None,
+        evidence=None,
+        resolver=None,
+        attempts=0,
+        updated_at="2026-07-15T00:00:00Z",
+    )
+    claims_store.save("PROJ-001-atomic", [claim], repo_root=tmp_path)
+    loaded = claims_store.load("PROJ-001-atomic", repo_root=tmp_path)
+    assert len(loaded) == 1
+    assert loaded[0].claim_id == "claim-1"
+
+
+# ---------------------------------------------------------------------------
+# results.py
+# ---------------------------------------------------------------------------
+
+
+def test_results_save_load_roundtrip(tmp_path: Path) -> None:
+    import hashlib
+
+    from llmxive.results.receipt import Receipt
+    from llmxive.state import results as results_store
+
+    receipt = Receipt(
+        result_id="r_atomic01",
+        value="42.0",
+        kind="scalar",
+        producer={"script_path": "code/run.py", "code_sha": "abc",
+                  "entrypoint": "main", "seed": 0},
+        inputs={"dataset_id": "ds", "data_sha256": "deadbeef", "params": {}},
+        env_sha="env_sha",
+        captured={"stdout_path": "out.txt", "return_repr": "42.0"},
+        output_sha256=hashlib.sha256(b"42.0").hexdigest(),
+        created_at="2026-07-15T00:00:00Z",
+        hmac="placeholder",
+    )
+    results_store.save("PROJ-001-atomic", receipt, repo_root=tmp_path)
+    loaded = results_store.load("PROJ-001-atomic", "r_atomic01", repo_root=tmp_path)
+    assert loaded is not None
+    assert loaded.result_id == "r_atomic01"
+    assert loaded.value == "42.0"
+
+
+# ---------------------------------------------------------------------------
+# reviews.py
+# ---------------------------------------------------------------------------
+
+
+def test_reviews_write_read_roundtrip(tmp_path: Path) -> None:
+    from llmxive.state import reviews as reviews_store
+    from llmxive.types import BackendName, ReviewerKind, ReviewRecord
+
+    record = ReviewRecord(
+        reviewer_name="paper_reviewer_jargon_police",
+        reviewer_kind=ReviewerKind.LLM,
+        artifact_path="projects/PROJ-001-atomic/paper/metadata.json",
+        artifact_hash="a" * 64,
+        score=0.5,
+        verdict="accept",
+        feedback="looks good",
+        reviewed_at=datetime(2026, 7, 15, tzinfo=UTC),
+        prompt_version="1.1.0",
+        model_name="qwen.qwen3.5-122b",
+        backend=BackendName.DARTMOUTH,
+        action_items=[],
+    )
+    path = reviews_store.write(
+        record,
+        body="Detailed review body.",
+        stage="paper",
+        review_type="paper_review",
+        produced_by_agent=None,
+        repo_root=tmp_path,
+    )
+    back = reviews_store.read(path)
+    assert back.reviewer_name == "paper_reviewer_jargon_police"
+    assert back.verdict == "accept"
+
+
+# ---------------------------------------------------------------------------
+# paper_status.py
+# ---------------------------------------------------------------------------
+
+
+def test_paper_status_save_load_roundtrip(tmp_path: Path) -> None:
+    from llmxive.state import paper_status
+
+    rec = paper_status.record_compile_result(
+        "PROJ-001-atomic",
+        {"ok": True, "strategy": "llmxive-compile",
+         "pdf": "main-llmxive.pdf", "errors": []},
+        repo_root=tmp_path,
+    )
+    assert rec["status"] == paper_status.STATUS_RESTYLED_UNAUDITED
+    loaded = paper_status.load("PROJ-001-atomic", repo_root=tmp_path)
+    assert loaded is not None
+    assert loaded["pdf"] == "main-llmxive.pdf"
+
+
+# ---------------------------------------------------------------------------
+# escalations.py
+# ---------------------------------------------------------------------------
+
+
+def test_escalations_write_list_roundtrip(tmp_path: Path) -> None:
+    from llmxive.state import escalations
+
+    escalations.write_record(
+        escalations.EscalationRecord(
+            project_id="PROJ-001-atomic", stage="plan",
+            loop="convergence-kickback", bound=3, rounds_used=3,
+        ),
+        repo_root=tmp_path,
+    )
+    records = escalations.list_records(repo_root=tmp_path)
+    assert len(records) == 1
+    assert records[0].project_id == "PROJ-001-atomic"
+
+
+# ---------------------------------------------------------------------------
+# runlog.py — the invalid-entry dump is the atomic full-file write; the
+# happy-path append round-trips through the public reader.
+# ---------------------------------------------------------------------------
+
+
+def test_runlog_append_read_roundtrip(tmp_path: Path) -> None:
+    from llmxive.state import runlog
+    from llmxive.types import BackendName, Outcome, RunLogEntry
+
+    entry = RunLogEntry(
+        run_id="run-atomic-1",
+        entry_id="entry-1",
+        agent_name="tasker",
+        project_id="PROJ-001-atomic",
+        task_id="task-1",
+        inputs=[],
+        outputs=["projects/PROJ-001-atomic/specs/001-f/tasks.md"],
+        backend=BackendName.DARTMOUTH,
+        model_name="qwen.qwen3.5-122b",
+        prompt_version="1.0.0",
+        started_at=datetime(2026, 7, 15, tzinfo=UTC),
+        ended_at=datetime(2026, 7, 15, tzinfo=UTC),
+        outcome=Outcome.SUCCESS,
+        cost_estimate_usd=0.0,
+    )
+    runlog.append_entry(entry, repo_root=tmp_path)
+    back = runlog.read_entries("run-atomic-1", repo_root=tmp_path)
+    assert len(back) == 1
+    assert back[0].agent_name == "tasker"
+
+
+# ---------------------------------------------------------------------------
+# publication.py — private _atomic_write deleted; now routes through shared.
+# ---------------------------------------------------------------------------
+
+
+def test_publication_save_load_roundtrip(tmp_path: Path) -> None:
+    from llmxive.state import publication as pub_state
+    from llmxive.types import AuthorEntry, DOIVersion, Publication
+
+    now = datetime(2026, 7, 15, 10, 30, 0, tzinfo=UTC)
+    pub = Publication(
+        project_id="PROJ-001-atomic",
+        title="A Paper",
+        volume="26",
+        issue="07",
+        display_volume_issue="26.07",
+        doi="10.5281/zenodo.13456789",
+        doi_url="https://doi.org/10.5281/zenodo.13456789",
+        concept_doi=None,
+        doi_versions=[
+            DOIVersion(doi="10.5281/zenodo.13456789", version_index=1,
+                       published_at=now, pdf_sha256="a" * 64),
+        ],
+        zenodo_id=13456789,
+        zenodo_environment="production",
+        citation_string="Alice. 2026. *A Paper*. llmXive **26.07**.",
+        authors_at_publication=[AuthorEntry(name="Alice", kind="human")],
+        accepted_at=now,
+        published_at=now,
+        review_summary={"num_reviewers": 13, "num_revision_rounds": 1,
+                        "num_action_items_addressed": 5, "num_action_items_failed": 0},
+    )
+    pub_state.save("PROJ-001-atomic", pub, repo_root=tmp_path)
+    loaded = pub_state.load("PROJ-001-atomic", repo_root=tmp_path)
+    assert loaded is not None
+    assert loaded.doi == pub.doi
+    # The metadata.json mirror was written atomically too.
+    meta = tmp_path / "projects" / "PROJ-001-atomic" / "paper" / "metadata.json"
+    assert meta.is_file()
+
+
+# ---------------------------------------------------------------------------
+# revision_history.py — private _atomic_write deleted; now routes through shared.
+# ---------------------------------------------------------------------------
+
+
+def test_revision_history_append_load_roundtrip(tmp_path: Path) -> None:
+    from llmxive.state import revision_history as rh
+    from llmxive.types import RevisionRound
+
+    now = datetime(2026, 7, 15, 10, 14, 0, tzinfo=UTC)
+    rnd = RevisionRound(
+        round_number=1,
+        ran_at=now,
+        implementer_agent="llmXive-implementer-v1.0",
+        canonical_identity=f"llmXive-implementer-v1.0 (m on b, {now:%Y-%m-%d})",
+        tasks_done=5,
+        tasks_failed=0,
+        tasks_skipped=0,
+        resulting_pdf_sha256="a" * 64,
+        implementer_log_path=(
+            "specs/auto-revisions/PROJ-001-atomic/round-1/implementer-log.yaml"
+        ),
+        task_outcomes=[],
+    )
+    rh.append_round("PROJ-001-atomic", rnd, repo_root=tmp_path)
+    hist = rh.load("PROJ-001-atomic", repo_root=tmp_path)
+    assert len(hist.rounds) == 1
+    assert hist.rounds[0].round_number == 1

--- a/tests/unit/test_state_readers_check.py
+++ b/tests/unit/test_state_readers_check.py
@@ -1,0 +1,122 @@
+"""Tests for the state-artifact reader guard (issue #1139 anti-pattern 1).
+
+Real files only: each test writes a tiny synthetic ``src/llmxive/*.py`` tree into
+a temp dir, points the check's ``repo_root`` at it, and asserts the guard's exit
+code — plus one test that the REAL repository is clean (locks the invariant).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from llmxive.checks import state_readers
+
+
+def _make_repo(tmp_path: Path, modules: dict[str, str]) -> Path:
+    pkg = tmp_path / "src" / "llmxive"
+    pkg.mkdir(parents=True)
+    for name, body in modules.items():
+        (pkg / name).write_text(body, encoding="utf-8")
+    return tmp_path
+
+
+_WRITER = (
+    "from pathlib import Path\n"
+    "def go(root: Path):\n"
+    "    (root / 'state' / 'xyz_widget.yaml').write_text('x', encoding='utf-8')\n"
+)
+
+
+def test_write_only_state_artifact_is_flagged(tmp_path, monkeypatch):
+    repo = _make_repo(tmp_path, {"writer.py": _WRITER})
+    monkeypatch.setattr(state_readers, "_repo_root", lambda: repo)
+    monkeypatch.setattr(state_readers, "ALLOWLIST", {})
+    assert state_readers.main() == 1  # dead-end: written, read by nobody
+
+
+def test_writer_with_a_reader_passes(tmp_path, monkeypatch):
+    reader = (
+        "from pathlib import Path\n"
+        "def load(root: Path):\n"
+        "    return (root / 'state' / 'xyz_widget.yaml').read_text()\n"
+    )
+    repo = _make_repo(tmp_path, {"writer.py": _WRITER, "reader.py": reader})
+    monkeypatch.setattr(state_readers, "_repo_root", lambda: repo)
+    monkeypatch.setattr(state_readers, "ALLOWLIST", {})
+    assert state_readers.main() == 0
+
+
+def test_read_via_custom_wrapper_counts_as_reader(tmp_path, monkeypatch):
+    reader = (
+        "from pathlib import Path\n"
+        "def _ro(p):\n"
+        "    return p.read_text() if p.exists() else ''\n"
+        "def use(root: Path):\n"
+        "    return _ro(root / 'state' / 'xyz_widget.yaml')\n"
+    )
+    repo = _make_repo(tmp_path, {"writer.py": _WRITER, "reader.py": reader})
+    monkeypatch.setattr(state_readers, "_repo_root", lambda: repo)
+    monkeypatch.setattr(state_readers, "ALLOWLIST", {})
+    assert state_readers.main() == 0
+
+
+def test_write_inside_nested_block_is_still_detected(tmp_path, monkeypatch):
+    # The write is nested in an `if` — the dataflow must still see it as a write
+    # (regression guard for the top-level-only bug).
+    nested_writer = (
+        "from pathlib import Path\n"
+        "def go(root: Path, flag: bool):\n"
+        "    if flag:\n"
+        "        p = root / 'state' / 'xyz_widget.yaml'\n"
+        "        p.write_text('x', encoding='utf-8')\n"
+    )
+    repo = _make_repo(tmp_path, {"writer.py": nested_writer})
+    monkeypatch.setattr(state_readers, "_repo_root", lambda: repo)
+    monkeypatch.setattr(state_readers, "ALLOWLIST", {})
+    assert state_readers.main() == 1
+
+
+def test_path_helper_and_const_resolve(tmp_path, monkeypatch):
+    # `_CACHE` const + `_cache_path` helper resolve so the store's own read-back
+    # counts (healthy owns-and-serves store must NOT be flagged).
+    store = (
+        "from pathlib import Path\n"
+        "_CACHE = 'xyz_widget.yaml'\n"
+        "def _cache_path(root: Path):\n"
+        "    return root / 'state' / _CACHE\n"
+        "def save(root: Path):\n"
+        "    _cache_path(root).write_text('x', encoding='utf-8')\n"
+        "def load(root: Path):\n"
+        "    return _cache_path(root).read_text()\n"
+    )
+    repo = _make_repo(tmp_path, {"store.py": store})
+    monkeypatch.setattr(state_readers, "_repo_root", lambda: repo)
+    monkeypatch.setattr(state_readers, "ALLOWLIST", {})
+    assert state_readers.main() == 0
+
+
+def test_allowlist_suppresses_a_dead_end(tmp_path, monkeypatch):
+    repo = _make_repo(tmp_path, {"writer.py": _WRITER})
+    monkeypatch.setattr(state_readers, "_repo_root", lambda: repo)
+    monkeypatch.setattr(state_readers, "ALLOWLIST", {"xyz_widget.yaml": "external"})
+    assert state_readers.main() == 0
+
+
+def test_dynamic_per_project_name_is_out_of_scope(tmp_path, monkeypatch):
+    # A per-project f"{id}.json" file carries no fixed basename → not a candidate,
+    # so a write-only per-project store does NOT false-positive.
+    store = (
+        "from pathlib import Path\n"
+        "def save(root: Path, pid: str):\n"
+        "    (root / 'state' / f'{pid}.json').write_text('x', encoding='utf-8')\n"
+    )
+    repo = _make_repo(tmp_path, {"store.py": store})
+    monkeypatch.setattr(state_readers, "_repo_root", lambda: repo)
+    monkeypatch.setattr(state_readers, "ALLOWLIST", {})
+    assert state_readers.main() == 0
+
+
+def test_real_repository_has_no_dead_ends():
+    """The live repo must pass — locks the invariant so any new persist-and-forget
+    state writer fails CI."""
+    assert state_readers.main() == 0

--- a/tests/unit/test_task_verifier.py
+++ b/tests/unit/test_task_verifier.py
@@ -169,10 +169,16 @@ def test_settled_task_not_rejudged_after_reannotation(tmp_path: Path, monkeypatc
     assert "- [X] " in tasks.read_text(encoding="utf-8")
 
 
-def test_reject_counts_accumulate_across_reannotation(tmp_path: Path, monkeypatch) -> None:
-    """Repeated rejection of the SAME task must reach REJECT_CAP even though the claims
-    layer rewrites its line between ticks — otherwise the redo loop never breaks."""
+def test_reject_cap_records_unverifiable_never_accepts(tmp_path: Path, monkeypatch) -> None:
+    """REJECT_CAP consecutive INCOMPLETE verdicts must NEVER force-accept the task
+    (the fail-open removed in issue #1139). Instead, after the cap the task is
+    reopened ``[ ]`` AND recorded in :mod:`llmxive.state.unverifiable` — which both
+    breaks the redo loop (a recorded task is not re-judged) and signals CORE to
+    route the project to research_full_revision. Reject counts still accumulate
+    across the claims layer's per-tick re-annotation of the line."""
     from types import SimpleNamespace
+
+    from llmxive.state import unverifiable
 
     monkeypatch.setattr(
         tv, "verify_task",
@@ -181,19 +187,27 @@ def test_reject_counts_accumulate_across_reannotation(tmp_path: Path, monkeypatc
     tasks = tmp_path / "tasks.md"
     state = tmp_path / "state.yaml"
     marks = []
+    result: dict = {}
     for tick in range(tv.REJECT_CAP):
-        # Each tick the claims layer stamps a DIFFERENT fresh claim id.
+        # Each tick the claims layer stamps a DIFFERENT fresh claim id. The task has
+        # NO artifact path, so it routes to the (forced-INCOMPLETE) semantic verifier.
         line = (
-            f"T009 Set up logging in `src/utils/logger.py` "
+            f"T009 wire up the pipeline module "
             f"(verify codes [UNRESOLVED-CLAIM: c_tick{tick} — status=not_enough_info])."
         )
         tasks.write_text(f"# Tasks\n\n- [X] {line}\n", encoding="utf-8")
-        tv.run_verification_pass(
+        result = tv.run_verification_pass(
             tmp_path, tasks, already_verified=set(),  # re-claimed by the implementer
             notes_path=tmp_path / "notes.md", state_path=state,
+            project_id="PROJ-CAP", repo_root=tmp_path,
         )
         marks.append(tasks.read_text(encoding="utf-8").split("\n")[2][:6])
 
-    # Rejected the first REJECT_CAP-1 ticks, then ACCEPTED (loop-breaker fires).
-    assert marks[:-1] == ["- [ ] "] * (tv.REJECT_CAP - 1), marks
-    assert marks[-1] == "- [X] ", marks
+    # NEVER accepted — reopened [ ] every tick, and [X] appears at NO point.
+    assert marks == ["- [ ] "] * tv.REJECT_CAP, marks
+    assert "- [X]" not in tasks.read_text(encoding="utf-8")
+    # The final tick recorded the task as unverifiable and flagged it in the result.
+    assert result["unverifiable"] == ["T009"], result
+    recorded = unverifiable.load("PROJ-CAP", repo_root=tmp_path)
+    assert [t["task_key"] for t in recorded] == ["T009"], recorded
+    assert unverifiable.has_unverifiable("PROJ-CAP", repo_root=tmp_path)

--- a/tests/unit/test_task_verifier_integration.py
+++ b/tests/unit/test_task_verifier_integration.py
@@ -3,8 +3,13 @@
 After the implementer claims tasks done, a SEPARATE model (outside the implementer
 session) judges whether the artifacts satisfy the requirements. These tests drive
 the REAL ``run_one_step`` batch loop (only the implementer agent + store/registry +
-the verifier's model boundary are stubbed) and pin: accept → stays ``[X]``;
-reject → ``[ ]`` + a note the next implementer reads; transient failure → ``[~]``.
+the verifier's model boundary are stubbed) and pin the SEMANTIC-verdict wiring:
+accept → stays ``[X]``; reject → ``[ ]`` + a note the next implementer reads;
+transient failure → ``[~]``.
+
+The tasks here are intentionally PATHLESS (no ``code/…`` artifact) so they bypass
+the deterministic-first settle and reach the (stubbed/forced) semantic verifier —
+the deterministic file-state path has its own suite (``test_verifier_deterministic``).
 """
 
 from __future__ import annotations
@@ -12,8 +17,6 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
-
-import pytest
 
 from llmxive.agents import task_verifier as tv
 from llmxive.pipeline import graph
@@ -43,7 +46,7 @@ def _write_tasks(tmp_path: Path, project: Project, n: int) -> Path:
     t = d / "tasks.md"
     t.write_text(
         "# Tasks\n\n"
-        + "".join(f"- [ ] T{i:03d} do thing {i} in code/a{i}.py\n" for i in range(1, n + 1)),
+        + "".join(f"- [ ] T{i:03d} do thing {i}\n" for i in range(1, n + 1)),
         encoding="utf-8",
     )
     return t
@@ -90,7 +93,7 @@ def test_reject_reverts_task_to_open_and_writes_notes(tmp_path, monkeypatch) -> 
     project = _project()
     t = _write_tasks(tmp_path, project, n=3)
     _wire(monkeypatch, project)
-    _force_verdict(monkeypatch, complete=False, reason="the csv data/a1.py is empty")
+    _force_verdict(monkeypatch, complete=False, reason="the produced output is empty")
 
     graph.run_one_step(project, repo_root=tmp_path)
 
@@ -100,7 +103,7 @@ def test_reject_reverts_task_to_open_and_writes_notes(tmp_path, monkeypatch) -> 
     assert "- [X]" not in text
     notes = tmp_path / "projects" / project.id / ".specify" / "memory" / "task_verifier_notes.md"
     assert notes.is_file()
-    assert "the csv data/a1.py is empty" in notes.read_text(encoding="utf-8")
+    assert "the produced output is empty" in notes.read_text(encoding="utf-8")
 
 
 def test_defer_marks_task_under_review_and_blocks_advancement(tmp_path, monkeypatch) -> None:
@@ -129,7 +132,7 @@ def test_already_verified_tasks_are_not_rejudged(tmp_path, monkeypatch) -> None:
     t = d / "tasks.md"
     # T001 pre-accepted ([X]); T002 still open and will be claimed this tick.
     t.write_text(
-        "# Tasks\n\n- [X] T001 prior work in code/a1.py\n- [ ] T002 new in code/a2.py\n",
+        "# Tasks\n\n- [X] T001 prior work\n- [ ] T002 new work\n",
         encoding="utf-8",
     )
     _wire(monkeypatch, project)

--- a/tests/unit/test_unverifiable_store.py
+++ b/tests/unit/test_unverifiable_store.py
@@ -1,0 +1,78 @@
+"""Round-trip tests for the repeatedly-unverifiable-task store (issue #1139, D6).
+
+Exercises the REAL JSON files under ``state/unverifiable_tasks/<id>.json`` — no
+mocks — pinning the cross-cluster contract the pipeline graph consumes to route a
+project to ``research_full_revision``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from llmxive.state import unverifiable as unv
+
+
+def test_record_load_clear_round_trip(tmp_path: Path) -> None:
+    pid = "PROJ-777-demo"
+    assert unv.load(pid, repo_root=tmp_path) == []
+    assert not unv.has_unverifiable(pid, repo_root=tmp_path)
+
+    rec = unv.record_unverifiable(pid, "T012", "artifact missing", repo_root=tmp_path)
+    assert rec["project_id"] == pid
+    assert unv.has_unverifiable(pid, repo_root=tmp_path)
+
+    loaded = unv.load(pid, repo_root=tmp_path)
+    assert len(loaded) == 1
+    entry = loaded[0]
+    # Contract schema: task_key, reject_count, last_reason, first_seen, last_seen.
+    assert entry["task_key"] == "T012"
+    assert entry["reject_count"] == 1
+    assert entry["last_reason"] == "artifact missing"
+    assert "first_seen" in entry and "last_seen" in entry
+    assert unv.recorded_keys(pid, repo_root=tmp_path) == {"T012"}
+
+    # The file lives at the documented path and is valid JSON with an updated_at.
+    p = tmp_path / "state" / "unverifiable_tasks" / f"{pid}.json"
+    assert p.is_file()
+    raw = json.loads(p.read_text(encoding="utf-8"))
+    assert raw["project_id"] == pid and "updated_at" in raw
+
+    unv.clear(pid, repo_root=tmp_path)
+    assert unv.load(pid, repo_root=tmp_path) == []
+    assert not unv.has_unverifiable(pid, repo_root=tmp_path)
+    assert not p.exists()
+
+
+def test_record_same_key_bumps_count_and_preserves_first_seen(tmp_path: Path) -> None:
+    pid = "PROJ-778-bump"
+    unv.record_unverifiable(pid, "T003", "reason one", repo_root=tmp_path)
+    first_seen = unv.load(pid, repo_root=tmp_path)[0]["first_seen"]
+
+    unv.record_unverifiable(pid, "T003", "reason two", repo_root=tmp_path)
+    loaded = unv.load(pid, repo_root=tmp_path)
+    assert len(loaded) == 1  # same key → one entry, not two
+    entry = loaded[0]
+    assert entry["reject_count"] == 2
+    assert entry["last_reason"] == "reason two"
+    assert entry["first_seen"] == first_seen  # preserved
+
+
+def test_multiple_keys_and_recorded_keys(tmp_path: Path) -> None:
+    pid = "PROJ-779-multi"
+    unv.record_unverifiable(pid, "T001", "a", repo_root=tmp_path)
+    unv.record_unverifiable(pid, "T002", "b", repo_root=tmp_path)
+    assert unv.recorded_keys(pid, repo_root=tmp_path) == {"T001", "T002"}
+    assert len(unv.load(pid, repo_root=tmp_path)) == 2
+
+
+def test_load_tolerates_missing_and_corrupt_file(tmp_path: Path) -> None:
+    pid = "PROJ-780-corrupt"
+    # Missing file → empty list, no raise.
+    assert unv.load(pid, repo_root=tmp_path) == []
+    # Corrupt JSON → empty list, no raise.
+    p = tmp_path / "state" / "unverifiable_tasks" / f"{pid}.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("{not valid json", encoding="utf-8")
+    assert unv.load(pid, repo_root=tmp_path) == []
+    assert unv.recorded_keys(pid, repo_root=tmp_path) == set()

--- a/tests/unit/test_verifier_deterministic.py
+++ b/tests/unit/test_verifier_deterministic.py
@@ -1,0 +1,180 @@
+"""Deterministic-first task settle (issue #1139, defect D6).
+
+The verifier now settles a claimed task from FILESYSTEM STATE before spending any
+LLM call: declared artifacts all valid → ``[X]``; a production task's declared
+artifacts all missing → ``[ ]``; only genuinely ambiguous tasks reach the semantic
+model. These tests prove the deterministic path short-circuits the LLM entirely,
+and that the broadened artifact detector gives setup/config/test tasks REAL file
+evidence instead of the "no artifact path" prose fallback.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from llmxive.agents import task_verifier as tv
+
+
+def _boom(**_kw):  # any semantic call here is a bug — the deterministic path must win
+    raise AssertionError("semantic verify_task must NOT be called for a settled task")
+
+
+def _run(project_dir: Path, tasks: Path, monkeypatch) -> dict:
+    monkeypatch.setattr(tv, "verify_task", _boom)
+    return tv.run_verification_pass(
+        project_dir, tasks, already_verified=set(),
+        notes_path=project_dir / "notes.md", state_path=project_dir / "state.yaml",
+        project_id="PROJ-DET", repo_root=project_dir,
+    )
+
+
+def test_existing_artifact_accepted_without_llm(tmp_path: Path, monkeypatch) -> None:
+    """A claimed task whose declared artifact exists + is non-empty is ACCEPTED
+    with NO LLM call (verify_task is monkeypatched to raise)."""
+    (tmp_path / "code").mkdir()
+    (tmp_path / "code" / "model.py").write_text("def train():\n    return 1\n", encoding="utf-8")
+    tasks = tmp_path / "tasks.md"
+    tasks.write_text("# T\n\n- [X] T001 implement code/model.py\n", encoding="utf-8")
+
+    result = _run(tmp_path, tasks, monkeypatch)
+
+    assert result["accepted"] == 1 and not result["deferred"]
+    assert "- [X] T001" in tasks.read_text(encoding="utf-8")
+
+
+def test_missing_production_artifact_reopened_without_llm(tmp_path: Path, monkeypatch) -> None:
+    """A production task whose declared artifact is MISSING is reopened ``[ ]`` with
+    NO LLM call."""
+    tasks = tmp_path / "tasks.md"
+    tasks.write_text("# T\n\n- [X] T002 create results/metrics.json\n", encoding="utf-8")
+
+    result = _run(tmp_path, tasks, monkeypatch)
+
+    assert result["accepted"] == 0
+    assert result["rejected"] and result["rejected"][0][0] == "T002"
+    assert "- [ ] T002" in tasks.read_text(encoding="utf-8")
+
+
+def test_empty_data_output_is_not_valid(tmp_path: Path, monkeypatch) -> None:
+    """A declared data output that exists but has NO rows (header only / empty) does
+    NOT validate → the production task is reopened, no LLM call."""
+    (tmp_path / "data").mkdir()
+    (tmp_path / "data" / "out.csv").write_text("col_a,col_b\n", encoding="utf-8")  # header only
+    tasks = tmp_path / "tasks.md"
+    tasks.write_text("# T\n\n- [X] T003 generate data/out.csv with rows\n", encoding="utf-8")
+
+    result = _run(tmp_path, tasks, monkeypatch)
+    assert result["rejected"] and "- [ ] T003" in tasks.read_text(encoding="utf-8")
+
+
+def test_populated_data_output_is_accepted(tmp_path: Path, monkeypatch) -> None:
+    """A declared data output with a header + at least one data row validates → the
+    task is accepted with no LLM call."""
+    (tmp_path / "data").mkdir()
+    (tmp_path / "data" / "out.csv").write_text("col_a,col_b\n1,2\n3,4\n", encoding="utf-8")
+    tasks = tmp_path / "tasks.md"
+    tasks.write_text("# T\n\n- [X] T004 generate data/out.csv with rows\n", encoding="utf-8")
+
+    result = _run(tmp_path, tasks, monkeypatch)
+    assert result["accepted"] == 1 and "- [X] T004" in tasks.read_text(encoding="utf-8")
+
+
+def test_setup_task_gets_real_file_evidence_not_prose_fallback(tmp_path: Path) -> None:
+    """A setup/config/test-path task (outside the OLD code/data/… roots) yields REAL
+    file evidence via the broadened detector — not the 'no artifact path' fallback."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_model.py").write_text(
+        "def test_ok():\n    assert True\n", encoding="utf-8"
+    )
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "pkg.py").write_text("VALUE = 42\n", encoding="utf-8")
+
+    for task, needle in (
+        ("T010 configure pyproject.toml for the package", "name = \"demo\""),
+        ("T011 add tests in tests/test_model.py", "def test_ok"),
+        ("T012 implement src/pkg.py", "VALUE = 42"),
+    ):
+        ev = tv.gather_evidence(tmp_path, task)
+        assert needle in ev, (task, ev)
+        assert "references no code/data/figure artifact path" not in ev, (task, ev)
+
+
+def test_ambiguous_task_falls_through_to_semantic(tmp_path: Path, monkeypatch) -> None:
+    """A task with NO detectable artifact path is ambiguous → it DOES reach the
+    semantic verifier (deterministic layer returns no verdict)."""
+    calls: list[str] = []
+
+    def _spy(**kw):
+        calls.append(kw["task_text"])
+        return tv.TaskVerdict(complete=True, reason="ok")
+
+    monkeypatch.setattr(tv, "verify_task", _spy)
+    tasks = tmp_path / "tasks.md"
+    tasks.write_text("# T\n\n- [X] T020 think carefully about the approach\n", encoding="utf-8")
+
+    tv.run_verification_pass(
+        tmp_path, tasks, already_verified=set(),
+        notes_path=tmp_path / "n.md", state_path=tmp_path / "s.yaml",
+        project_id="PROJ-DET", repo_root=tmp_path,
+    )
+    assert len(calls) == 1 and "T020" in calls[0]
+
+
+def test_remove_task_missing_artifact_is_not_deterministic_reject(tmp_path: Path, monkeypatch) -> None:
+    """A 'remove/delete' task legitimately ends with the artifact ABSENT, so a
+    missing artifact must NOT trigger a deterministic reject — it goes to the
+    semantic verifier instead."""
+    calls: list[str] = []
+
+    def _spy(**kw):
+        calls.append(kw["task_text"])
+        return tv.TaskVerdict(complete=True, reason="ok")
+
+    monkeypatch.setattr(tv, "verify_task", _spy)
+    tasks = tmp_path / "tasks.md"
+    tasks.write_text("# T\n\n- [X] T030 remove the obsolete code/legacy.py module\n", encoding="utf-8")
+
+    tv.run_verification_pass(
+        tmp_path, tasks, already_verified=set(),
+        notes_path=tmp_path / "n.md", state_path=tmp_path / "s.yaml",
+        project_id="PROJ-DET", repo_root=tmp_path,
+    )
+    assert len(calls) == 1, "removal task must fall through to the semantic verifier"
+
+
+def test_evidence_hash_cache_hit_avoids_second_llm_call(tmp_path: Path, monkeypatch) -> None:
+    """A semantic verdict is bound to (task_key, evidence_hash): re-verifying the
+    SAME ambiguous task with unchanged evidence is a cache hit (no second LLM call),
+    while changing the evidence invalidates it."""
+    calls: list[str] = []
+
+    def _spy(**kw):
+        calls.append(kw["evidence"])
+        return tv.TaskVerdict(complete=False, reason="not yet")
+
+    monkeypatch.setattr(tv, "verify_task", _spy)
+    tasks = tmp_path / "tasks.md"
+    state = tmp_path / "s.yaml"
+
+    # Tick 1: ambiguous task, LLM called once → reopened [ ].
+    tasks.write_text("# T\n\n- [X] T040 refine the analysis approach\n", encoding="utf-8")
+    tv.run_verification_pass(
+        tmp_path, tasks, already_verified=set(),
+        notes_path=tmp_path / "n.md", state_path=state,
+        project_id="PROJ-DET", repo_root=tmp_path,
+    )
+    assert len(calls) == 1
+
+    # Tick 2: implementer re-claims the SAME task, unchanged evidence → cache hit,
+    # NO second LLM call, still reopened [ ].
+    tasks.write_text("# T\n\n- [X] T040 refine the analysis approach\n", encoding="utf-8")
+    tv.run_verification_pass(
+        tmp_path, tasks, already_verified=set(),
+        notes_path=tmp_path / "n.md", state_path=state,
+        project_id="PROJ-DET", repo_root=tmp_path,
+    )
+    assert len(calls) == 1, "unchanged evidence must be a cache hit"
+    assert "- [ ] T040" in tasks.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Comprehensive audit + fix of **every** defect surfaced in #1139 — the issue body's 5 recurring anti-patterns, the liveness-audit comment's 12 P0/P1 findings, and the 7 section-3 gaps. Each was re-confirmed with a reproduction at `bfe019a785` (7 parallel read-only recon passes) and fixed with regression tests.

Detailed per-defect evidence (before/after) is posted as comments on #1139.

## Verification

- **Full offline suite green**: `tests/unit tests/contract -m "not slow"` → **6165 passed, 8 skipped** (the one failure in an unrelated run was `test_datacite_resolves_doi`, a live `requests.get` to doi.org that returned HTTP 503 — an external outage, not touched by this branch; it passed in the pre-change baseline).
- **Contract suite**: 86 passed, 2 skipped.
- **CI pre-checks**: `checks.prompts` (54 agents), `checks.speckit_scripts` (8 scripts), `checks.backends` all pass.
- **New regression tests**: 8 core + per-cluster suites (verifier, ledger, data cache/url, semantic gates, atomic IO, resolver pointer, project lease, drain).
- **Ruff**: clean on all changed files.

## What changed (by area)

| Area | Defects | Key files |
|-|-|-|
| Deterministic contracts | paper-PDF path, SSoT feature-dir bypass, invalid transitions | graph.py, stage.py, analysis_runner.py, paper_writing.py, paper_figure_generation.py |
| Failure classification | durable FailureClass threaded to feedback; distinct execution terminal | failure_class.py, execution_status.py, lifecycle.py |
| Verifier | deterministic-first drain, verdict hashing, no force-accept | task_verifier.py, state/unverifiable.py |
| Error ledger | typed control record + scheduler backoff/hold | advance_ledger.py, cli.py, scheduler.py |
| Data resolution | dead manifest, poison cache, url verify, kind renderer, proactive plan-time | dataset_resolver.py, data_source.py, data_source_discovery.py, plan_cmd.py |
| Semantic gates | offload rejoins gate, proofreader hash, positive citation gate | analysis_runner.py, proofreader.py, citation_fetcher.py, reference_validator.py |
| Durability | shared atomic write + CAS across 11 stores; workflow cadence | state/_io.py + stores, advance.yml, commit-and-push.sh, project_lease.py |

## State migrations (scripts/maintenance, dry-run verified)

- `drain_under_review`: 7,021 `[~]` → 3,791 `[X]` + 1,141 `[ ]` + 2,089 residue.
- `classify_advance_errors`: 74 records → 53 permanent / 8 transient / 5 invariant / 4 repair / 4 emitter.
- `archive_weak_manifests`: 676 dead manifests (9.8 MB).

All default to **dry-run**; `--apply` persists. These operate on the live 1,084-project corpus and are intended to run after merge.

Addresses #1139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
