### PR TITLE
fix: classify Dartmouth transient auth-flap + HTTP 499 as transient (engine-failures #505/#515-518); self-clearing escalation digest (#314)

### DIFF
--- a/notes/2026-07-16-engine-failure-issues.md
+++ b/notes/2026-07-16-engine-failure-issues.md
@@ -1,0 +1,84 @@
+# Engine-failure issues + #314 — root cause & fix (2026-07-16)
+
+Scope: all open `engine-failure` issues (#505, #515, #516, #517, #518) and the
+escalation-digest issue #314. Goal: fix root causes, post evidence comments,
+tests green.
+
+## Findings
+
+### #505 — `PermanentBackendError: Client Closed Request`
+- HTTP **499** (upstream proxy closed the connection before the Dartmouth vLLM
+  pod first-byte). Textbook transient, but `"client closed request"` was not in
+  `dartmouth._TRANSIENT_ERROR_MARKERS`, so `_do_one_attempt` fell through to the
+  catch-all `raise PermanentBackendError`. A permanent error → `_stage_panel`
+  files an engine-failure issue (FR-016). A transient → `BackendUnavailable` →
+  no issue, project retries next tick.
+
+### #515–518 — `PermanentBackendError: 'API key invalid!'`
+- Not our string — comes from Dartmouth's gateway. Key is **valid** (live catalog
+  probe returns HTTP 200 / 43 models today). All four issues clustered in a
+  ~2h window on **2026-07-06 (00:56Z→02:58Z)** then stopped — a transient
+  auth-service flap, NOT a persistently-bad credential (which would fail every
+  cron cycle continuously).
+- Same misclassification: an unmatched auth string → `PermanentBackendError` →
+  spurious engine-failure issue.
+
+### #314 — escalation digest
+- Every row was **PROJ-552** (2026-06-11..18), long resolved: post-mortem
+  `notes/2026-06-11-proj-552-postmortem.md` + router `saw_transient`/`saw_outage`
+  → `BackendUnavailable` fixes; project has since advanced to the **execution**
+  stage (`state/execution_status/PROJ-552-…json`, total_attempts=16, 2026-07-13).
+- Bug: escalation records were write-once/forever and `build_digest_markdown`
+  rendered ALL of them → resolved rows never left the digest. A maintainer had
+  worked around it by stuffing `"resolved: …"` into `digest_id` (a hack the body
+  ignored).
+
+## Fixes
+
+### `src/llmxive/backends/dartmouth.py`
+- Added `"client closed request"`, `"499"` to `_TRANSIENT_ERROR_MARKERS`.
+- Added `_AUTH_ERROR_MARKERS` + `_is_auth_error_text`.
+- Added `_gateway_rejects_key()` — a cached catalog-endpoint preflight (same key +
+  host as chat); True only on a definitive 401/403; False on 200 or any
+  indeterminate outcome ("cannot confirm the key is bad"); probes up to 3×.
+- Added `_raise_for_backend_error(text, exc)` — THE single classification
+  chokepoint: model-down → transient → auth-flap-when-key-valid → permanent.
+  `_do_one_attempt` now delegates to it.
+- Extracted `_catalog_get(key, timeout)` — single lazy `requests` import + auth
+  header (used by `_fetch_cloud_models` and `_gateway_rejects_key`).
+- Net: a transient flap (valid key) → `TransientBackendError` → no spurious
+  issue; a genuinely bad key (catalog 401/403) → stays `PermanentBackendError`
+  (fail-fast, loud). `_is_transient_error_text` stays a pure, over-match-free
+  function so `test_permanent_errors_stay_permanent` is unaffected.
+
+### `src/llmxive/state/escalations.py`
+- `EscalationRecord.resolution` field + `_is_resolved()` (recognizes the legacy
+  `digest_id:"resolved:…"` hack).
+- `list_records(include_resolved=False)` default-excludes resolved.
+- `resolve_records(project_id, note=…, stage=…, loop=…)` — clean resolution.
+- `refresh_digest()` + `_find_digest_issue()` — re-render the live digest from
+  unresolved records without waiting for a new escalation.
+- `update_digest` body now resolved-free. `GhRunner` type alias annotates all
+  `gh` params (fixed 2 pre-existing mypy no-untyped-def errors too).
+- Marked the 5 stale PROJ-552 records resolved (audit trail preserved on disk).
+
+## Tests (all real, TDD RED→GREEN)
+- `tests/unit/test_dartmouth_retry.py`: +5 (client-closed-499, auth-error-matcher,
+  auth-flap-transient, genuine-bad-key-permanent, classifier-precedence).
+- `tests/unit/test_escalation_paths.py`: +5 (resolved excluded from listing/digest,
+  resolution note persists, stage filter, refresh_digest repatches, update_digest
+  omits resolved).
+- Full offline suite: 6700 passed / 17 skipped. ruff + mypy clean on changed files.
+
+## Direct evidence (fixed tree)
+```
+_gateway_rejects_key() [live]            -> False (key accepted)
+#505 Client Closed Request               -> TransientBackendError
+#515-518 API key invalid! (valid key)    -> TransientBackendError
+genuine bad key (catalog 401)            -> PermanentBackendError
+list_records() before/after resolve      -> 4 -> 0 (digest rows); 5 preserved w/ include_resolved
+```
+
+## Remaining GitHub ops (post-merge / live)
+- Evidence comments posted on #505/#515/#516/#517/#518/#314.
+- #314 body refreshes to zero rows via `refresh_digest` / next `update_digest`.

--- a/src/llmxive/backends/dartmouth.py
+++ b/src/llmxive/backends/dartmouth.py
@@ -12,7 +12,7 @@ import os
 import random
 import time
 from collections.abc import Callable, Iterable
-from typing import Any, TypeVar
+from typing import Any, NoReturn, TypeVar
 
 from llmxive.backends.base import (
     BackendUnavailable,
@@ -249,6 +249,12 @@ _TRANSIENT_ERROR_MARKERS: tuple[str, ...] = (
     "not found", "no such model", "does not exist", "model_not_found",
     # Network-level transients:
     "temporary failure", "name resolution", "connection error",
+    # HTTP 499: an upstream proxy/gateway closed the connection before the model
+    # responded (Dartmouth returns this when the vLLM pod is slow to first-byte).
+    # A textbook transient — retrying/falling through to a peer recovers it.
+    # (engine-failure #505: was misclassified PermanentBackendError, crashing the
+    # plan stage and filing a spurious engine-failure issue.)
+    "client closed request", "499",
     # Connection dropped mid-stream while reading a large response (common when a
     # flaky endpoint streams a big planner/reviewer reply): requests
     # ChunkedEncodingError wrapping urllib3/http.client IncompleteRead, SSL EOF,
@@ -282,6 +288,124 @@ def _is_model_down_text(text: str) -> bool:
     """True if *text* names the maintenance/outage redirect (model is DOWN)."""
     low = text.lower()
     return any(marker in low for marker in _MODEL_DOWN_MARKERS)
+
+
+# Substrings that mark a Dartmouth failure as an AUTH rejection ("API key
+# invalid!", a 401/403). These are DELIBERATELY kept out of _TRANSIENT_ERROR_MARKERS
+# — an auth rejection is AMBIGUOUS: it can mean a genuinely bad/expired key (a real
+# config error → fail fast + loud) OR a transient auth-service flap that spuriously
+# rejects a VALID key (engine-failure #515-518: a ~2h Dartmouth flap on 2026-07-06).
+# The two are disambiguated at classification time by _gateway_rejects_key (a live
+# catalog-endpoint probe), NOT by substring — so _is_transient_error_text stays a
+# pure, over-match-free function.
+_AUTH_ERROR_MARKERS: tuple[str, ...] = (
+    "api key invalid", "invalid api key", "unauthorized", "authentication",
+    "401", "403", "not authenticated", "invalid_api_key", "authenticationerror",
+    "invalid authentication", "incorrect api key",
+)
+
+
+def _is_auth_error_text(text: str) -> bool:
+    """True if *text* (a lowercased exception str) names an auth/key rejection."""
+    low = text.lower()
+    return any(marker in low for marker in _AUTH_ERROR_MARKERS)
+
+
+# Process-cached result of the key-validity preflight. True = the gateway
+# DEFINITIVELY rejects the configured key (genuine bad/expired key). False/None =
+# accepted or indeterminate ("cannot confirm the key is bad"). Only a definitive
+# True is cached — an indeterminate probe (network/5xx/flap) is re-probed on the
+# next auth error rather than being frozen into a wrong verdict.
+_KEY_REJECTED_CACHE: bool | None = None
+
+
+def _catalog_get(key: str, *, timeout: float = 30.0):  # type: ignore[no-untyped-def]
+    """GET the Dartmouth chat catalog authenticated with *key*, returning the
+    ``requests.Response`` (the caller inspects status / raises). THE single place
+    the lazy ``requests`` import and the auth header live (Constitution I) — used
+    by both the free-model catalog fetch and the key-validity preflight."""
+    import requests  # type: ignore[import-untyped]  # no stubs; types-requests not installed
+
+    return requests.get(
+        _cloud_models_url(),
+        headers={"Authorization": f"Bearer {key}"},
+        timeout=timeout,
+    )
+
+
+def _gateway_rejects_key(*, force_refresh: bool = False) -> bool:
+    """True ONLY if the Dartmouth chat catalog endpoint DEFINITIVELY rejects the
+    configured key (HTTP 401/403) — i.e. the key is genuinely bad/expired.
+
+    The catalog uses the SAME key + host as chat completions, so it is an exact
+    proxy for "is this key accepted right now". Returns False on a 200 (accepted)
+    OR on ANY indeterminate outcome (missing ``requests``, network error, 5xx,
+    timeout, a flapping catalog): we only escalate an ``API key invalid!`` chat
+    error to PERMANENT when we can CONFIRM the key itself is rejected. This keeps a
+    transient auth-service flap (which spuriously 401s the chat path while the key
+    is actually valid) from being misread as a permanent config error.
+
+    Probes up to 3 times so a briefly-flapping catalog is not mistaken for a
+    genuine rejection (a real bad key 401s consistently; a flap recovers).
+    Definitive verdicts are cached for the process lifetime.
+    """
+    global _KEY_REJECTED_CACHE
+    if _KEY_REJECTED_CACHE is not None and not force_refresh:
+        return _KEY_REJECTED_CACHE
+    try:
+        _ensure_api_key_env()
+        key = os.environ.get("DARTMOUTH_CHAT_API_KEY")
+    except Exception:
+        return False
+    if not key:
+        # No key configured at all: genuinely unusable (a real config error).
+        _KEY_REJECTED_CACHE = True
+        return True
+    for attempt in range(3):
+        try:
+            resp = _catalog_get(key, timeout=15)
+        except Exception:
+            # Missing ``requests`` / network / timeout: indeterminate. Retry a
+            # couple times, then give up as "cannot confirm bad" (False) — the
+            # flap will clear next tick.
+            continue
+        status = resp.status_code
+        if status in (401, 403):
+            _KEY_REJECTED_CACHE = True
+            return True
+        if 200 <= status < 400:
+            _KEY_REJECTED_CACHE = False
+            return False
+        # 5xx / 429 / other: the gateway is flapping, not rejecting the key.
+        # Retry a couple times before concluding "cannot confirm bad".
+        if attempt < 2:
+            time.sleep(1.0)
+    return False
+
+
+def _raise_for_backend_error(text: str, exc: BaseException) -> NoReturn:
+    """Classify a raw Dartmouth/vLLM exception and raise the typed BackendError.
+
+    THE single classification chokepoint (Constitution I) — every chat-path
+    failure routes through here so the transient/model-down/auth/permanent
+    precedence is defined in exactly one place:
+
+    * maintenance/outage redirect → :class:`ModelDownError` (fast-fail to a peer)
+    * a listed transient marker    → :class:`TransientBackendError` (retry)
+    * an AUTH rejection whose key the catalog still ACCEPTS (or cannot be
+      confirmed bad) → :class:`TransientBackendError` — a transient auth-service
+      flap (engine-failure #515-518), NOT a config error. A genuinely bad key is
+      rejected by the catalog too (_gateway_rejects_key → True) and falls through
+      to PERMANENT below, surfacing a loud, actionable engine-failure issue.
+    * anything else                → :class:`PermanentBackendError` (no retry)
+    """
+    if _is_model_down_text(text):
+        raise ModelDownError(str(exc)) from exc
+    if _is_transient_error_text(text):
+        raise TransientBackendError(str(exc)) from exc
+    if _is_auth_error_text(text) and not _gateway_rejects_key():
+        raise TransientBackendError(str(exc)) from exc
+    raise PermanentBackendError(str(exc)) from exc
 
 
 def _retry_with_backoff(
@@ -427,13 +551,7 @@ def _fetch_cloud_models() -> list[dict[str, Any]]:
         raise PermanentBackendError(
             "DARTMOUTH_CHAT_API_KEY is not set (required by Dartmouth backend)"
         )
-    import requests  # type: ignore[import-untyped]  # no stubs; types-requests not installed
-
-    resp = requests.get(
-        _cloud_models_url(),
-        headers={"Authorization": f"Bearer {key}"},
-        timeout=30,
-    )
+    resp = _catalog_get(key, timeout=30)
     resp.raise_for_status()
     return list((resp.json() or {}).get("data") or [])
 
@@ -725,13 +843,10 @@ class DartmouthBackend(BaseBackend):
                     else:
                         exc = None  # type: ignore[assignment]
                 if exc is not None:
-                    if _is_model_down_text(text):
-                        # 302 → outage.dartmouth.edu: THIS model is in
-                        # maintenance — fail fast to a peer (don't burn retries).
-                        raise ModelDownError(str(exc)) from exc
-                    if _is_transient_error_text(text):
-                        raise TransientBackendError(str(exc)) from exc
-                    raise PermanentBackendError(str(exc)) from exc
+                    # Single classification chokepoint: model-down → transient →
+                    # auth-flap-vs-genuine-bad-key → permanent (see
+                    # _raise_for_backend_error).
+                    _raise_for_backend_error(text, exc)
 
             text_out = str(reply.content)
             # Reasoning models (Qwen 3.5, gpt-oss) consume completion-budget

--- a/src/llmxive/state/escalations.py
+++ b/src/llmxive/state/escalations.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -33,6 +34,10 @@ import yaml
 
 from llmxive.config import repo_root as _repo_root
 from llmxive.state._io import atomic_write_text
+
+# A `gh` runner: called with CLI args, returns (returncode, stdout, stderr).
+# Tests inject a recording fake at this boundary (Constitution III).
+GhRunner = Callable[..., tuple[int, str, str]]
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +68,14 @@ class EscalationRecord:
     recommended_action: str = ""
     timestamp: str = ""
     digest_id: str | None = None
+    # Non-empty once the escalation has been HANDLED (the project advanced past
+    # the escalated stage, the defect was fixed, or a maintainer signed it off).
+    # A resolved record is kept on disk for the audit trail but drops out of the
+    # digest — this is what makes "steady-state target: zero rows" reachable
+    # (before it, records lived forever and every resolved row re-appeared in the
+    # digest, e.g. #314's stale PROJ-552 rows). Distinct from ``digest_id`` (mere
+    # aggregation bookkeeping — that a record was folded into digest issue N).
+    resolution: str = ""
 
     def validate(self) -> None:
         if self.rounds_used < self.bound:
@@ -101,9 +114,29 @@ def write_record(
     return path
 
 
+def _is_resolved(rec: EscalationRecord) -> bool:
+    """True if *rec* has been handled and should drop out of the digest.
+
+    Recognizes both the current ``resolution`` field and the legacy hack that
+    stuffed a ``"resolved: ..."`` string into ``digest_id`` (used before the
+    ``resolution`` field existed), so a record marked either way is excluded.
+    """
+    if rec.resolution.strip():
+        return True
+    did = (rec.digest_id or "").strip().lower()
+    return did.startswith("resolved")
+
+
 def list_records(
-    *, repo_root: Path | None = None, open_only: bool = False
+    *,
+    repo_root: Path | None = None,
+    open_only: bool = False,
+    include_resolved: bool = False,
 ) -> list[EscalationRecord]:
+    """Load escalation records. By default RESOLVED records are excluded (they
+    are kept on disk for the audit trail but never re-surface in the digest);
+    pass ``include_resolved=True`` to inspect them. ``open_only=True`` further
+    restricts to not-yet-digested records (the trigger for a digest refresh)."""
     out: list[EscalationRecord] = []
     d = _dir(repo_root)
     if not d.is_dir():
@@ -115,10 +148,62 @@ def list_records(
         except (yaml.YAMLError, TypeError) as exc:
             logger.warning("unreadable escalation record %s: %s", p, exc)
             continue
+        if not include_resolved and _is_resolved(rec):
+            continue
         if open_only and rec.digest_id:
             continue
         out.append(rec)
     return out
+
+
+def resolve_records(
+    project_id: str,
+    *,
+    note: str,
+    stage: str | None = None,
+    loop: str | None = None,
+    repo_root: Path | None = None,
+) -> int:
+    """Mark this project's open escalation record(s) RESOLVED so they leave the
+    digest (they stay on disk, carrying ``note`` as the audit trail). Optionally
+    narrow by ``stage`` / ``loop``. Returns the number of records resolved.
+
+    This is the clean replacement for the former practice of overwriting
+    ``digest_id`` with a ``"resolved: ..."`` string. Call ``refresh_digest``
+    afterwards to re-render the live digest issue immediately.
+    """
+    if not note.strip():
+        raise ValueError("resolve_records requires a non-empty resolution note")
+    d = _dir(repo_root)
+    if not d.is_dir():
+        return 0
+    resolved = 0
+    for p in sorted(d.glob("*.yaml")):
+        try:
+            data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+        except yaml.YAMLError:
+            continue
+        if data.get("project_id") != project_id:
+            continue
+        if stage is not None and data.get("stage") != stage:
+            continue
+        if loop is not None and data.get("loop") != loop:
+            continue
+        if str(data.get("resolution") or "").strip():
+            continue  # already resolved
+        data["resolution"] = note
+        # Normalize the legacy digest_id hack (a "resolved: ..." string) back to a
+        # plain aggregation marker / cleared value.
+        did = str(data.get("digest_id") or "")
+        if did.strip().lower().startswith("resolved"):
+            data["digest_id"] = None
+        atomic_write_text(p, yaml.safe_dump(data, sort_keys=False))
+        resolved += 1
+    if resolved:
+        logger.info(
+            "resolved %d escalation record(s) for %s (%s)", resolved, project_id, note,
+        )
+    return resolved
 
 
 def _default_gh(*args: str) -> tuple[int, str, str]:
@@ -144,7 +229,7 @@ def file_engine_failure_issue(
     evidence: str = "",
     run_id: str = "",
     repo_root: Path | None = None,
-    gh=None,
+    gh: GhRunner | None = None,
 ) -> int | None:
     """File (or reuse) the tracked issue for an engine failure (FR-016).
 
@@ -226,28 +311,60 @@ def build_digest_markdown(records: list[EscalationRecord]) -> str:
     return "\n".join(lines)
 
 
-def update_digest(*, repo_root: Path | None = None, gh=None) -> int | None:
-    """Aggregate open records into the single digest issue; mark them
-    digested. Called by the scheduled audit lane. Returns the digest issue
-    number (None when there is nothing to digest or GitHub is unreachable).
-    """
-    gh = gh or _default_gh
-    open_records = list_records(repo_root=repo_root, open_only=True)
-    if not open_records:
-        return None
+def _find_digest_issue(gh: GhRunner) -> int | None:
+    """Return the number of the single open digest issue, or None if there is
+    none / GitHub is unreachable."""
     rc, out, _err = gh(
         "api",
         f"search/issues?q=repo:{GITHUB_REPO}+is:issue+is:open"
         f"+label:{DIGEST_LABEL}+in:title+%22Escalation+digest%22",
     )
-    number: int | None = None
-    if rc == 0:
-        try:
-            items = json.loads(out).get("items", [])
-            if items:
-                number = int(items[0]["number"])
-        except (json.JSONDecodeError, KeyError, ValueError):
-            number = None
+    if rc != 0:
+        return None
+    try:
+        items = json.loads(out).get("items", [])
+        if items:
+            return int(items[0]["number"])
+    except (json.JSONDecodeError, KeyError, ValueError):
+        return None
+    return None
+
+
+def refresh_digest(*, repo_root: Path | None = None, gh: GhRunner | None = None) -> int | None:
+    """Re-render the EXISTING digest issue body from the current UNRESOLVED
+    records, dropping any that were resolved since the last write. Unlike
+    :func:`update_digest` this neither creates a new issue nor marks records — it
+    is the immediate-cleanup path (call it after :func:`resolve_records` so a
+    resolved row leaves the live digest without waiting for the next escalation
+    to trigger ``update_digest``). Returns the digest issue number, or None when
+    no digest issue exists / GitHub is unreachable.
+    """
+    gh = gh or _default_gh
+    number = _find_digest_issue(gh)
+    if number is None:
+        return None
+    body = build_digest_markdown(list_records(repo_root=repo_root))
+    rc, _out, err = gh(
+        "api", f"repos/{GITHUB_REPO}/issues/{number}", "-X", "PATCH",
+        "-f", f"body={body}",
+    )
+    if rc != 0:
+        logger.warning("digest issue refresh failed: %s", err.strip())
+    return number
+
+
+def update_digest(*, repo_root: Path | None = None, gh: GhRunner | None = None) -> int | None:
+    """Aggregate open records into the single digest issue; mark them
+    digested. Called by the scheduled audit lane. Returns the digest issue
+    number (None when there is nothing to digest or GitHub is unreachable).
+    Resolved records are excluded from the rendered body (see
+    :func:`list_records` / :func:`resolve_records`).
+    """
+    gh = gh or _default_gh
+    open_records = list_records(repo_root=repo_root, open_only=True)
+    if not open_records:
+        return None
+    number: int | None = _find_digest_issue(gh)
     body = build_digest_markdown(list_records(repo_root=repo_root))
     if number is None:
         rc, out, err = gh(
@@ -270,12 +387,15 @@ def update_digest(*, repo_root: Path | None = None, gh=None) -> int | None:
         if rc != 0:
             logger.warning("digest issue update failed: %s", err.strip())
     if number:
-        # Mark the digested records so they don't re-aggregate.
+        # Mark the digested records so they don't re-aggregate. Resolved records
+        # are left untouched (they never re-aggregate anyway).
         d = _dir(repo_root)
         for p in sorted(d.glob("*.yaml")):
             try:
                 data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
             except yaml.YAMLError:
+                continue
+            if str(data.get("resolution") or "").strip():
                 continue
             if not data.get("digest_id"):
                 data["digest_id"] = str(number)
@@ -291,6 +411,8 @@ __all__ = [
     "build_digest_markdown",
     "file_engine_failure_issue",
     "list_records",
+    "refresh_digest",
+    "resolve_records",
     "update_digest",
     "write_record",
 ]

--- a/state/escalations/PROJ-552-quantifying-the-complexity-of-knot-diagr__2026-06-11T095745.802151Z0000.yaml
+++ b/state/escalations/PROJ-552-quantifying-the-complexity-of-knot-diagr__2026-06-11T095745.802151Z0000.yaml
@@ -12,5 +12,8 @@ attempts:
 recommended_action: Review the unresolved panel concerns and either revise the content
   manually or terminate the project honestly.
 timestamp: '2026-06-11T09:57:45.802151+00:00'
-digest_id: "resolved: maintainer post-mortem 2026-06-11 (notes/2026-06-11-proj-552-postmortem.md)\
-  \ \u2014 pipeline-induced (defects #14/#15); resumed at specified"
+digest_id: null
+resolution: 'resolved 2026-07-16: root cause fixed (router saw_transient/saw_outage
+  -> BackendUnavailable; convergence defects #11-#15) + post-mortem notes/2026-06-11-proj-552-postmortem.md;
+  project has since advanced to the execution stage (state/execution_status, total_attempts=16,
+  updated 2026-07-13) -- all escalated plan/spec/research_review rounds are moot.'

--- a/state/escalations/PROJ-552-quantifying-the-complexity-of-knot-diagr__2026-06-11T215834.808207Z0000.yaml
+++ b/state/escalations/PROJ-552-quantifying-the-complexity-of-knot-diagr__2026-06-11T215834.808207Z0000.yaml
@@ -13,3 +13,7 @@ recommended_action: Review the unresolved panel concerns and either revise the c
   manually or terminate the project honestly.
 timestamp: '2026-06-11T21:58:34.808207+00:00'
 digest_id: '314'
+resolution: 'resolved 2026-07-16: root cause fixed (router saw_transient/saw_outage
+  -> BackendUnavailable; convergence defects #11-#15) + post-mortem notes/2026-06-11-proj-552-postmortem.md;
+  project has since advanced to the execution stage (state/execution_status, total_attempts=16,
+  updated 2026-07-13) -- all escalated plan/spec/research_review rounds are moot.'

--- a/state/escalations/PROJ-552-quantifying-the-complexity-of-knot-diagr__2026-06-12T013052.702902Z0000.yaml
+++ b/state/escalations/PROJ-552-quantifying-the-complexity-of-knot-diagr__2026-06-12T013052.702902Z0000.yaml
@@ -13,3 +13,7 @@ recommended_action: Review the unresolved panel concerns and either revise the c
   manually or terminate the project honestly.
 timestamp: '2026-06-12T01:30:52.702902+00:00'
 digest_id: '314'
+resolution: 'resolved 2026-07-16: root cause fixed (router saw_transient/saw_outage
+  -> BackendUnavailable; convergence defects #11-#15) + post-mortem notes/2026-06-11-proj-552-postmortem.md;
+  project has since advanced to the execution stage (state/execution_status, total_attempts=16,
+  updated 2026-07-13) -- all escalated plan/spec/research_review rounds are moot.'

--- a/state/escalations/PROJ-552-quantifying-the-complexity-of-knot-diagr__2026-06-12T170539.541326Z0000.yaml
+++ b/state/escalations/PROJ-552-quantifying-the-complexity-of-knot-diagr__2026-06-12T170539.541326Z0000.yaml
@@ -13,3 +13,7 @@ recommended_action: Review the unresolved panel concerns and either revise the c
   manually or terminate the project honestly.
 timestamp: '2026-06-12T17:05:39.541326+00:00'
 digest_id: '314'
+resolution: 'resolved 2026-07-16: root cause fixed (router saw_transient/saw_outage
+  -> BackendUnavailable; convergence defects #11-#15) + post-mortem notes/2026-06-11-proj-552-postmortem.md;
+  project has since advanced to the execution stage (state/execution_status, total_attempts=16,
+  updated 2026-07-13) -- all escalated plan/spec/research_review rounds are moot.'

--- a/state/escalations/PROJ-552-quantifying-the-complexity-of-knot-diagr__2026-06-18T072216.843286Z0000.yaml
+++ b/state/escalations/PROJ-552-quantifying-the-complexity-of-knot-diagr__2026-06-18T072216.843286Z0000.yaml
@@ -15,3 +15,7 @@ recommended_action: Triage the unclassifiable implementer failure, then `llmxive
   unblock-agent`.
 timestamp: '2026-06-18T07:22:16.843286+00:00'
 digest_id: '314'
+resolution: 'resolved 2026-07-16: root cause fixed (router saw_transient/saw_outage
+  -> BackendUnavailable; convergence defects #11-#15) + post-mortem notes/2026-06-11-proj-552-postmortem.md;
+  project has since advanced to the execution stage (state/execution_status, total_attempts=16,
+  updated 2026-07-13) -- all escalated plan/spec/research_review rounds are moot.'

--- a/tests/unit/test_dartmouth_retry.py
+++ b/tests/unit/test_dartmouth_retry.py
@@ -387,3 +387,91 @@ def test_generic_transient_keeps_full_retry_budget():
     with pytest.raises(TransientBackendError):
         _retry_with_backoff(fn, max_retries=4, base_delay_s=0.001)
     assert len(calls) == 5  # max_retries + 1
+
+
+def test_client_closed_request_is_transient():
+    """Regression (engine-failure #505): Dartmouth's gateway returns HTTP 499
+    'Client Closed Request' when an upstream proxy drops the connection before
+    the model responds — a textbook transient. Before the fix it fell through to
+    PermanentBackendError, crashing the plan stage and filing a spurious
+    engine-failure issue instead of riding out the flap."""
+    for txt in (
+        "Client Closed Request",
+        "PermanentBackendError: Client Closed Request",
+        "499 client closed request",
+    ):
+        assert _is_transient_error_text(txt), txt
+
+
+def test_auth_error_text_matches_gateway_reject_strings():
+    """The auth-error matcher recognizes the gateway's key-rejection strings
+    (both word orders) without over-matching unrelated errors."""
+    from llmxive.backends.dartmouth import _is_auth_error_text
+
+    for txt in (
+        "api key invalid!",          # Dartmouth gateway's exact string (#515-518)
+        "'API key invalid!'",
+        "invalid api key",
+        "authentication failed: 401 unauthorized",
+        "AuthenticationError: 401",
+    ):
+        assert _is_auth_error_text(txt.lower()), txt
+    for txt in (
+        "503 service unavailable",
+        "connection reset by peer",
+        "the model produced a malformed schema",
+    ):
+        assert not _is_auth_error_text(txt.lower()), txt
+
+
+def test_auth_flap_with_valid_key_is_transient(monkeypatch):
+    """Regression (engine-failure #515-518): the Dartmouth gateway transiently
+    rejected a VALID key ('API key invalid!') during a ~2h auth-service flap on
+    2026-07-06. When the catalog endpoint (same key + host) still ACCEPTS the key
+    — i.e. we cannot confirm the key is genuinely bad — the mid-run rejection is a
+    flap and must be TRANSIENT so the router aborts cleanly (BackendUnavailable)
+    and the project retries next tick, NOT a PermanentBackendError that files a
+    spurious engine-failure issue."""
+    from llmxive.backends import dartmouth
+
+    # Catalog accepts the key → NOT a genuine bad key → flap.
+    monkeypatch.setattr(dartmouth, "_gateway_rejects_key", lambda **_: False)
+    with pytest.raises(TransientBackendError):
+        dartmouth._raise_for_backend_error("'api key invalid!'", RuntimeError("x"))
+
+
+def test_genuine_bad_key_stays_permanent(monkeypatch):
+    """A GENUINELY bad/expired key is rejected by the catalog endpoint too
+    (401/403). That is a real config error — it must stay PermanentBackendError so
+    the run surfaces a loud, actionable engine-failure issue (Fail Fast), never a
+    silent retry-forever."""
+    from llmxive.backends import dartmouth
+
+    monkeypatch.setattr(dartmouth, "_gateway_rejects_key", lambda **_: True)
+    with pytest.raises(PermanentBackendError):
+        dartmouth._raise_for_backend_error("'api key invalid!'", RuntimeError("x"))
+
+
+def test_raise_for_backend_error_preserves_model_down_and_transient(monkeypatch):
+    """The centralized classifier keeps the existing precedence: a model-down
+    redirect → ModelDownError; a generic transient → TransientBackendError; an
+    unclassified non-auth error → PermanentBackendError (auth preflight is only
+    consulted for auth-shaped errors)."""
+    from llmxive.backends import dartmouth
+
+    # Auth preflight must NOT be consulted for non-auth errors.
+    def _boom(**_):  # pragma: no cover - must never run
+        raise AssertionError("_gateway_rejects_key consulted for a non-auth error")
+
+    monkeypatch.setattr(dartmouth, "_gateway_rejects_key", _boom)
+
+    with pytest.raises(ModelDownError):
+        dartmouth._raise_for_backend_error(
+            "302 moved temporarily → outage.dartmouth.edu", RuntimeError("x")
+        )
+    with pytest.raises(TransientBackendError):
+        dartmouth._raise_for_backend_error("503 service unavailable", RuntimeError("x"))
+    with pytest.raises(PermanentBackendError):
+        dartmouth._raise_for_backend_error(
+            "the model produced a malformed schema", RuntimeError("x")
+        )

--- a/tests/unit/test_escalation_paths.py
+++ b/tests/unit/test_escalation_paths.py
@@ -156,3 +156,108 @@ def test_digest_aggregates_and_marks(tmp_path: Path) -> None:
     )
     # A second run with nothing open does nothing.
     assert escalations.update_digest(repo_root=tmp_path, gh=gh) is None
+
+
+class _DigestGh:
+    """`gh` fake whose issue search returns an EXISTING digest issue (#314),
+    so refresh/update PATCH it in place instead of creating a new one."""
+
+    def __init__(self, existing: int = 314) -> None:
+        self.calls: list[tuple[str, ...]] = []
+        self.existing = existing
+        self.patched_bodies: list[str] = []
+
+    def __call__(self, *args: str) -> tuple[int, str, str]:
+        self.calls.append(args)
+        if args[0] == "api" and args[1].startswith("search/issues"):
+            return 0, json.dumps({"items": [{"number": self.existing}]}), ""
+        if args[0] == "api" and "-X" in args and "PATCH" in args:
+            for i, a in enumerate(args):
+                if a == "-f" and i + 1 < len(args) and args[i + 1].startswith("body="):
+                    self.patched_bodies.append(args[i + 1][len("body="):])
+            return 0, "{}", ""
+        return 0, "{}", ""
+
+
+def _write(tmp_path: Path, pid: str, stage: str, **extra) -> None:
+    escalations.write_record(
+        escalations.EscalationRecord(
+            project_id=pid, stage=stage, loop="convergence-kickback",
+            bound=3, rounds_used=3, **extra,
+        ),
+        repo_root=tmp_path,
+    )
+
+
+def test_resolved_records_excluded_from_listing_and_digest(tmp_path: Path) -> None:
+    """A record marked resolved drops out of the default listing AND the digest
+    body, but remains inspectable via include_resolved=True. This is the fix for
+    the digest showing stale, long-resolved rows forever (#314)."""
+    _write(tmp_path, "PROJ-1-open", "plan")
+    _write(tmp_path, "PROJ-2-done", "spec")
+    n = escalations.resolve_records(
+        "PROJ-2-done", note="advanced past spec", repo_root=tmp_path,
+    )
+    assert n == 1
+    open_ids = [r.project_id for r in escalations.list_records(repo_root=tmp_path)]
+    assert open_ids == ["PROJ-1-open"], "resolved record excluded from default listing"
+    all_ids = [
+        r.project_id
+        for r in escalations.list_records(repo_root=tmp_path, include_resolved=True)
+    ]
+    assert set(all_ids) == {"PROJ-1-open", "PROJ-2-done"}
+    body = escalations.build_digest_markdown(
+        escalations.list_records(repo_root=tmp_path)
+    )
+    assert "PROJ-1-open" in body
+    assert "PROJ-2-done" not in body, "resolved row must not appear in the digest"
+
+
+def test_resolve_records_records_the_note_and_survives_reload(tmp_path: Path) -> None:
+    """resolve_records persists the resolution note so the audit trail is kept
+    (records are never silently deleted)."""
+    _write(tmp_path, "PROJ-9-x", "plan")
+    escalations.resolve_records("PROJ-9-x", note="post-mortem 2026-06-11", repo_root=tmp_path)
+    [rec] = escalations.list_records(repo_root=tmp_path, include_resolved=True)
+    assert rec.resolution == "post-mortem 2026-06-11"
+
+
+def test_resolve_records_stage_filter(tmp_path: Path) -> None:
+    """A stage filter resolves only matching-stage records."""
+    _write(tmp_path, "PROJ-7-x", "plan")
+    _write(tmp_path, "PROJ-7-x", "spec")
+    n = escalations.resolve_records(
+        "PROJ-7-x", note="only plan", stage="plan", repo_root=tmp_path,
+    )
+    assert n == 1
+    remaining = [r.stage for r in escalations.list_records(repo_root=tmp_path)]
+    assert remaining == ["spec"]
+
+
+def test_refresh_digest_repatches_existing_issue_dropping_resolved(tmp_path: Path) -> None:
+    """refresh_digest re-renders the EXISTING digest issue from current
+    unresolved records — the mechanism that clears stale rows from #314 without
+    waiting for a brand-new escalation to trigger update_digest."""
+    _write(tmp_path, "PROJ-A-live", "plan")
+    _write(tmp_path, "PROJ-B-stale", "spec")
+    escalations.resolve_records("PROJ-B-stale", note="done", repo_root=tmp_path)
+    gh = _DigestGh(existing=314)
+    number = escalations.refresh_digest(repo_root=tmp_path, gh=gh)
+    assert number == 314
+    assert gh.patched_bodies, "the existing digest issue was PATCHed"
+    latest = gh.patched_bodies[-1]
+    assert "PROJ-A-live" in latest
+    assert "PROJ-B-stale" not in latest
+
+
+def test_update_digest_body_omits_resolved(tmp_path: Path) -> None:
+    """The regular update_digest path (triggered by a NEW escalation) also emits
+    a body free of resolved rows."""
+    _write(tmp_path, "PROJ-C-live", "plan")
+    _write(tmp_path, "PROJ-D-stale", "spec")
+    escalations.resolve_records("PROJ-D-stale", note="done", repo_root=tmp_path)
+    gh = _DigestGh(existing=314)
+    escalations.update_digest(repo_root=tmp_path, gh=gh)
+    joined = "\n".join(gh.patched_bodies)
+    assert "PROJ-C-live" in joined
+    assert "PROJ-D-stale" not in joined


### PR DESCRIPTION
## Summary

Addresses every open `engine-failure` issue (#505, #515, #516, #517, #518) and the escalation-digest issue (#314). All five engine-failures were the **same class of bug**: a *transient* Dartmouth gateway flap was misclassified as a `PermanentBackendError`, which `_stage_panel` treats as a genuine engine failure and files an issue for (FR-016). A transient instead surfaces as `BackendUnavailable` — no issue, project retries next tick.

Fixes #505
Fixes #515
Fixes #516
Fixes #517
Fixes #518

### Root causes (evidence-backed)
- **#505 — `Client Closed Request`**: HTTP **499** (upstream proxy closed the connection before first byte). Textbook transient, but the string wasn't in `_TRANSIENT_ERROR_MARKERS` → fell through to the catch-all `raise PermanentBackendError`.
- **#515–518 — `'API key invalid!'`**: comes from Dartmouth's gateway, not our code. The key is **valid** — a live catalog probe returns HTTP 200 today, and the four issues clustered in a single **~2h window on 2026-07-06** then stopped: a transient auth-service flap, not a bad credential (which would fail every cron cycle continuously).
- **#314 — escalation digest**: every row was a long-resolved **PROJ-552** escalation (post-mortem `notes/2026-06-11-proj-552-postmortem.md`; project has since advanced to the **execution** stage). Records were write-once and `build_digest_markdown` rendered *all* of them, so resolved rows never left the digest.

### Fix — `backends/dartmouth.py`
- `"client closed request"` / `"499"` added to `_TRANSIENT_ERROR_MARKERS`.
- `_gateway_rejects_key()` — a cached catalog-endpoint preflight (same key + host as chat). Returns `True` only on a **definitive 401/403** (genuinely bad key); `False` on 200 or any indeterminate outcome ("cannot confirm the key is bad"); probes up to 3× to ride out a flapping catalog.
- `_raise_for_backend_error()` — THE single classification chokepoint: model-down → transient → **auth-flap-when-key-valid** → permanent.
- `_catalog_get()` — one lazy `requests` import + auth header, shared by the catalog fetch and the preflight.

Net: a flap (valid key) → `TransientBackendError` → `BackendUnavailable` → **no spurious issue**; a genuinely bad key (catalog 401/403) → stays `PermanentBackendError` → **loud, actionable** (Fail-Fast preserved). `_is_transient_error_text` stays a pure, over-match-free function.

### Fix — `state/escalations.py`
- `EscalationRecord.resolution` + `_is_resolved()` (recognizes the legacy `digest_id:"resolved:…"` hack); `list_records(include_resolved=False)` and the digest body now exclude resolved records.
- `resolve_records()` + `refresh_digest()` — clean resolution + immediate live-digest re-render.
- The 5 stale PROJ-552 records are marked resolved (audit trail preserved on disk) → digest steady-state is **zero rows**.
- `GhRunner` type alias annotates all `gh` params (fixes 2 pre-existing mypy `no-untyped-def` errors too).

### Direct evidence (fixed tree)
```
_gateway_rejects_key() [live key]        -> False (key accepted)
#505 Client Closed Request               -> TransientBackendError   (was Permanent)
#515-518 API key invalid! (valid key)    -> TransientBackendError   (was Permanent)
genuine bad key (catalog 401)            -> PermanentBackendError   (fail-fast preserved)
escalations.list_records() digest rows   -> 4 -> 0 after resolve; 5 preserved w/ include_resolved
```

### Tests
+5 `tests/unit/test_dartmouth_retry.py`, +5 `tests/unit/test_escalation_paths.py` (all real, TDD RED→GREEN). Full offline suite: **6700 passed, 17 skipped**; `ruff` + `mypy` clean on changed files.

On merge: the engine-failure issues auto-close, and the next `update_digest` cron re-renders #314 to zero rows (resolved records now excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)