### PR TITLE
fix(pipeline): resolve issue #1139 round 2 — the execution wall (0 organic crossings)

### DIFF
--- a/.github/workflows/advance.yml
+++ b/.github/workflows/advance.yml
@@ -32,7 +32,16 @@ name: Pipeline — Advance (deterministic matrix workers)
 
 on:
   schedule:
-    - cron: '*/30 * * * *'   # every 30 minutes (was */15; issue #1139 lost-work race)
+    # Hourly (was */30). issue #1139 round 2: a matrix JOB runs 60-90 min (setup +
+    # the multi-tick loop + a single convergence step observed at ~77 min + commit)
+    # — LONGER than a 30-min interval. Under the per-worker `cancel-in-progress:
+    # false` group, GitHub keeps at most one running + one pending and CANCELS the
+    # older pending when a third fire arrives, so ~2/3 of */30 fires cancelled (did
+    # no work) — polluting history and skipping ticks. At hourly cadence most jobs
+    # (setup + a few quick ticks ≈ 15-45 min) finish BEFORE the next fire, so no
+    # pending accumulates and nothing is evicted. Effective throughput RISES:
+    # ~24 productive fires/day beats ~16 (48 fires × ~1/3 surviving).
+    - cron: '0 * * * *'      # top of every hour
   workflow_dispatch:
     inputs:
       workers:
@@ -60,9 +69,12 @@ jobs:
       group: advance-${{ matrix.worker }}
       cancel-in-progress: false
     # Fits the worst single convergence step (a live tasked/review panel
-    # convergence was observed at ~77 min); the wall budget breaks the
-    # multi-tick loop early so the final step + commit always land.
-    timeout-minutes: 150
+    # convergence was observed at ~77 min) + setup/commit slack; the 2400s wall
+    # budget breaks the multi-tick loop early so the final step + commit always
+    # land. Lowered 150→90 (issue #1139 round 2) so a job cannot outlive the
+    # hourly cadence by more than one interval — bounding the concurrency-eviction
+    # window (a 150-min hang used to cancel up to 4 intervening scheduled ticks).
+    timeout-minutes: 90
     strategy:
       fail-fast: false            # preserved (issue #1139): one worker failing
                                   # must NOT abort the rest of the matrix.

--- a/.github/workflows/llmxive-real-call-tests.yml
+++ b/.github/workflows/llmxive-real-call-tests.yml
@@ -105,6 +105,14 @@ jobs:
       - name: Contract tests
         run: pytest tests/contract -v
 
+      # issue #1139 round 2: the offline unit suite was NOT run by ANY workflow,
+      # so unit regressions (e.g. the fix-loop task-reopen, fabrication-guard
+      # precision, intake throttle, and the research-wall crossing contract) never
+      # gated a PR. Run the FAST offline subset here (slow venv/build tests stay
+      # nightly), fail-fast BEFORE the real-LLM minutes.
+      - name: Unit tests (fast offline subset)
+        run: pytest tests/unit -q -m "not slow"
+
       # The real-call suite is the canonical Constitution III gate. The per-PR
       # gate runs the FAST subset (connectivity + backend fallback + the
       # reference/citation gates + personality liveness + Spec Kit scripts); the

--- a/.github/workflows/llmxive-real-call-tests.yml
+++ b/.github/workflows/llmxive-real-call-tests.yml
@@ -66,9 +66,11 @@ jobs:
             texlive-luatex texlive-latex-recommended texlive-latex-extra \
             texlive-fonts-recommended texlive-fonts-extra texlive-science \
             texlive-bibtex-extra texlive-pictures texlive-plain-generic \
-            texlive-lang-english fonts-noto-core
+            texlive-lang-english fonts-noto-core \
+            poppler-utils
           lualatex --version | head -1
           bibtex --version | head -1
+          pdftotext -v 2>&1 | head -1   # poppler, for the pdf_auditor unit tests
 
       # Install the house fonts (Fraunces serif + JetBrains Mono) so
       # fontspec resolves them and the real-call compile renders the true
@@ -111,6 +113,14 @@ jobs:
       # gated a PR. Run the FAST offline subset here (slow venv/build tests stay
       # nightly), fail-fast BEFORE the real-LLM minutes.
       - name: Unit tests (fast offline subset)
+        # Force TRUE offline mode: the job sets LLMXIVE_REAL_TESTS=1 + a Dartmouth
+        # key for the real-call gate, but the unit suite must be DETERMINISTIC —
+        # with the key present some agent tests (flesh_out_reviser, implement
+        # batching, task_verifier) take the real-LLM path and their canned-output
+        # assertions flake. Unset both so conftest's offline stubs apply.
+        env:
+          LLMXIVE_REAL_TESTS: ""
+          DARTMOUTH_CHAT_API_KEY: ""
         run: pytest tests/unit -q -m "not slow"
 
       # The real-call suite is the canonical Constitution III gate. The per-PR

--- a/.github/workflows/paper-compile.yml
+++ b/.github/workflows/paper-compile.yml
@@ -79,6 +79,31 @@ jobs:
         # drain rate so no PDF-less backlog accumulates in the dashboard tab.
         run: python3 scripts/build_missing_preprint_pdfs.py --max 30
 
+      - name: Audit restyled papers (non-failing)
+        # Flip paper_status `restyled_unaudited` -> `audited` (spec 010 / 023
+        # FR-023). The deterministic PDF audit (`llmxive pdf-pipeline audit`)
+        # calls record_audit_result, but NO other workflow ever invoked it, so
+        # restyled papers were stranded at `restyled_unaudited`. Audit each
+        # canonical restyled main PDF here, right after compile, so the updated
+        # state/paper_status/*.json + state/audit/pdf/*.json get committed below.
+        #
+        # SAFE in CI: the audit never moves or deletes a PDF — the only file
+        # mutation is on a render CRASH, where it COPIES the PDF into a
+        # quarantine dir (audit.py ~L263, shutil.copy2). Per-paper failures never
+        # fail the sweep (the CLI exits 1 on defects — swallowed by set +e), and
+        # the loop is bounded to 200 papers/tick.
+        run: |
+          set +e
+          n=0
+          for pdf in projects/PROJ-*/paper/pdf/main-llmxive.pdf; do
+            [ -f "$pdf" ] || continue
+            if [ "$n" -ge 200 ]; then break; fi
+            python3 -m llmxive pdf-pipeline audit "$pdf"
+            n=$((n + 1))
+          done
+          echo "[paper-compile] audited $n restyled paper PDF(s)"
+          exit 0
+
       - name: Commit + push
         id: commit
         # Robust concurrent-safe commit+push (scripts/ci/commit-and-push.sh):

--- a/scripts/maintenance/backfill_failure_class.py
+++ b/scripts/maintenance/backfill_failure_class.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+"""One-time migration: backfill the durable ``failure_class`` on legacy
+execution-status records.
+
+Issue #1139 (P1-2) made :func:`llmxive.state.execution_status.record` persist a
+durable :class:`llmxive.execution.failure_class.FailureClass` on every failed
+execution attempt, so downstream re-plan feedback and terminal routing branch on
+the REAL cause instead of re-parsing ``reason``/``failures`` strings. But the ~44
+of 48 live records that predate the fix have no ``failure_class`` key (or a null
+one), so class-specific routing is INERT for them until each project re-executes.
+
+This script upgrades those records IN PLACE. For each
+``state/execution_status/*.json`` with ``ok == false`` and a missing/null
+``failure_class``, it reconstructs the class with the SAME logic the live path
+uses (:mod:`llmxive.execution.stage`'s ``_compute_infra_failures`` /
+``_data_unavailable_failures`` signature matchers + fabrication/hollow detection),
+calls :meth:`FailureClass.from_signals`, and writes ``failure_class`` + ``evidence``
+via the shared atomic writer. Records with ``ok == true`` — or that already carry a
+non-null ``failure_class`` — are left untouched (the migration is idempotent).
+
+DEFAULT is a DRY-RUN (nothing written). Pass ``--apply`` to write. Run with
+``PYTHONPATH=src``::
+
+    ./.venv/bin/python scripts/maintenance/backfill_failure_class.py            # dry-run
+    ./.venv/bin/python scripts/maintenance/backfill_failure_class.py --apply    # write
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from llmxive.config import repo_root as _repo_root
+from llmxive.execution.failure_class import FailureClass
+from llmxive.execution.stage import _compute_infra_failures, _data_unavailable_failures
+from llmxive.state._io import atomic_write_text
+
+
+def _reconstruct(rec: dict) -> tuple[str, list[str]]:
+    """Reconstruct ``(failure_class, evidence)`` from a stored record using the
+    SAME signature logic the live execution path uses.
+
+    ``_compute_infra_failures`` / ``_data_unavailable_failures`` run over the
+    persisted ``failures`` list AND the ``reason`` string (a legacy record may
+    carry the signal in either), and fabrication/hollow are read off the
+    ``reason`` text (the live path had the SemanticGate booleans, which the
+    ``SemanticGate.reason()`` prose faithfully reflects: "fabricated/simulated"
+    and "hollow-result")."""
+    reason = str(rec.get("reason", "") or "")
+    failures = [str(f) for f in (rec.get("failures") or [])]
+    signals = [*failures, reason]
+    infra = _compute_infra_failures(signals)
+    dataunavail = _data_unavailable_failures(signals)
+    fclass = FailureClass.from_signals(
+        compute_infra=bool(infra),
+        data_unavailable=bool(dataunavail),
+        fabrication="fabricat" in reason.lower(),
+        hollow="hollow" in reason.lower(),
+        has_command_failures=bool(failures),
+    )
+    evidence = (infra + dataunavail)[:20]
+    return fclass.value, evidence
+
+
+def _needs_backfill(rec: dict) -> bool:
+    """A failed record with no (or null) ``failure_class`` — the only kind we
+    touch. ok=true records and records already classified are left alone."""
+    return rec.get("ok") is not True and not rec.get("failure_class")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="write the backfilled records (default: dry-run, no writes)",
+    )
+    parser.add_argument(
+        "--repo-root", default=None,
+        help="repo root (default: llmxive.config.repo_root())",
+    )
+    args = parser.parse_args(argv)
+
+    repo = Path(args.repo_root) if args.repo_root else _repo_root()
+    status_dir = repo / "state" / "execution_status"
+    files = sorted(status_dir.glob("*.json"))
+    if not files:
+        print(f"[backfill] no records under {status_dir}")
+        return 0
+
+    rows: list[tuple[str, str, list[str]]] = []  # (project_id, new_class, evidence)
+    skipped_ok = 0
+    skipped_classified = 0
+    for path in files:
+        try:
+            rec = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            print(f"[backfill] SKIP {path.name}: unreadable ({exc})", file=sys.stderr)
+            continue
+        if rec.get("ok") is True:
+            skipped_ok += 1
+            continue
+        if rec.get("failure_class"):
+            skipped_classified += 1
+            continue
+        if not _needs_backfill(rec):
+            continue
+        new_class, evidence = _reconstruct(rec)
+        rows.append((path.name, new_class, evidence))
+        if args.apply:
+            rec["failure_class"] = new_class
+            rec["evidence"] = [str(e)[:600] for e in evidence][:20]
+            atomic_write_text(path, json.dumps(rec, indent=2) + "\n")
+
+    hdr = f"{'record':<40} {'old':<10} -> {'new class':<18} {'evidence'}"
+    print(f"\n{'DRY-RUN (no writes) — ' if not args.apply else 'APPLYING — '}"
+          f"{len(rows)} record(s) to backfill under {status_dir}\n")
+    print(hdr)
+    print("-" * len(hdr))
+    class_hist: dict[str, int] = {}
+    for name, new_class, evidence in rows:
+        class_hist[new_class] = class_hist.get(new_class, 0) + 1
+        ev = (evidence[0][:40] + "…") if evidence else "-"
+        print(f"{name:<40} {'(none)':<10} -> {new_class:<18} {ev}")
+
+    print("\nby class:")
+    for cls, n in sorted(class_hist.items(), key=lambda kv: (-kv[1], kv[0])):
+        print(f"  {cls:<20} {n}")
+    print(
+        f"\nskipped: {skipped_ok} ok=true, {skipped_classified} already-classified."
+    )
+    if args.apply:
+        print(f"\n[backfill] wrote {len(rows)} backfilled record(s).")
+    else:
+        print("\n[backfill] dry-run only; re-run with --apply to write.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/llmxive/checks/state_readers.py
+++ b/src/llmxive/checks/state_readers.py
@@ -77,9 +77,16 @@ ALLOWLIST: dict[str, str] = {
     # round contract, agents/implementer.py ~L2208) — consumed by a directory glob,
     # so it is never named literally for a by-name static reader to see.
     "analyze-report.md": "read by implementer via round_dir.glob('*.md') (spec-012)",
-    # Human reproduction guide for a reprocessed code paper; surfaced as a project
-    # artifact link in web/data/projects.json (dashboard), read by humans.
-    "reproduction.md": "human reproduction guide; surfaced as a dashboard artifact",
+    # Human reproduction guide for a reprocessed code paper, committed to git
+    # (e.g. projects/PROJ-615/idea/reproduction.md, projects/PROJ-638/idea/
+    # reproduction.md) and read by humans from the repo. It is NOT surfaced by
+    # name on the dashboard: web_data._build_artifact_links only picks the FIRST
+    # idea/*.md as the generic "idea" link and never references `reproduction`.
+    # So its consumer is git + human readers, not non-test src.
+    "reproduction.md": (
+        "git-committed human reproduction guide (projects/**/idea/reproduction.md); "
+        "consumer is git + human readers, not non-test src or the dashboard"
+    ),
     # Documented human-facing deliverable of the arXiv/reprocess intake bundle
     # (paper_reprocess/__init__ lists it); the actionable code-resource data is
     # threaded via metadata.json (consumed by paper_reprocess/classify.py).

--- a/src/llmxive/execution/fabrication_guard.py
+++ b/src/llmxive/execution/fabrication_guard.py
@@ -64,12 +64,28 @@ _RNG_DRAW_FUNCS = {
     "lognormvariate", "expovariate", "standard_normal",
 }
 # Result/metric-ish names: when an RNG draw is assigned to (or returned as) one of
-# these, the reported number IS the random draw.
-_METRIC_NAME_RE = re.compile(
-    r"speedup|throughput|latency|accuracy|score|fps|memory|mem_|"
-    r"reduction|improvement|gain|ratio|perf|time_ms|metric|result",
-    re.IGNORECASE,
-)
+# these, the reported number IS the random draw. Matched against the identifier's
+# TOKENS (snake_case + camelCase split), NOT as a substring — a substring match on
+# "ratio" wrongly flagged "concentration"/"duration"/"iteration" (simulated INPUT
+# quantities, not reported metrics; the live PROJ-475 false positive), while
+# "throughput_ratio"/"memUsage" still tokenise to a metric word (issue #1139 F3).
+_METRIC_WORDS = frozenset({
+    "speedup", "throughput", "latency", "accuracy", "score", "fps", "memory",
+    "mem", "ms", "reduction", "improvement", "gain", "ratio", "perf", "metric",
+    "result", "auc", "precision", "recall", "loss", "rmse", "mae", "mse", "r2",
+})
+
+
+def _identifier_tokens(name: str) -> set[str]:
+    """Lowercase token set of an identifier, splitting snake_case AND camelCase
+    (``throughput_ratio`` / ``throughputRatio`` → ``{throughput, ratio}``)."""
+    snake = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", name)
+    return {t.lower() for t in re.split(r"[^A-Za-z0-9]+", snake) if t}
+
+
+def _is_metric_name(name: str) -> bool:
+    """True iff any TOKEN of ``name`` is a reported-metric word (not a substring)."""
+    return bool(_identifier_tokens(name) & _METRIC_WORDS)
 _RESULT_SINK_RE = re.compile(r"to_csv|to_json|to_parquet|json\.dump|savefig|DataFrame")
 
 
@@ -145,7 +161,7 @@ def _scan_code_rng_metrics(code_text: str, *, source: str) -> list[str]:
             continue
         for tgt in node.targets:
             name = getattr(tgt, "id", None)
-            if name and _METRIC_NAME_RE.search(name):
+            if name and _is_metric_name(name):
                 how = "an RNG draw" if from_rng else f"fabricator `{rhs.func.id}()`"
                 out.append(
                     f"{source}: metric `{name}` assigned from {how} (line {node.lineno})"
@@ -266,25 +282,46 @@ _AVOIDANCE_RE = re.compile(
 )
 
 
+#: A SIMULATION-METHODOLOGY study legitimately generates its own data AS the
+#: research method (a statistics paper whose whole point is Monte-Carlo estimation
+#: of Type-I error, power, or estimator bias under a known ground truth). Such an
+#: idea describes the design in methods vocabulary and often never writes the
+#: literal "synthetic data" noun phrase, so the narrow :data:`_SYNTHETIC_DATA_RE`
+#: authorizer failed and the study was wrongly fabrication-blocked (live PROJ-427).
+#: These patterns key on genuine simulation-STUDY INTENT — not a passing mention of
+#: the word "simulate" — so a real-world-data project is not accidentally
+#: authorized (issue #1139 F2).
+_SIMULATION_STUDY_RE = re.compile(
+    r"monte[\s-]*carlo|simulation\s+study|simulation\s+results|"
+    r"simulation\s+batch(?:es)?|simulation\s+iterations?|simulated\s+datasets?|"
+    r"power\s+analysis|type\s*(?:i{1,2}|1|2)\s+error|under\s+the\s+null|"
+    r"null\s+hypothesis|known\s+ground\s+truth",
+    re.IGNORECASE,
+)
+
+
 def _synthetic_data_authorized(project_dir: Path) -> bool:
     """True iff the project's ORIGINAL research intent explicitly calls for
-    synthetic or simulated data (the research question is about it).
+    synthetic or simulated data (the research question is about it), OR the idea
+    describes a SIMULATION-METHODOLOGY study whose method IS generating its own
+    data (Monte-Carlo / power analysis / Type-I error / under-the-null).
 
     Scans the ``idea/`` dir ONLY — the genuine, pre-implementation intent.
     Deliberately NOT the spec/plan/tasks: those are BACK-FILLED from the code for
     reprocessed papers, so they mention synthetic data merely BECAUSE the code
     uses it (circular self-authorization). A real-world-insight project's idea
-    never frames itself around synthetic data, so synthetic data in its code is an
-    unauthorized shortcut, not the design."""
+    never frames itself around synthetic data or a simulation methodology, so
+    synthetic data in its code is an unauthorized shortcut, not the design."""
     d = project_dir / "idea"
     if not d.is_dir():
         return False
     for f in d.rglob("*.md"):
         try:
-            if _SYNTHETIC_DATA_RE.search(f.read_text(encoding="utf-8", errors="ignore")):
-                return True
+            text = f.read_text(encoding="utf-8", errors="ignore")
         except OSError:
             continue
+        if _SYNTHETIC_DATA_RE.search(text) or _SIMULATION_STUDY_RE.search(text):
+            return True
     return False
 
 

--- a/src/llmxive/execution/stage.py
+++ b/src/llmxive/execution/stage.py
@@ -785,6 +785,47 @@ def _write_execution_feedback(
     (mem_dir / _FEEDBACK_FILENAME).write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
+# Path segments that mark an INSTALLED-dependency frame (the per-project venv),
+# NOT the project's own analysis. A traceback through pandas/numpy lives under
+# ``code/.venv/.../site-packages/...`` — whose path also contains ``code/`` — so a
+# naive scan would harvest library files. Exclude them (issue #1139 B1).
+_VENV_PATH_MARKERS = (".venv/", "/venv/", "site-packages/", "dist-packages/")
+
+
+def _code_paths_in_text(text: str) -> set[str]:
+    """Project-owned ``code/<pkg>/<mod>.py`` files named anywhere in *text* — a
+    command line OR a traceback tail.
+
+    Handles BOTH the filesystem-frame form (``File
+    ".../code/simulation/output_writer.py"``) and the dotted-module form
+    (``No module named 'code.simulation.output_writer'`` / ``from
+    code.simulation.output_writer import ...``). The dotted form is where a
+    transitive-import bug's ROOT module is named — the failing COMMAND only ever
+    names the entrypoint (``python code/main.py``), so before this the buggy
+    module's task stayed ``[X]`` and the implementer oscillated on the entrypoint
+    forever (the live PROJ-341 import-chain stall). Installed-dependency frames
+    under the per-project venv are excluded (issue #1139 B1)."""
+    out: set[str] = set()
+    if not text:
+        return out
+    # a) filesystem path form — anchor at the ``code/`` dir boundary. A leading
+    #    path separator is fine; a preceding WORD char (``decode/x.py``,
+    #    ``encode/...``) would make ``code`` part of another identifier, so reject
+    #    that with a word-char lookbehind.
+    for m in re.finditer(r"(?<!\w)(code/[\w./-]+\.py)", text):
+        rel = m.group(1)
+        if not any(mark in rel for mark in _VENV_PATH_MARKERS):
+            out.add(rel)
+    # b) dotted-module form — ``code.<pkg>.<mod>`` → ``code/<pkg>/<mod>.py``. Not
+    #    preceded by a word char or dot (so ``mypkg.code.x`` is not mistaken for
+    #    our top-level ``code`` package).
+    for m in re.finditer(r"(?<![\w.])(code(?:\.[A-Za-z_]\w*)+)", text):
+        rel = m.group(1).replace(".", "/") + ".py"
+        if not any(mark in rel for mark in _VENV_PATH_MARKERS):
+            out.add(rel)
+    return out
+
+
 def _reopen_failing_tasks(
     project_dir: Path, res: AnalysisRunResult, contract_issues: list | None = None,
     data_contract_issues: list | None = None,
@@ -822,9 +863,16 @@ def _reopen_failing_tasks(
     for r in res.commands:
         if r.ok:
             continue
-        m = re.search(r"\b(code/[\w./-]+\.py)\b", r.command)
-        if m:
-            rel = m.group(1)
+        # The failing COMMAND names only the ENTRYPOINT (``python code/main.py``);
+        # a transitive-import / deep-module bug is named ONLY in the traceback TAIL
+        # (issue #1139 B1 — the live PROJ-341 import-chain stall: main.py was
+        # reopened every round while the real bug in
+        # code/simulation/output_writer.py kept its task [X], so the implementer
+        # oscillated on the entrypoint forever). Reopen EVERY project-owned
+        # code/*.py named in the command AND the tail.
+        cmd_paths = _code_paths_in_text(r.command)
+        tail_paths = _code_paths_in_text(r.tail or "")
+        for rel in cmd_paths | tail_paths:
             targets.add(rel)
             # The FILENAME (``download.py``) — not the bare stem. A stem like
             # "analysis" / "download" / "main" is an ordinary English word that
@@ -833,8 +881,9 @@ def _reopen_failing_tasks(
             # it). The filename still catches the same script under a different
             # directory, which IS the likely owner of a path mismatch.
             targets.add(Path(rel).name)
-            if r.script_missing:
-                missing_scripts.append(rel)
+        # script_missing is a property of the run-book command's OWN script.
+        if r.script_missing:
+            missing_scripts.extend(cmd_paths)
     for d in res.declared_missing:
         targets.add(d)
         targets.add(Path(d).name)

--- a/src/llmxive/execution/stage.py
+++ b/src/llmxive/execution/stage.py
@@ -122,7 +122,7 @@ def _runbook_cli_mismatches(res: AnalysisRunResult) -> list[tuple[str, str, str]
     mismatch so the implementer is told to reconcile the quickstart command and the
     script's argparse (not pointlessly edit the body)."""
     out: list[tuple[str, str, str]] = []
-    for r in res.commands:
+    for r in getattr(res, "commands", None) or []:
         if r.ok or not r.tail:
             continue
         if not _ARGPARSE_ERROR_RE.search(r.tail):
@@ -568,26 +568,37 @@ def _poll_offload(project_dir: Path, repo: Path) -> bool:
                 project_id, len(real),
             )
             return True
+        # Capture WHY the completed bundle failed so the durable offload
+        # sub-record carries the diagnosis (issue #1139 AP4), not just "failed".
         if real and gate is not None:
+            fail_reason = gate.reason()
+            fail_evidence = [
+                *gate.fabrication[:5], *gate.hollow[:5],
+                *gate.undurable[:5], *gate.declared_missing[:5],
+            ]
             logger.warning(
                 "offload %s completed but the retrieved bundle FAILED the semantic "
                 "gate — NOT advancing (%s); falling back to a local pass",
-                project_id, gate.reason(),
+                project_id, fail_reason,
             )
         else:
+            fail_reason = "offload retrieved no real (non-empty) artifacts"
+            fail_evidence = []
             logger.warning(
                 "offload %s completed but retrieved no real artifacts; falling back",
                 project_id,
             )
         execution_status.record_offload(
-            project_id, status="failed", kernel_ref=kernel_ref, repo_root=repo,
+            project_id, status="failed", kernel_ref=kernel_ref,
+            reason=fail_reason, evidence=fail_evidence, repo_root=repo,
         )
         return _run_local_after_failed_offload(project_dir, repo)
 
     # error / cancelAcknowledged / unknown-terminal → failed, then local fallback.
     logger.warning("offload %s ended status=%s; falling back to local path", project_id, status)
     execution_status.record_offload(
-        project_id, status="failed", kernel_ref=kernel_ref, repo_root=repo,
+        project_id, status="failed", kernel_ref=kernel_ref,
+        reason=f"offload kernel ended in terminal status={status}", repo_root=repo,
     )
     return _run_local_after_failed_offload(project_dir, repo)
 

--- a/src/llmxive/execution/stage.py
+++ b/src/llmxive/execution/stage.py
@@ -97,6 +97,46 @@ def _data_unavailable_failures(failures: list[str]) -> list[str]:
     return out
 
 
+#: argparse's own rejection lines when a run-book command's ARGS don't match the
+#: script's CLI — the quickstart invokes ``python code/x.py --icc 0.1`` but x.py's
+#: argparse never declared ``--icc`` (``unrecognized arguments``), or invokes it
+#: with NO args while x.py marks flags ``required`` (``the following arguments are
+#: required``). Re-running the identical command can NEVER pass and editing the
+#: script BODY won't help — the run-book command and the script's argparse have
+#: DRIFTED and must be reconciled (the live PROJ-148/239/585 stalls at fr=2-7).
+_ARGPARSE_ERROR_RE = re.compile(
+    r":\s*error:\s+(?:the following arguments are required|unrecognized arguments|"
+    r"argument\s+[^\n:]+:|invalid choice|expected (?:one|at least one) argument|"
+    r"ambiguous option|not allowed with argument)",
+    re.IGNORECASE,
+)
+_USAGE_RE = re.compile(r"^usage:\s*(.+)$", re.MULTILINE)
+
+
+def _runbook_cli_mismatches(res: AnalysisRunResult) -> list[tuple[str, str, str]]:
+    """Failing commands where the RUN-BOOK invocation doesn't match the script's
+    own argparse CLI. argparse prints ``usage: <prog> ...`` then ``<prog>: error:
+    the following arguments are required: --input`` / ``unrecognized arguments:
+    --icc`` — BOTH already in the captured tail, so the real CLI is recovered
+    without re-running ``--help``. Returns ``(command, usage, error_line)`` per
+    mismatch so the implementer is told to reconcile the quickstart command and the
+    script's argparse (not pointlessly edit the body)."""
+    out: list[tuple[str, str, str]] = []
+    for r in res.commands:
+        if r.ok or not r.tail:
+            continue
+        if not _ARGPARSE_ERROR_RE.search(r.tail):
+            continue
+        err_line = next(
+            (ln.strip() for ln in r.tail.splitlines() if _ARGPARSE_ERROR_RE.search(ln)),
+            "",
+        )
+        um = _USAGE_RE.search(r.tail)
+        usage = " ".join(um.group(1).split()) if um else ""
+        out.append((r.command, usage, err_line))
+    return out
+
+
 def _needs_verified_source(res: AnalysisRunResult, failures: list[str]) -> bool:
     """True when the failure signals the project lacks a REAL, programmatically
     reachable data source — the exact case data-source discovery exists to fix.
@@ -645,6 +685,29 @@ def _write_execution_feedback(
             *(f"- `{c}`" for c in regressions),
             "",
         ]
+    cli_mismatches = _runbook_cli_mismatches(res)
+    if cli_mismatches:
+        lines += [
+            "## ⚠ RUN-BOOK / CLI MISMATCH — the quickstart calls the script with the wrong arguments",
+            "",
+            "These commands did not crash on a code bug — the script's own argparse "
+            "REJECTED the arguments the quickstart passed (it required flags the "
+            "quickstart omitted, or the quickstart passed flags the script never "
+            "declared). Re-running the identical command can NEVER pass, and editing "
+            "the script's logic will NOT help: the run-book command and the script's "
+            "CLI have DRIFTED. Reconcile them — either change the quickstart command "
+            "to match the script's real usage, OR change the script's argparse to "
+            "accept the quickstart's arguments (whichever is correct for the "
+            "analysis). The script's REAL usage is shown so you can see the exact gap:",
+            "",
+        ]
+        for cmd, usage, err in cli_mismatches:
+            lines.append(f"- run-book command: `{cmd}`")
+            if usage:
+                lines.append(f"  - script usage: `{usage}`")
+            if err:
+                lines.append(f"  - argparse error: `{err}`")
+        lines.append("")
     infra = _compute_infra_failures(failures)
     if infra:
         lines += [

--- a/src/llmxive/pipeline/intake_throttle.py
+++ b/src/llmxive/pipeline/intake_throttle.py
@@ -41,12 +41,38 @@ IDEA_BACKLOG_STAGES: frozenset[Stage] = frozenset(
     }
 )
 
+#: Stages counted as DOWNSTREAM in-flight work — a project that has left the idea
+#: stages and entered the implementation/execution pipeline. Seeding MORE ideas
+#: while this pit is congested (the live #1139 state: 492 projects at in_progress,
+#: ~0 reaching research_complete) just grows unbounded WIP behind a stalled
+#: pipeline — the intake throttle was BLIND to it (it watched only the idea
+#: backlog ~192, which was flat, so it granted full intake). issue #1139 M1.
+DOWNSTREAM_WIP_STAGES: frozenset[Stage] = frozenset(
+    {
+        Stage.PLANNED,
+        Stage.TASKED,
+        Stage.ANALYZE_IN_PROGRESS,
+        Stage.ANALYZED,
+        Stage.IN_PROGRESS,
+    }
+)
+
 #: Backlog-growth measurement window.
 WINDOW_HOURS: float = 24.0
 
 #: Growth (projects added net over the window) at which automated intake
 #: shuts off entirely; below it the allowance scales linearly.
 FULL_STOP_GROWTH: int = 20
+
+#: Net DOWNSTREAM-WIP growth over the window at which automated intake shuts off
+#: (drain < intake through the whole pipeline, not just the idea stages).
+DOWNSTREAM_FULL_STOP_GROWTH: int = 40
+
+#: Absolute downstream-WIP size above which automated intake is damped REGARDLESS
+#: of growth — a congested implementation pipeline must DRAIN (projects reaching
+#: research_complete) before more ideas enter. Self-recovering: as WIP falls back
+#: under the ceiling the allowance returns to full.
+DOWNSTREAM_WIP_CEILING: int = 250
 
 #: Human submissions are never throttled below this per tick.
 MIN_HUMAN_ALLOWANCE: int = 1
@@ -101,6 +127,22 @@ def backlog_depth(*, repo_root: Path | None = None) -> int:
     )
 
 
+def downstream_wip_depth(*, repo_root: Path | None = None) -> int:
+    """Current DOWNSTREAM in-flight work (implementation/execution pipeline)."""
+    return sum(
+        1
+        for p in project_store.list_all(repo_root=repo_root)
+        if p.current_stage in DOWNSTREAM_WIP_STAGES
+    )
+
+
+def _growth_fraction(growth: int, full_stop: int) -> float:
+    """Linear allowance fraction: 1.0 at growth<=0, 0.0 at ``full_stop``."""
+    if growth <= 0:
+        return 1.0
+    return max(0.0, 1.0 - growth / full_stop)
+
+
 def intake_allowance(
     requested: int,
     *,
@@ -116,6 +158,7 @@ def intake_allowance(
     """
     now = now or datetime.now(UTC)
     depth = backlog_depth(repo_root=repo_root)
+    wip = downstream_wip_depth(repo_root=repo_root)
     state = _load_state(repo_root)
     cutoff = now - timedelta(hours=WINDOW_HOURS)
     samples = [
@@ -123,27 +166,48 @@ def intake_allowance(
         for s in state["samples"]
         if datetime.fromisoformat(str(s["at"])) >= cutoff
     ]
-    samples.append({"at": now.isoformat(), "backlog": depth})
+    samples.append({"at": now.isoformat(), "backlog": depth, "wip": wip})
 
     growth = 0
+    wip_growth = 0
     if len(samples) >= 2:
         growth = depth - int(samples[0]["backlog"])
+        # Old samples (pre-#1139-M1) have no "wip" key → treat as the current
+        # value so a missing history contributes 0 growth (never a false stop).
+        wip_growth = wip - int(samples[0].get("wip", wip))
 
     requested = max(0, requested)
-    if growth <= 0:
-        allowed = requested
+    # Three self-recovering signals, each a linear allowance fraction; the
+    # allowance is damped by the WORST (smallest) of them (issue #1139 M1):
+    #   1. idea-stage backlog growth (the original FR-008 signal);
+    #   2. DOWNSTREAM-WIP growth (the implementation pipeline filling faster than
+    #      it drains) — the signal the throttle was blind to;
+    #   3. an absolute downstream-WIP ceiling (a congested pipeline must DRAIN
+    #      before more ideas enter, regardless of growth).
+    f_backlog = _growth_fraction(growth, FULL_STOP_GROWTH)
+    f_wip_growth = _growth_fraction(wip_growth, DOWNSTREAM_FULL_STOP_GROWTH)
+    f_wip_ceiling = _growth_fraction(
+        max(0, wip - DOWNSTREAM_WIP_CEILING), DOWNSTREAM_WIP_CEILING
+    )
+    fraction = min(f_backlog, f_wip_growth, f_wip_ceiling)
+    allowed = int(requested * fraction)
+    if fraction >= 1.0:
         reason = (
-            f"backlog flat/draining over the window (growth={growth}); "
-            "full intake"
+            f"backlog flat/draining (growth={growth}) and downstream WIP "
+            f"healthy (wip={wip}, growth={wip_growth}); full intake"
         )
     else:
-        # Proportional damping: linear from full allowance at growth=0 to
-        # zero at FULL_STOP_GROWTH.
-        fraction = max(0.0, 1.0 - growth / FULL_STOP_GROWTH)
-        allowed = int(requested * fraction)
+        # Name the binding constraint so the decision is self-explaining.
+        binding = min(
+            ("idea-backlog", f_backlog),
+            ("downstream-WIP-growth", f_wip_growth),
+            ("downstream-WIP-ceiling", f_wip_ceiling),
+            key=lambda kv: kv[1],
+        )[0]
         reason = (
-            f"backlog grew by {growth} over {WINDOW_HOURS:.0f}h "
-            f"(drain < intake); allowance damped to {fraction:.0%}"
+            f"damped to {fraction:.0%} by {binding} "
+            f"(idea growth={growth}, wip={wip}, wip growth={wip_growth}, "
+            f"ceiling={DOWNSTREAM_WIP_CEILING})"
         )
     if kind == "human":
         allowed = max(allowed, min(requested, MIN_HUMAN_ALLOWANCE))
@@ -165,11 +229,15 @@ def intake_allowance(
 
 
 __all__ = [
+    "DOWNSTREAM_FULL_STOP_GROWTH",
+    "DOWNSTREAM_WIP_CEILING",
+    "DOWNSTREAM_WIP_STAGES",
     "FULL_STOP_GROWTH",
     "IDEA_BACKLOG_STAGES",
     "MIN_HUMAN_ALLOWANCE",
     "WINDOW_HOURS",
     "IntakeDecision",
     "backlog_depth",
+    "downstream_wip_depth",
     "intake_allowance",
 ]

--- a/src/llmxive/sandbox.py
+++ b/src/llmxive/sandbox.py
@@ -104,42 +104,54 @@ def _resilient_pip_install(py: Path, req: Path) -> None:
     those names auto-added to requirements.txt as if they were PyPI packages,
     so `pip install -r` failed and the real deps never landed).
 
-    Try the fast batch install first; on failure, fall back to installing each
-    requirement INDIVIDUALLY so the GOOD deps land and only the genuinely
-    un-installable lines are skipped (logged, never fatal — a missing real dep
-    still resurfaces as a script ModuleNotFoundError for the bounded fix loop).
+    Try the fast batch install first; on failure, DIAGNOSE which individual
+    requirement lines are un-installable, then RE-RUN the batch on the survivors
+    so the resolver picks a MUTUALLY-CONSISTENT set. The old fallback left each
+    package installed by a SEPARATE ``pip install`` invocation, so pip could land
+    ABI-incompatible binaries (an unpinned ``numpy`` 2.x next to a ``pandas`` /
+    ``scipy`` wheel built for numpy 1.x) → ``cannot import name '__version__' from
+    numpy`` / ``pandas.compat.numpy`` import breaks that no fix-round can repair
+    (the live PROJ-262/300 ABI stall). A single batch install of the survivors
+    keeps the whole scientific stack version-consistent (issue #1139 RC-C).
     """
-    batch = subprocess.run(
-        [str(py), "-m", "pip", "install", "-q", "-r", str(req)],
+    if _pip_install(py, ["-r", str(req)]).returncode == 0:
+        return
+    lines = [
+        raw.split("#", 1)[0].strip()
+        for raw in req.read_text(encoding="utf-8", errors="replace").splitlines()
+    ]
+    lines = [ln for ln in lines if ln]
+    # Diagnose the genuinely un-installable line(s) individually (a local module
+    # or a namespace submodule wrongly auto-added — the PROJ-262 bad-line case).
+    failed = [pkg for pkg in lines if _pip_install(py, [pkg]).returncode != 0]
+    survivors = [ln for ln in lines if ln not in failed]
+    if failed:
+        logger.warning(
+            "batch `pip install -r %s` failed; skipped %d un-installable line(s): "
+            "%s", req, len(failed), failed,
+        )
+    # RECONCILE: one final BATCH install of the survivors so pip's resolver
+    # selects a single ABI-consistent version set (never the per-package mix that
+    # broke the numpy/pandas/scipy ABI). Best-effort — each survivor already
+    # installed individually above, so this only reconciles versions.
+    if survivors:
+        recon = _pip_install(py, survivors)
+        if recon.returncode != 0:
+            logger.warning(
+                "pip: survivor reconcile install returned rc=%s (deps landed "
+                "per-package; a residual version skew may remain). tail: %s",
+                recon.returncode, (recon.stderr or "")[-300:],
+            )
+
+
+def _pip_install(py: Path, args: list[str]) -> subprocess.CompletedProcess:
+    """Run ``<py> -m pip install -q <args>`` (never raises; caller checks rc)."""
+    return subprocess.run(
+        [str(py), "-m", "pip", "install", "-q", *args],
         check=False,
         capture_output=True,
         text=True,
     )
-    if batch.returncode == 0:
-        return
-    logger.warning(
-        "batch `pip install -r %s` failed (rc=%s); falling back to per-package "
-        "install so good deps still land. tail: %s",
-        req, batch.returncode, (batch.stderr or "")[-300:],
-    )
-    failed: list[str] = []
-    for raw in req.read_text(encoding="utf-8", errors="replace").splitlines():
-        pkg = raw.split("#", 1)[0].strip()
-        if not pkg:
-            continue
-        r = subprocess.run(
-            [str(py), "-m", "pip", "install", "-q", pkg],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-        if r.returncode != 0:
-            failed.append(pkg)
-    if failed:
-        logger.warning(
-            "pip: skipped %d un-installable requirement line(s): %s",
-            len(failed), failed,
-        )
 
 
 def _ensure_code_package(project_dir: Path) -> None:

--- a/src/llmxive/state/execution_status.py
+++ b/src/llmxive/state/execution_status.py
@@ -352,6 +352,8 @@ def record_offload(
     *,
     status: str,
     kernel_ref: str,
+    reason: str | None = None,
+    evidence: list[str] | None = None,
     repo_root: Path | None = None,
 ) -> dict[str, Any]:
     """Persist the async GPU-offload tri-state (issue #367) on the record.
@@ -362,6 +364,13 @@ def record_offload(
     human_input_needed while a kernel is in flight (it stays IN_PROGRESS and
     keeps polling). The rest of the execution record (ok, reason, artifacts,
     failures, fix_rounds) is PRESERVED untouched.
+
+    ``reason``/``evidence`` (issue #1139 residual, AP4): when a completed offload
+    bundle FAILS the semantic gate (fabrication/hollow/no-deliverable) — or ends
+    in a terminal error — the caller passes the gate's diagnosis so the durable
+    offload sub-record carries WHY it failed, not just the bare ``failed``
+    status. Only meaningful for ``status='failed'``; omitted for pending/retrieved
+    transitions.
     """
     existing = load(project_id, repo_root=repo_root) or {}
     prior_rounds = existing.get("fix_rounds", 0)
@@ -386,6 +395,15 @@ def record_offload(
             "status": status,
             "kernel_ref": kernel_ref,
             "submitted_at": submitted_at,
+            # Durable failure diagnosis (issue #1139 AP4): why the bundle failed
+            # the semantic gate / how the kernel terminated. Empty for the
+            # pending/retrieved transitions that carry no failure.
+            "reason": (reason or "") if status == "failed" else "",
+            "evidence": (
+                [str(e)[:600] for e in (evidence or [])][:20]
+                if status == "failed"
+                else []
+            ),
         },
         "updated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }

--- a/tests/unit/test_analysis_runner.py
+++ b/tests/unit/test_analysis_runner.py
@@ -79,18 +79,63 @@ def test_declared_deliverables_excludes_gitkeep() -> None:
     assert declared_deliverables(tasks) == set()
 
 
+# A checked-in, STABLE quickstart fixture — a multi-step run-book with setup noise
+# (cd / venv / pip / source) that must be filtered, a line-continuation to join, and
+# a `python -c` smoke line. Decoupled from any live project file (issue #1139).
+_QUICKSTART_FIXTURE = """# Quickstart
+## Setup
+```bash
+cd code
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+## Run the analysis
+```bash
+cd code
+python download_data.py --out data/raw
+python preprocess.py --in data/raw --out data/processed
+python analyze.py \\
+    --in data/processed --out results/metrics.json
+python make_figures.py --in results/metrics.json --out figures/
+python -c "import json; print(json.load(open('results/metrics.json')))"
+```
+"""
+
+
+def test_extract_run_commands_filters_setup_keeps_python() -> None:
+    """extract_run_commands keeps ONLY runnable `python` commands (joining
+    line-continuations) and drops the venv/pip/cd/source setup lines. Exercised on
+    a fixed fixture so the assertion never drifts with live project state."""
+    cmds = extract_run_commands(_QUICKSTART_FIXTURE)
+    assert cmds == [
+        "python download_data.py --out data/raw",
+        "python preprocess.py --in data/raw --out data/processed",
+        "python analyze.py  --in data/processed --out results/metrics.json",
+        "python make_figures.py --in results/metrics.json --out figures/",
+        "python -c \"import json; print(json.load(open('results/metrics.json')))\"",
+    ]
+    assert not any("pip" in c or c.startswith("cd ") or "venv" in c for c in cmds)
+
+
 def test_extract_run_commands_on_real_552_quickstart() -> None:
-    """Regression: the live PROJ-552 quickstart yields runnable commands
-    (the hollow-implementation finding — code existed, nothing ran it)."""
+    """Regression: the live PROJ-552 quickstart yields RUNNABLE commands (the
+    hollow-implementation finding — code existed, nothing ran it).
+
+    The exact command COUNT is intentionally NOT asserted: the pipeline rewrites
+    this quickstart as the project advances, so a hard-coded `>= 5` (plus a
+    'download' step) from an older, longer version went red when the run-book
+    legitimately got leaner (issue #1139 CI2). Only stable properties are checked.
+    """
     repo = Path(__file__).resolve().parents[2]
     qs = repo / ("projects/PROJ-552-quantifying-the-complexity-of-knot-diagr/"
                  "specs/010-quantifying-the-complexity-of-knot-diagr/quickstart.md")
     if not qs.is_file():
         return  # 552 spec dir may be renamed later; skip gracefully
     cmds = extract_run_commands(qs.read_text(encoding="utf-8"))
-    assert len(cmds) >= 5
+    assert cmds, "the real quickstart must yield >=1 runnable command (not zero)"
     assert all(c.startswith(("python ", "python3 ")) for c in cmds)
-    assert any("download" in c for c in cmds)  # the data-download step is present
+    assert any("main.py" in c for c in cmds)  # the analysis entrypoint is present
 
 
 def test_resolve_script_token_set(tmp_path) -> None:

--- a/tests/unit/test_intake_throttle.py
+++ b/tests/unit/test_intake_throttle.py
@@ -57,7 +57,7 @@ def test_growing_backlog_throttles_proportionally(tmp_path: Path) -> None:
     assert d.growth == 10
     assert d.allowed == 2  # int(5 * 0.5)
     assert d.throttled
-    assert "drain < intake" in d.reason
+    assert "idea-backlog" in d.reason  # the binding constraint is named
 
 
 def test_runaway_growth_stops_auto_intake_entirely(tmp_path: Path) -> None:
@@ -111,3 +111,64 @@ def test_window_expires_old_samples(tmp_path: Path) -> None:
     )
     assert d.growth == 0
     assert d.allowed == 5
+
+
+def _seed_stage(repo: Path, n: int, stage: Stage, *, start: int) -> None:
+    (repo / "state" / "projects").mkdir(parents=True, exist_ok=True)
+    for i in range(start, start + n):
+        pid = f"PROJ-{6000 + i}-x"
+        project_store.save(
+            Project(
+                id=pid, title=f"p{i}", field="test",
+                current_stage=stage, created_at=_T0, updated_at=_T0,
+                artifact_hashes={},
+                # required from 'specified' onward (in_progress/planned/tasked/…)
+                speckit_research_dir=f"projects/{pid}/specs/001-x",
+            ),
+            repo_root=repo,
+        )
+
+
+def test_growing_downstream_wip_throttles_even_with_flat_idea_backlog(tmp_path: Path) -> None:
+    """issue #1139 M1: the throttle was BLIND to the implementation pipeline. Even
+    with a FLAT idea backlog, a growing downstream WIP (in_progress filling faster
+    than it drains) must damp auto-intake."""
+    _seed_backlog(tmp_path, 10)  # flat idea backlog
+    _seed_stage(tmp_path, 5, Stage.IN_PROGRESS, start=1000)
+    it.intake_allowance(5, repo_root=tmp_path, now=_T0)
+    # idea backlog stays flat; downstream WIP grows by DOWNSTREAM_FULL_STOP_GROWTH/2.
+    _seed_stage(tmp_path, it.DOWNSTREAM_FULL_STOP_GROWTH // 2, Stage.IN_PROGRESS, start=2000)
+    d = it.intake_allowance(5, repo_root=tmp_path, now=_T0 + timedelta(hours=2))
+    assert d.growth == 0, "idea backlog is flat"
+    assert d.allowed < 5, "growing downstream WIP must damp auto-intake"
+    assert "downstream-WIP" in d.reason
+
+
+def test_downstream_wip_ceiling_stops_auto_intake(tmp_path: Path) -> None:
+    """A congested implementation pipeline above the ceiling damps auto-intake to
+    zero regardless of growth — it must DRAIN before more ideas enter."""
+    _seed_backlog(tmp_path, 5)  # small, flat idea backlog
+    _seed_stage(tmp_path, it.DOWNSTREAM_WIP_CEILING * 2, Stage.IN_PROGRESS, start=3000)
+    d = it.intake_allowance(5, repo_root=tmp_path, now=_T0)
+    assert d.allowed == 0, "auto-intake stops when downstream WIP is 2x the ceiling"
+    assert "downstream-WIP-ceiling" in d.reason
+    # Human intake is still floored.
+    h = it.intake_allowance(4, repo_root=tmp_path, kind="human", now=_T0)
+    assert h.allowed >= it.MIN_HUMAN_ALLOWANCE
+
+
+def test_downstream_wip_ceiling_is_self_recovering(tmp_path: Path) -> None:
+    """Once the pipeline drains back under the ceiling, full auto-intake resumes."""
+    _seed_backlog(tmp_path, 5)
+    _seed_stage(tmp_path, it.DOWNSTREAM_WIP_CEILING * 2, Stage.IN_PROGRESS, start=4000)
+    blocked = it.intake_allowance(5, repo_root=tmp_path, now=_T0)
+    assert blocked.allowed == 0
+    # Drain: projects reach research_complete (leave the WIP stages).
+    for p in project_store.list_all(repo_root=tmp_path):
+        if p.current_stage == Stage.IN_PROGRESS:
+            project_store.save(
+                p.model_copy(update={"current_stage": Stage.RESEARCH_COMPLETE}),
+                repo_root=tmp_path,
+            )
+    recovered = it.intake_allowance(5, repo_root=tmp_path, now=_T0 + timedelta(hours=2))
+    assert recovered.allowed == 5, "full intake resumes once WIP drains under the ceiling"

--- a/tests/unit/test_issue_1139_crossing.py
+++ b/tests/unit/test_issue_1139_crossing.py
@@ -1,0 +1,94 @@
+"""Issue #1139 — the missing HAPPY-PATH crossing contract.
+
+Round 1's audit noted: "negative-path tests lack end-to-end success contracts
+(paper completion, plan-time data provenance, ... transition closure)" and NO
+organically-advanced project had ever crossed `in_progress → research_complete`.
+
+This is that missing contract: a CORRECT, CPU-tractable simulation study runs its
+real analysis end-to-end, produces real (measured, non-fabricated, non-hollow)
+artifacts, passes the backend-independent semantic gate, and `_decide_next_stage`
+advances it to RESEARCH_COMPLETE. Real venv + real numpy/scipy, no mocks.
+
+Marked slow (installs numpy+scipy). Run: `pytest -m slow tests/unit/test_issue_1139_crossing.py`.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from llmxive.execution.stage import execute_and_gate
+from llmxive.pipeline import graph
+from llmxive.state import execution_status as es
+from llmxive.state import project as ps
+from llmxive.types import Project, Stage
+
+
+@pytest.mark.slow
+def test_correct_simulation_study_crosses_to_research_complete(tmp_path: Path) -> None:
+    pid = "PROJ-999-monte-carlo-type-i-error"
+    pdir = tmp_path / "projects" / pid
+    (pdir / "code").mkdir(parents=True)
+    (pdir / "idea").mkdir(parents=True)
+    (pdir / "specs" / "001-mc").mkdir(parents=True)
+    (tmp_path / "state" / "execution_status").mkdir(parents=True)
+
+    # A genuine simulation-methodology study: F2 authorizes its own data-gen.
+    (pdir / "idea" / "idea.md").write_text(
+        "# Type I error of the t-test under normality\n"
+        "A Monte Carlo simulation study: generate data under the null hypothesis "
+        "and estimate the Type I error rate of the two-sample t-test.\n",
+        encoding="utf-8",
+    )
+    # A REAL simulation — the reported rate is MEASURED (counted), not RNG-drawn.
+    (pdir / "code" / "main.py").write_text(
+        "import json, os\n"
+        "import numpy as np\n"
+        "from scipy import stats\n"
+        "os.makedirs('data/results', exist_ok=True)\n"
+        "rng = np.random.default_rng(0)\n"
+        "N, iters, alpha = 30, 5000, 0.05\n"
+        "false_pos = 0\n"
+        "for _ in range(iters):\n"
+        "    a = rng.normal(0, 1, N); b = rng.normal(0, 1, N)  # both under the null\n"
+        "    _, p = stats.ttest_ind(a, b)\n"
+        "    if p < alpha: false_pos += 1\n"
+        "rate = false_pos / iters  # MEASURED, not drawn\n"
+        "json.dump({'type_i_error_rate': rate, 'iters': iters, 'alpha': alpha},\n"
+        "          open('data/results/type1_error.json', 'w'), indent=2)\n"
+        "print('measured type-I error rate =', rate)\n",
+        encoding="utf-8",
+    )
+    (pdir / "code" / "requirements.txt").write_text("numpy\nscipy\n", encoding="utf-8")
+    (pdir / "specs" / "001-mc" / "quickstart.md").write_text(
+        "# Quickstart\n```bash\ncd code\npython main.py\n```\n", encoding="utf-8"
+    )
+    (pdir / "specs" / "001-mc" / "tasks.md").write_text(
+        "- [X] T001 Implement the Monte Carlo simulation in `code/main.py`\n"
+        "- [X] T002 Produce `data/results/type1_error.json`\n",
+        encoding="utf-8",
+    )
+
+    now = datetime.now(UTC)
+    proj = Project(
+        id=pid, title="MC Type I error", field="statistics",
+        current_stage=Stage.IN_PROGRESS, created_at=now, updated_at=now,
+        artifact_hashes={}, speckit_research_dir=f"projects/{pid}/specs/001-mc",
+    )
+    ps.save(proj, repo_root=tmp_path)
+
+    assert es.is_ok(pid, repo_root=tmp_path) is False
+    ok = execute_and_gate(pdir, repo_root=tmp_path)
+    assert ok is True, "a correct simulation must pass the execution gate"
+    assert es.is_ok(pid, repo_root=tmp_path) is True
+
+    rec = es.load(pid, repo_root=tmp_path)
+    assert "data/results/type1_error.json" in (rec.get("artifacts") or [])
+    assert not rec.get("failures"), "no command should have failed"
+
+    nxt = graph._decide_next_stage(proj, pdir, repo_root=tmp_path)
+    assert nxt == Stage.RESEARCH_COMPLETE, (
+        f"a correct, gated simulation must cross to research_complete, got {nxt}"
+    )

--- a/tests/unit/test_issue_1139_round2.py
+++ b/tests/unit/test_issue_1139_round2.py
@@ -1,0 +1,110 @@
+"""Issue #1139 — round-2 regression tests.
+
+Round 1 (PR #1145) fixed ~20 structural defects but the pipeline still produced
+ZERO organic `research_complete` crossings: every organic project stalls at the
+`in_progress → research_complete` execution gate. A deep audit (this round) found
+the execution gate never passes because the fix-loop cannot converge a small set
+of concrete, code-fixable defects. These tests lock the round-2 fixes.
+
+Each test names the defect id from the audit (B1/B2/B3/RC-C/F*) so the issue
+comment can point at the exact lock.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from llmxive.execution.analysis_runner import AnalysisRunResult, RunCommandResult
+from llmxive.execution.stage import _reopen_failing_tasks
+
+
+def _mk_project(tmp_path: Path, pid: str, tasks_md: str) -> Path:
+    """A project dir with a single first-glob specs dir (no canonical pointer, so
+    `_reopen_failing_tasks` falls through to the first-glob tasks.md)."""
+    proj = tmp_path / "projects" / pid
+    (proj / "specs" / "001-feature").mkdir(parents=True, exist_ok=True)
+    (proj / "specs" / "001-feature" / "tasks.md").write_text(tasks_md, encoding="utf-8")
+    (tmp_path / "state" / "execution_status").mkdir(parents=True, exist_ok=True)
+    return proj
+
+
+# ---------------------------------------------------------------------------
+# B1 — reopen the module named in the traceback TAIL, not just the entrypoint
+# ---------------------------------------------------------------------------
+
+
+def test_b1_reopen_scans_traceback_tail_for_failing_module(tmp_path: Path) -> None:
+    """The failing command is only ever the ENTRYPOINT (`python code/main.py`),
+    but a transitive-import bug lives in a module named solely in the traceback
+    tail (`code/analysis/aggregator.py` → `code/simulation/output_writer.py`).
+    Before the fix, only the entrypoint task was reopened, the buggy-module task
+    stayed `[X]`, and the implementer oscillated on main.py forever (live PROJ-341).
+    The reopen must un-check the buggy-module tasks named in the tail."""
+    pid = "PROJ-B1-import-chain"
+    tasks_md = (
+        "- [X] T001 Create the `code/main.py` entrypoint\n"
+        "- [X] T002 Implement `code/analysis/aggregator.py`\n"
+        "- [X] T003 Implement `code/simulation/output_writer.py`\n"
+        "- [X] T004 Write `code/plots/figures.py` (unrelated, must stay done)\n"
+    )
+    proj = _mk_project(tmp_path, pid, tasks_md)
+
+    tail = (
+        "Traceback (most recent call last):\n"
+        f'  File "{proj}/code/main.py", line 24, in <module>\n'
+        "    from code.analysis.aggregator import main as aggregator_main\n"
+        f'  File "{proj}/code/analysis/aggregator.py", line 13, in <module>\n'
+        "    from code.simulation.output_writer import load_p_values_raw\n"
+        f'  File "{proj}/code/simulation/output_writer.py", line 40, in <module>\n'
+        "    log_operation(logger)('start')\n"
+        "TypeError: 'LogEntry' object is not callable\n"
+    )
+    res = AnalysisRunResult(
+        ok=False,
+        commands=[
+            RunCommandResult("python code/main.py", False, 1, 0.5, False, tail),
+        ],
+    )
+
+    reopened = _reopen_failing_tasks(proj, res)
+    after = (proj / "specs" / "001-feature" / "tasks.md").read_text(encoding="utf-8")
+
+    assert reopened >= 3
+    assert "- [ ] T001" in after, "entrypoint task should reopen"
+    assert "- [ ] T002" in after, "aggregator (named in tail) must reopen"
+    assert "- [ ] T003" in after, "output_writer (the real bug, tail-only) must reopen"
+    assert "- [X] T004" in after, "unrelated task must stay done"
+
+
+def test_b1_tail_scan_ignores_venv_library_frames(tmp_path: Path) -> None:
+    """A traceback that passes THROUGH an installed dependency under the per-project
+    venv (`code/.venv/.../site-packages/pandas/...`) must NOT reopen anything for the
+    library frame — only the project's own `code/` modules."""
+    pid = "PROJ-B1-venv"
+    tasks_md = (
+        "- [X] T001 Create `code/main.py`\n"
+        "- [X] T002 Implement `code/loaders/ingest.py`\n"
+    )
+    proj = _mk_project(tmp_path, pid, tasks_md)
+    tail = (
+        "Traceback (most recent call last):\n"
+        f'  File "{proj}/code/main.py", line 3, in <module>\n'
+        "    from code.loaders.ingest import load\n"
+        f'  File "{proj}/code/loaders/ingest.py", line 2, in <module>\n'
+        "    import pandas as pd\n"
+        f'  File "{proj}/code/.venv/lib/python3.11/site-packages/pandas/compat/__init__.py", line 27\n'
+        "    from pandas.compat.numpy import is_numpy_dev\n"
+        "ImportError: cannot import name 'is_numpy_dev'\n"
+    )
+    res = AnalysisRunResult(
+        ok=False,
+        commands=[RunCommandResult("python code/main.py", False, 1, 0.5, False, tail)],
+    )
+    reopened = _reopen_failing_tasks(proj, res)
+    after = (proj / "specs" / "001-feature" / "tasks.md").read_text(encoding="utf-8")
+    assert "- [ ] T001" in after
+    assert "- [ ] T002" in after, "the project's own ingest.py (in the tail) reopens"
+    # The pandas library frame did not add a spurious task or crash.
+    assert "pandas" not in after
+    assert reopened >= 2

--- a/tests/unit/test_issue_1139_round2.py
+++ b/tests/unit/test_issue_1139_round2.py
@@ -231,3 +231,94 @@ def test_b3_script_missing_selfheal_is_self_owning(tmp_path: Path) -> None:
         "self-heal must not append a duplicate reconciliation task each round"
     )
     assert second == 0, "a converged self-heal reopens nothing new on the next round"
+
+
+# ---------------------------------------------------------------------------
+# F3 — RNG-metric detector uses identifier TOKENS, not substrings
+# ---------------------------------------------------------------------------
+
+from llmxive.execution.fabrication_guard import (  # noqa: E402
+    _scan_code_rng_metrics,
+    _synthetic_data_authorized,
+    find_synthetic_data_use,
+)
+
+
+def test_f3_rng_metric_name_is_token_matched_not_substring() -> None:
+    """`_METRIC_NAME_RE` matched 'ratio' as a SUBSTRING, so 'concentration',
+    'duration', 'iteration' (all contain 'ratio') were wrongly flagged as
+    fabricated METRICS when assigned from an RNG — but those are simulated INPUT
+    quantities, not reported metrics (live PROJ-475 'concentration'). Token
+    matching flags the real metric names and stops the substring false positives.
+    """
+    # FALSE-POSITIVE names (contain a metric word as a substring only) — NOT flagged.
+    for name in ("concentration", "duration", "iteration", "moderation"):
+        code = f"import numpy as np\n{name} = np.random.normal(0, 1, 100)\n"
+        assert _scan_code_rng_metrics(code, source="sim.py") == [], (
+            f"{name!r} is a simulated input, not a fabricated metric"
+        )
+    # TRUE-POSITIVE metric names — still flagged (detection preserved).
+    for name in ("speedup", "throughput_ratio", "accuracy", "mem_usage"):
+        code = f"import random\n{name} = random.uniform(1.5, 2.0)\n"
+        findings = _scan_code_rng_metrics(code, source="bench.py")
+        assert findings, f"{name!r} assigned from an RNG draw must still be flagged"
+
+
+def test_f3_preserves_proj604_fabricator_pattern() -> None:
+    """The PROJ-604 true positive (a fabricator function returning a bare RNG draw,
+    whose result is assigned to a metric) MUST still fire."""
+    code = (
+        "import random\n"
+        "def simulate_gemm_throughput(n):\n"
+        "    return random.uniform(100, 200)\n"
+        "speedup = simulate_gemm_throughput(4)\n"
+    )
+    findings = _scan_code_rng_metrics(code, source="quant.py")
+    assert any("simulate_gemm_throughput" in f for f in findings)
+    assert any("speedup" in f for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# F2 — simulation-methodology studies are AUTHORIZED to generate their own data
+# ---------------------------------------------------------------------------
+
+
+def _mk_idea(tmp_path: Path, pid: str, idea_text: str) -> Path:
+    proj = tmp_path / "projects" / pid
+    (proj / "idea").mkdir(parents=True, exist_ok=True)
+    (proj / "idea" / "idea.md").write_text(idea_text, encoding="utf-8")
+    return proj
+
+
+def test_f2_authorizes_simulation_methodology_vocab(tmp_path: Path) -> None:
+    """A statistical simulation study legitimately GENERATES its own data as the
+    METHOD. Its idea describes a Monte-Carlo / power / Type-I-error design without
+    the literal 'synthetic data' noun phrase, so the narrow authorizer failed and
+    the study was wrongly fabrication-blocked (live PROJ-427). The expanded
+    authorizer recognises simulation-methodology intent."""
+    for vocab in (
+        "We run a Monte Carlo simulation to establish Type I error rates.",
+        "A power analysis via simulation under the null hypothesis.",
+        "Each simulation batch generates datasets with known ground truth.",
+        "This is a simulation study of estimator bias across 10,000 simulated datasets.",
+    ):
+        proj = _mk_idea(tmp_path, "PROJ-SIM-" + str(abs(hash(vocab)) % 9999), vocab)
+        assert _synthetic_data_authorized(proj) is True, f"should authorize: {vocab!r}"
+
+
+def test_f2_does_not_authorize_realworld_idea(tmp_path: Path) -> None:
+    """A real-world-insight project (no simulation-methodology intent) is NOT
+    authorized to substitute synthetic data — fabrication detection preserved."""
+    proj = _mk_idea(
+        tmp_path, "PROJ-REAL-1",
+        "Predict cognitive decline from resting-state fMRI connectivity in the "
+        "HCP dataset using a regularized regression.",
+    )
+    assert _synthetic_data_authorized(proj) is False
+    # And synthetic input in its code is still surfaced as a finding.
+    (proj / "code").mkdir(exist_ok=True)
+    (proj / "code" / "load.py").write_text(
+        "def load():\n    return make_synthetic_data()  # synthetic data fallback\n",
+        encoding="utf-8",
+    )
+    assert find_synthetic_data_use(proj), "unauthorized synthetic input must still flag"

--- a/tests/unit/test_issue_1139_round2.py
+++ b/tests/unit/test_issue_1139_round2.py
@@ -16,7 +16,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from llmxive.execution.analysis_runner import AnalysisRunResult, RunCommandResult
-from llmxive.execution.stage import _reopen_failing_tasks
+from llmxive.execution.stage import (
+    _FEEDBACK_FILENAME,
+    _reopen_failing_tasks,
+    _runbook_cli_mismatches,
+    _write_execution_feedback,
+)
 
 
 def _mk_project(tmp_path: Path, pid: str, tasks_md: str) -> Path:
@@ -108,3 +113,121 @@ def test_b1_tail_scan_ignores_venv_library_frames(tmp_path: Path) -> None:
     # The pandas library frame did not add a spurious task or crash.
     assert "pandas" not in after
     assert reopened >= 2
+
+
+# ---------------------------------------------------------------------------
+# B2 — run-book / CLI (argparse) mismatch is diagnosed for the implementer
+# ---------------------------------------------------------------------------
+
+_ARGPARSE_TAIL_REQUIRED = (
+    "usage: extract_metrics.py [-h] --input INPUT --output OUTPUT\n"
+    "                          [--extension EXTENSION]\n"
+    "extract_metrics.py: error: the following arguments are required: --input, --output\n"
+)
+_ARGPARSE_TAIL_UNRECOGNIZED = (
+    "usage: simulation_runner.py [-h] [--iterations ITERATIONS]\n"
+    "simulation_runner.py: error: unrecognized arguments: --icc 0.1 --alpha 0.05\n"
+)
+
+
+def test_b2_detects_argparse_runbook_mismatch() -> None:
+    """A quickstart command whose argparse rejects the args ('the following
+    arguments are required' / 'unrecognized arguments') is a run-book/CLI drift —
+    re-running never succeeds and editing the script body won't help. The detector
+    surfaces (command, usage, error) for each (live PROJ-148/239/585)."""
+    res = AnalysisRunResult(
+        ok=False,
+        commands=[
+            RunCommandResult(
+                "python code/extract_metrics.py", False, 2, 0.1, False,
+                _ARGPARSE_TAIL_REQUIRED,
+            ),
+            RunCommandResult(
+                "python code/simulation_runner.py --icc 0.1 --alpha 0.05",
+                False, 2, 0.1, False, _ARGPARSE_TAIL_UNRECOGNIZED,
+            ),
+            RunCommandResult(  # an ordinary crash — NOT a CLI mismatch
+                "python code/train.py", False, 1, 0.1, False,
+                "Traceback ...\nValueError: shapes not aligned\n",
+            ),
+        ],
+    )
+    mm = _runbook_cli_mismatches(res)
+    cmds = {c for c, _u, _e in mm}
+    assert cmds == {
+        "python code/extract_metrics.py",
+        "python code/simulation_runner.py --icc 0.1 --alpha 0.05",
+    }, "only the two argparse-mismatch commands (not the ValueError crash)"
+    # usage + error are carried through
+    by_cmd = {c: (u, e) for c, u, e in mm}
+    assert "--input INPUT --output OUTPUT" in by_cmd["python code/extract_metrics.py"][0]
+    assert "required" in by_cmd["python code/extract_metrics.py"][1]
+    assert "unrecognized arguments" in by_cmd[
+        "python code/simulation_runner.py --icc 0.1 --alpha 0.05"][1]
+
+
+def test_b2_feedback_names_the_cli_mismatch(tmp_path: Path) -> None:
+    """The execution feedback the implementer reads must call out the run-book/CLI
+    mismatch explicitly (command + the script's real usage + the argparse error),
+    so the implementer reconciles the quickstart and the script's argparse instead
+    of pointlessly editing the script body."""
+    mem = tmp_path / ".specify" / "memory"
+    res = AnalysisRunResult(
+        ok=False,
+        commands=[
+            RunCommandResult(
+                "python code/extract_metrics.py", False, 2, 0.1, False,
+                _ARGPARSE_TAIL_REQUIRED,
+            ),
+        ],
+    )
+    failures = ["python code/extract_metrics.py -> rc=2\n    " + _ARGPARSE_TAIL_REQUIRED]
+    _write_execution_feedback(mem, res, failures)
+    fb = (mem / _FEEDBACK_FILENAME).read_text(encoding="utf-8")
+    assert "RUN-BOOK" in fb and "CLI" in fb
+    assert "extract_metrics.py" in fb
+    assert "--input INPUT --output OUTPUT" in fb  # the real usage is shown
+    assert "the following arguments are required" in fb  # the argparse error is shown
+
+
+# ---------------------------------------------------------------------------
+# B3 — script-missing self-heal appends a SELF-OWNING reconciliation task
+# ---------------------------------------------------------------------------
+
+
+def test_b3_script_missing_selfheal_is_self_owning(tmp_path: Path) -> None:
+    """A run-book command naming a script NO task created (script_missing) must get
+    a reconciliation task that (a) names the EXACT run-book path and (b) is
+    self-owning — a second identical failure round must NOT append a duplicate (the
+    PROJ-552 stall was the loop never converging). Guards convergence within a
+    spec cycle."""
+    pid = "PROJ-B3-scriptmissing"
+    tasks_md = (
+        "- [X] T001 Build `code/main.py`\n"
+        "- [X] T002 Produce `data/results.json`\n"
+    )
+    proj = _mk_project(tmp_path, pid, tasks_md)
+    missing = "code/reproducibility/checksum_generator.py"
+    res = AnalysisRunResult(
+        ok=False,
+        commands=[
+            RunCommandResult(
+                f"python {missing}", False, 2, 0.1, False,
+                "[script missing]", script_missing=True,
+            ),
+        ],
+    )
+
+    first = _reopen_failing_tasks(proj, res)
+    after1 = (proj / "specs" / "001-feature" / "tasks.md").read_text(encoding="utf-8")
+    assert first >= 1
+    assert "Reconcile run-book" in after1
+    assert missing in after1, "the reconciliation task must name the exact run-book path"
+
+    # Second identical round: the appended task now OWNS the path → no duplicate.
+    second = _reopen_failing_tasks(proj, res)
+    after2 = (proj / "specs" / "001-feature" / "tasks.md").read_text(encoding="utf-8")
+    assert after2.count("Reconcile run-book vs implementation for `%s`" % missing) == 1, (
+        "self-heal must not append a duplicate reconciliation task each round"
+    )
+    assert second == 0, "a converged self-heal reopens nothing new on the next round"

--- a/tests/unit/test_issue_1139_round2_downstream.py
+++ b/tests/unit/test_issue_1139_round2_downstream.py
@@ -1,0 +1,176 @@
+"""Issue #1139 round-2 downstream fixes (audit A4/A5/A6, P1-2 residual).
+
+Four independent fixes, each with a real (no-mock) test:
+
+* Fix 1 — ``scripts/maintenance/backfill_failure_class.py`` reconstructs the
+  durable ``failure_class`` on legacy execution-status records.
+* Fix 2 — the paper-compile workflow now invokes the deterministic PDF audit
+  (non-failing, bounded) so restyled papers reach ``audited``.
+* Fix 3 — the ``reproduction.md`` state-reader allowlist justification names the
+  ACCURATE consumer (git-committed human artifact, not a dashboard link).
+* Fix 4 — a failed GPU-offload record carries the semantic-gate diagnosis.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+_REPO = Path(__file__).resolve().parents[2]
+
+
+# --------------------------------------------------------------------------- #
+# Fix 1: backfill_failure_class migration
+# --------------------------------------------------------------------------- #
+def _load_backfill():
+    script = _REPO / "scripts" / "maintenance" / "backfill_failure_class.py"
+    spec = importlib.util.spec_from_file_location("backfill_failure_class", script)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _seed_exec_status(repo: Path, pid: str, rec: dict) -> Path:
+    d = repo / "state" / "execution_status"
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / f"{pid}.json"
+    p.write_text(json.dumps(rec, indent=2) + "\n", encoding="utf-8")
+    return p
+
+
+def test_backfill_failure_class_reconstructs_classes(tmp_path: Path) -> None:
+    mod = _load_backfill()
+
+    # compute_env failure (CUDA), no failure_class key.
+    _seed_exec_status(tmp_path, "PROJ-001", {
+        "project_id": "PROJ-001", "ok": False,
+        "reason": "analysis failed", "artifacts": [],
+        "failures": ["python code/train.py -> rc=1: RuntimeError: CUDA out of memory"],
+    })
+    # data_unreachable failure (HfUriError), failure_class present but null.
+    _seed_exec_status(tmp_path, "PROJ-002", {
+        "project_id": "PROJ-002", "ok": False, "failure_class": None,
+        "reason": "dataset load failed", "artifacts": [],
+        "failures": ["python code/load.py -> rc=1: HfUriError: Repository id must be 'namespace/name'"],
+    })
+    # fabrication failure — signal only in the reason string (SemanticGate prose).
+    _seed_exec_status(tmp_path, "PROJ-003", {
+        "project_id": "PROJ-003", "ok": False,
+        "reason": "2 fabricated/simulated-result signal(s) — results are not real measurements",
+        "artifacts": [], "failures": ["python code/run.py -> rc=0"],
+    })
+    # ok=true — MUST be left untouched.
+    _seed_exec_status(tmp_path, "PROJ-004", {
+        "project_id": "PROJ-004", "ok": True,
+        "reason": "3 artifacts produced", "artifacts": ["results/x.json"], "failures": [],
+    })
+    # already-classified failure — MUST be left untouched (idempotent).
+    _seed_exec_status(tmp_path, "PROJ-005", {
+        "project_id": "PROJ-005", "ok": False, "failure_class": "execution_bug",
+        "reason": "ImportError", "artifacts": [],
+        "failures": ["python code/a.py -> rc=1: ImportError"],
+    })
+
+    rc = mod.main(["--apply", "--repo-root", str(tmp_path)])
+    assert rc == 0
+
+    def _load(pid: str) -> dict:
+        return json.loads((tmp_path / "state" / "execution_status" / f"{pid}.json").read_text())
+
+    assert _load("PROJ-001")["failure_class"] == "compute_env"
+    assert _load("PROJ-001")["evidence"]  # matched infra signal recorded
+    assert _load("PROJ-002")["failure_class"] == "data_unreachable"
+    assert _load("PROJ-003")["failure_class"] == "fabrication"
+
+    # ok=true untouched: no failure_class key added.
+    p004 = _load("PROJ-004")
+    assert p004["ok"] is True
+    assert "failure_class" not in p004 or p004["failure_class"] is None
+
+    # already-classified untouched: value preserved.
+    assert _load("PROJ-005")["failure_class"] == "execution_bug"
+
+
+def test_backfill_failure_class_dry_run_writes_nothing(tmp_path: Path) -> None:
+    mod = _load_backfill()
+    rec = {
+        "project_id": "PROJ-010", "ok": False,
+        "reason": "boom", "artifacts": [],
+        "failures": ["python code/x.py -> rc=1: RuntimeError: CUDA error"],
+    }
+    p = _seed_exec_status(tmp_path, "PROJ-010", rec)
+    before = p.read_text()
+    rc = mod.main(["--repo-root", str(tmp_path)])  # no --apply
+    assert rc == 0
+    assert p.read_text() == before  # dry-run mutated nothing
+
+
+# --------------------------------------------------------------------------- #
+# Fix 2: paper-compile workflow wires the PDF audit (safe + bounded + non-failing)
+# --------------------------------------------------------------------------- #
+def test_paper_compile_workflow_wires_pdf_audit() -> None:
+    wf_path = _REPO / ".github" / "workflows" / "paper-compile.yml"
+    doc = yaml.safe_load(wf_path.read_text())  # parses cleanly
+    steps = doc["jobs"]["compile"]["steps"]
+    audit_steps = [s for s in steps if "pdf-pipeline audit" in (s.get("run") or "")]
+    assert len(audit_steps) == 1, "expected exactly one PDF-audit step"
+    run = audit_steps[0]["run"]
+    # Non-failing: swallows per-paper exit codes and never fails the job.
+    assert "set +e" in run and "exit 0" in run
+    # Bounded: caps the sweep so one tick cannot audit unboundedly.
+    assert "200" in run
+    # Runs AFTER compile and BEFORE the commit step so state changes get pushed.
+    names = [s.get("name", "") for s in steps]
+    assert names.index(audit_steps[0]["name"]) < names.index("Commit + push")
+
+
+# --------------------------------------------------------------------------- #
+# Fix 3: reproduction.md allowlist justification names the real consumer
+# --------------------------------------------------------------------------- #
+def test_reproduction_allowlist_justification_is_accurate() -> None:
+    from llmxive.checks.state_readers import ALLOWLIST
+
+    just = ALLOWLIST["reproduction.md"]
+    # Accurate consumer: a git-committed human artifact.
+    assert "git-committed" in just
+    assert "human" in just
+    # No longer claims the non-existent dashboard link (audit A4).
+    assert "dashboard artifact" not in just
+
+
+# --------------------------------------------------------------------------- #
+# Fix 4: a failed offload record carries the gate's diagnosis
+# --------------------------------------------------------------------------- #
+def test_failed_offload_record_carries_reason(tmp_path: Path) -> None:
+    from llmxive.state import execution_status
+
+    pid = "PROJ-900"
+    # A prior in-flight offload sub-record (submitted) — no reason yet.
+    submitted = execution_status.record_offload(
+        pid, status="submitted", kernel_ref="user/kern-1", repo_root=tmp_path,
+    )
+    assert submitted["offload"]["reason"] == ""  # pending carries no failure reason
+
+    # Now the bundle fails the semantic gate: reason + evidence must persist.
+    rec = execution_status.record_offload(
+        pid, status="failed", kernel_ref="user/kern-1",
+        reason="2 fabricated/simulated-result signal(s) — results are not real",
+        evidence=["results/metrics.json: constant 0.0"],
+        repo_root=tmp_path,
+    )
+    off = rec["offload"]
+    assert off["status"] == "failed"
+    assert "fabricated" in off["reason"]
+    assert off["evidence"] == ["results/metrics.json: constant 0.0"]
+
+    # Durable: re-loading from disk shows the same diagnosis.
+    reloaded = execution_status.offload_state(pid, repo_root=tmp_path)
+    assert reloaded["reason"] == off["reason"]
+    assert reloaded["evidence"] == off["evidence"]
+    # And the offload transition never bumped fix_rounds.
+    assert rec["fix_rounds"] == 0

--- a/tests/unit/test_sandbox_venv.py
+++ b/tests/unit/test_sandbox_venv.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from llmxive import sandbox
 
 
@@ -84,3 +86,36 @@ def test_ensure_venv_tolerates_a_bad_requirement_line(tmp_path: Path) -> None:
     )
     assert res.ok, res.stderr
     assert "venv-ok" in res.stdout
+
+
+@pytest.mark.slow
+def test_ensure_venv_installs_abi_consistent_scipy_stack(tmp_path: Path) -> None:
+    """Issue #1139 RC-C: an unpinned scientific stack alongside a bad line must
+    land an ABI-CONSISTENT numpy/pandas set — the old per-package fallback could
+    install numpy 2.x next to a pandas wheel built for numpy 1.x, breaking with
+    `cannot import name '__version__' from numpy` / `pandas.compat.numpy` (the
+    PROJ-262/300 ABI stall). Prune-and-rebatch reconciles the survivors in one
+    resolver pass. Real install; verifies numpy and pandas import AND interoperate.
+    """
+    proj = tmp_path / "projects" / "PROJ-ABICONSISTENT"
+    (proj / "code").mkdir(parents=True)
+    (proj / "code" / "requirements.txt").write_text(
+        "numpy\npandas\nllmxive-nonexistent-package-zzz999  # bogus, must be skipped\n",
+        encoding="utf-8",
+    )
+    py = sandbox.ensure_venv(proj)  # must not raise despite the bad line
+    assert py.exists()
+    # numpy AND pandas import and INTEROPERATE — proves the ABI is consistent
+    # (a numpy/pandas ABI skew raises on `import pandas` or on DataFrame creation).
+    res = sandbox.run_in_venv(
+        project_dir=proj,
+        args=[
+            "-c",
+            "import numpy, pandas; "
+            "df = pandas.DataFrame(numpy.arange(6).reshape(2, 3)); "
+            "print('abi-ok', df.to_numpy().sum())",
+        ],
+        timeout_s=600,
+    )
+    assert res.ok, res.stderr
+    assert "abi-ok 15" in res.stdout


### PR DESCRIPTION
## Round 2 — resolve the execution wall that let 0 projects ever cross (#1139)

Round 1 (PR #1145) landed ~20 structural fixes; a monitoring loop then concluded "no regressions but no crossings — throughput-bound, not a bug." **That was wrong.** A fresh 6-front audit found a *structural* execution wall: across 1,089 projects, **zero have ever crossed `research_complete`** (or any downstream/terminal state); the only 7 `ok=true` records are stale arXiv intakes. The crossing gate needs both all-tasks-done **and** a passing execution — and no organic project's execution ever passed.

### Root cause (superposition, not one bug) and the fixes
| id | fix |
|-|-|
| **B1** | `_reopen_failing_tasks` scanned only the failing COMMAND; the real bug lives in a traceback-**tail** module → implementer oscillated on the entrypoint forever. Now scans command **and** tail (fs frames + dotted imports), excluding venv frames. |
| **B2** | run-book/CLI (argparse) mismatch now diagnosed — surfaces the script's real `usage:` diff instead of letting the implementer edit the body pointlessly. |
| **B3** | verified the script-missing self-heal is self-owning + convergent (locked). |
| **RC-C** | pip fallback installed packages separately → numpy/pandas ABI break; now prune-and-rebatch in one resolver pass. |
| **F2/F3** | fabrication guard: authorize simulation-methodology studies (Monte-Carlo/power) + tokenize metric names (`ratio` no longer matches `concentration`). Real detection (PROJ-604) preserved. |
| **CI1** | advance.yml cadence `*/30`→hourly, timeout 150→90 — stops the concurrency-eviction that cancelled 8/12 runs. |
| **CI2** | de-brittle the sole red unit test (coupled to a live pipeline-mutated file). |
| **M1** | intake throttle now sees downstream WIP (was blind to 492 in_progress + 0 departures). |
| **P1-2** | backfill migration for 37 execution_status records missing `failure_class`. |
| **A5** | wire the orphaned `pdf-pipeline audit` into paper-compile so `restyled_unaudited → audited` happens. |
| **CI** | the offline unit suite (6k tests) was run by NO workflow — added a fast unit lane to the per-PR gate. |

### Proof the wall is crossable
New `tests/unit/test_issue_1139_crossing.py`: a correct CPU-tractable Monte-Carlo simulation project runs its real analysis (real venv + numpy/scipy), produces a measured artifact, passes the semantic gate, and `_decide_next_stage` → `RESEARCH_COMPLETE`. This is the happy-path success contract the round-1 audit said was missing. Live-verified too: the real Dartmouth implementer, now correctly directed by B1 at `aggregator.py`, autonomously repaired a long-stalled project's import chain.

### Verification
- `python -m llmxive.checks.{prompts,speckit_scripts,backends,state_readers}` → all exit 0
- `pytest tests/contract` → 86 passed, 2 skipped
- `pytest tests/unit -m "not slow"` → green (the one red test fixed)
- new regression files: `test_issue_1139_round2.py`, `test_issue_1139_round2_downstream.py`, `test_issue_1139_crossing.py` (slow), RC-C sandbox test (slow)

Every problem is documented with before/after evidence in comments on #1139.

Closes the actionable scope of #1139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)